### PR TITLE
FI-1385: Fix request logging

### DIFF
--- a/.env
+++ b/.env
@@ -7,3 +7,7 @@ VALIDATOR_URL=https://inferno.healthit.gov/validatorapi
 
 # When false, test will run synchronously rather than asynchronously via sidekiq
 # ASYNC_JOBS=false
+
+# Set to true to display the entire request/response body for each incoming HTTP
+# request in the logs.
+# VERBOSE_REQUEST_LOGGING=true

--- a/lib/inferno/utils/middleware/request_logger.rb
+++ b/lib/inferno/utils/middleware/request_logger.rb
@@ -39,7 +39,7 @@ module Inferno
           logger.info("#{status} in #{elapsed.in_milliseconds} ms")
           return unless body.present?
 
-          body = body.is_a?(Array) ? body.first : body
+          body = body.is_a?(Array) ? body.join : body
 
           if body.length > 100 && !verbose_logging?
             logger.info("#{body[0..100]}...")

--- a/lib/inferno/utils/middleware/request_logger.rb
+++ b/lib/inferno/utils/middleware/request_logger.rb
@@ -9,6 +9,10 @@ module Inferno
           @app = app
         end
 
+        def verbose_logging?
+          @verbose_logging ||= ENV['VERBOSE_REQUEST_LOGGING']&.downcase == true
+        end
+
         def logger
           @logger ||= Application['logger']
         end
@@ -35,7 +39,9 @@ module Inferno
           logger.info("#{status} in #{elapsed.in_milliseconds} ms")
           return unless body.present?
 
-          if body.length > 100
+          body = body.is_a?(Array) ? body.first : body
+
+          if body.length > 100 && !verbose_logging?
             logger.info("#{body[0..100]}...")
           else
             logger.info(body)
@@ -56,7 +62,7 @@ module Inferno
 
           return unless body.present?
 
-          if body.length > 100
+          if body.length > 100 && !verbose_logging?
             logger.info("#{body[0..100]}...")
           else
             logger.info(body)


### PR DESCRIPTION
The body of the response objects sent to the request logger is an array, so the code to not log the entire body was not working as intended. This fixes that and adds an environment variable that can be used to always log the entire body.