### PR TITLE
Replace references to inferno-community GitHub org with inferno-framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Inferno Core
-[![codecov](https://codecov.io/gh/inferno-community/inferno-core/branch/main/graph/badge.svg?token=6NJTBHF82R)](https://codecov.io/gh/inferno-community/inferno-core)
+[![codecov](https://codecov.io/gh/inferno-framework/inferno-core/branch/main/graph/badge.svg?token=6NJTBHF82R)](https://codecov.io/gh/inferno-framework/inferno-core)
 
 **Inferno Core is currently in alpha status**
 
@@ -7,12 +7,12 @@ Inferno Core is an open source tool for testing data exchanges enabled by the [F
 Healthcare Interoperability Resources (FHIR)](http://hl7.org/fhir/) standard. 
 
 If you are interested in developing tests using Inferno Core, use the [Inferno
-Template Repository](https://github.com/inferno-community/inferno-template).
+Template Repository](https://github.com/inferno-framework/inferno-template).
 
 ## Documentation
-- [Inferno documentation](https://inferno-community.github.io/inferno-core/)
-- [Ruby API documentation](https://inferno-community.github.io/inferno-core/docs)
-- [JSON API documentation](https://inferno-community.github.io/inferno-core/api-docs)
+- [Inferno documentation](https://inferno-framework.github.io/inferno-core/)
+- [Ruby API documentation](https://inferno-framework.github.io/inferno-core/docs)
+- [JSON API documentation](https://inferno-framework.github.io/inferno-core/api-docs)
 
 ## Requirements
 Inferno Core requires [Ruby 2.7+](https://www.ruby-lang.org/en/) and [Node.js
@@ -21,7 +21,7 @@ and NPM](https://www.npmjs.com/get-npm).
 ## Running Inferno Core
 
 If you are interested in developing tests using Inferno Core, use the [Inferno
-Template Repository](https://github.com/inferno-community/inferno-template).
+Template Repository](https://github.com/inferno-framework/inferno-template).
 These instructions are for developers working on Inferno Core itself.
 
 ```

--- a/dev_suites/dev_demo_ig_stu1/groups/demo_group.rb
+++ b/dev_suites/dev_demo_ig_stu1/groups/demo_group.rb
@@ -7,7 +7,7 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
 
     description %(
     # This is a markdown header
-    **Inferno** [github](https://github.com/inferno-community/inferno-core)
+    **Inferno** [github](https://github.com/inferno-framework/inferno-core)
 
     )
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -17,7 +17,7 @@ title: Inferno
 email: inferno@groups.mitre.org
 description: Inferno documentation
 baseurl: "/inferno-core" # the subpath of your site, e.g. /blog
-url: "https://inferno-community.github.io" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://inferno-framework.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 
 # Build settings
 markdown: kramdown

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,7 +14,7 @@ nav_order: 2
 ## Installation
 1. Install [Docker](https://www.docker.com/get-started).
 1. Clone the [Inferno Template
-   repository](https://github.com/inferno-community/inferno-template). You can
+   repository](https://github.com/inferno-framework/inferno-template). You can
    either clone this repository directly, or click the green "Use this template"
    button to create your own repository based on this one.
 1. Run `./setup.sh` in the template repository to retrieve the necessary docker

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,16 +22,16 @@ Inferno is a tool for testing FHIR server implementations.
   information on Inferno's ruby api.
 
 ## Main Inferno Repositories
-- [Inferno Core](https://github.com/inferno-community/inferno-core) - The
+- [Inferno Core](https://github.com/inferno-framework/inferno-core) - The
   Inferno ruby library itself. This repository contains the code for defining
   and running tests, the command line and web interfaces, and this
   documentation. This is the repository to use if you want to investigate or
   make changes to the internals of Inferno.
-- [Inferno Template](https://github.com/inferno-community/inferno-template) - A
+- [Inferno Template](https://github.com/inferno-framework/inferno-template) - A
   template for test writers. This is the repository to use if you want to write
   your own set of tests with Inferno.
 - [FHIR Validator
-  Wrapper](https://github.com/inferno-community/fhir-validator-wrapper) - A
+  Wrapper](https://github.com/inferno-framework/fhir-validator-wrapper) - A
   simple web wrapper around the [official HL7 FHIR validation
   library](https://github.com/hapifhir/org.hl7.fhir.core/tree/master/org.hl7.fhir.validation).
   Inferno relies on this service to validate FHIR resources.
@@ -39,8 +39,8 @@ Inferno is a tool for testing FHIR server implementations.
 ## Inferno Test Kits
 [Get in touch with us](mailto:inferno@groups.mitre.org) if you have written a
 test kit that you would like included here.
-- [International Patient Summary (IPS) IG Test Kit](https://github.com/inferno-community/ips-test-kit)
-- [SMART Health Cards: Vaccination and Testing IG Test Kit](https://github.com/inferno-community/shc-vaccination-test-kit)
+- [International Patient Summary (IPS) IG Test Kit](https://github.com/inferno-framework/ips-test-kit)
+- [SMART Health Cards: Vaccination and Testing IG Test Kit](https://github.com/inferno-framework/shc-vaccination-test-kit)
 
 ## Contact the Inferno Team
 The fastest way to reach the Inferno team is via the [Inferno Zulip


### PR DESCRIPTION
Just a simple s/r across the whole repository.

Initially motivated by fixing this icon:
![Screen Shot 2021-10-26 at 4 30 36 PM](https://user-images.githubusercontent.com/412901/138956296-eac60103-b8c3-49b7-a3dc-9a12ba7446b9.png)
