### PR TITLE
FI-1403: Fix url-encoded request bodies

### DIFF
--- a/lib/inferno/entities/request.rb
+++ b/lib/inferno/entities/request.rb
@@ -186,6 +186,12 @@ module Inferno
             .map { |header_name, value| Header.new(name: header_name.downcase, value: value, type: 'request') }
           response_headers = response[:headers]
             .map { |header_name, value| Header.new(name: header_name.downcase, value: value, type: 'response') }
+          request_body =
+            if request.dig(:headers, 'Content-Type')&.include?('application/x-www-form-urlencoded')
+              URI.encode_www_form(request[:payload])
+            else
+              request[:payload]
+            end
 
           new(
             verb: request[:method],
@@ -193,7 +199,7 @@ module Inferno
             direction: direction,
             name: name,
             status: response[:code].to_i,
-            request_body: request[:payload],
+            request_body: request_body,
             response_body: response[:body],
             test_session_id: test_session_id,
             headers: request_headers + response_headers

--- a/spec/inferno/entities/request_spec.rb
+++ b/spec/inferno/entities/request_spec.rb
@@ -60,5 +60,17 @@ RSpec.describe Inferno::Entities::Request do
         end
       ).to eq(true)
     end
+
+    it 'correctly handles form encoded bodies' do
+      params = { _id: 'ABC' }
+      stub_request(:post, "#{url}/_search")
+        .to_return(status: 200)
+
+      response = FHIR::Client.new('http://example.com').search(FHIR::Patient, search: { body: params })
+
+      entity = described_class.from_fhir_client_reply(response, test_session_id: nil)
+
+      expect(entity.request_body).to eq(URI.encode_www_form(params))
+    end
   end
 end


### PR DESCRIPTION
`fhir_client` relies on `rest-client`, which handles url-encoded request bodies differently from other types of request bodies. This branch adds code to correctly get a string for url-encoded request bodies (we have [similar functionality in legacy](https://github.com/onc-healthit/inferno-program/blob/main/lib/app/utils/logged_rest_client.rb#L80)).