### PR TITLE
Delete and Stream Support

### DIFF
--- a/lib/inferno/dsl/assertions.rb
+++ b/lib/inferno/dsl/assertions.rb
@@ -30,10 +30,10 @@ module Inferno
       #
       # @param status [Integer, Array<Integer>] a single integer or an array of
       #   integer status codes
-      def assert_response_bad_or_unauthorized(status: self.response[:status])
+      def assert_response_bad_or_unauthorized(status: response[:status])
         message = "Bad response code: expected 400 or 401, but found #{status}"
         assert [400, 401].include?(status), message
-      end 
+      end
 
       # @private
       def bad_resource_type_message(expected, received)

--- a/lib/inferno/dsl/assertions.rb
+++ b/lib/inferno/dsl/assertions.rb
@@ -26,15 +26,6 @@ module Inferno
         assert Array.wrap(status).include?(response[:status]), bad_response_status_message(status, response[:status])
       end
 
-      # Confirm a response status to be bad or unauthorized.
-      #
-      # @param status [Integer, Array<Integer>] a single integer or an array of
-      #   integer status codes
-      def assert_response_bad_or_unauthorized(status: response[:status])
-        message = "Bad response code: expected 400 or 401, but found #{status}"
-        assert [400, 401].include?(status), message
-      end
-
       # @private
       def bad_resource_type_message(expected, received)
         "Bad resource type received: expected #{expected}, but received #{received}"

--- a/lib/inferno/dsl/assertions.rb
+++ b/lib/inferno/dsl/assertions.rb
@@ -26,6 +26,15 @@ module Inferno
         assert Array.wrap(status).include?(response[:status]), bad_response_status_message(status, response[:status])
       end
 
+      # Confirm a response status to be bad or unauthorized.
+      #
+      # @param status [Integer, Array<Integer>] a single integer or an array of
+      #   integer status codes
+      def assert_response_bad_or_unauthorized(status: self.response[:status])
+        message = "Bad response code: expected 400 or 401, but found #{status}"
+        assert [400, 401].include?(status), message
+      end 
+
       # @private
       def bad_resource_type_message(expected, received)
         "Bad resource type received: expected #{expected}, but received #{received}"

--- a/lib/inferno/dsl/fhir_client.rb
+++ b/lib/inferno/dsl/fhir_client.rb
@@ -139,7 +139,7 @@ module Inferno
       # @param name [Symbol] Name for this request to allow it to be used by
       #   other tests
       # @return [Inferno::Entities::Request]
-      def fhir_delete(resource_type, id = nil, client: :default, name: nil)
+      def fhir_delete(resource_type, id, client: :default, name: nil)
         store_request('outgoing', name) do
           fhir_client(client).destroy(fhir_class_from_resource_type(resource_type), id)
         end

--- a/lib/inferno/dsl/fhir_client.rb
+++ b/lib/inferno/dsl/fhir_client.rb
@@ -131,6 +131,21 @@ module Inferno
         end
       end
 
+      # Perform a FHIR delete interaction.
+      #
+      # @param resource_type [String, Symbol, Class]
+      # @param id [String]
+      # @param client [Symbol]
+      # @param name [Symbol] Name for this request to allow it to be used by
+      #   other tests
+      # @param _options [Hash] TODO
+      # @return [Inferno::Entities::Request]
+      def fhir_delete(resource_type, id = nil, client: :default, name: nil)
+        store_request('outgoing', name) do
+          fhir_client(client).destroy(fhir_class_from_resource_type(resource_type), id) 
+        end
+      end 
+
       # @todo Make this a FHIR class method? Something like
       #   FHIR.class_for(resource_type)
       # @api private

--- a/lib/inferno/dsl/fhir_client.rb
+++ b/lib/inferno/dsl/fhir_client.rb
@@ -142,9 +142,9 @@ module Inferno
       # @return [Inferno::Entities::Request]
       def fhir_delete(resource_type, id = nil, client: :default, name: nil)
         store_request('outgoing', name) do
-          fhir_client(client).destroy(fhir_class_from_resource_type(resource_type), id) 
+          fhir_client(client).destroy(fhir_class_from_resource_type(resource_type), id)
         end
-      end 
+      end
 
       # @todo Make this a FHIR class method? Something like
       #   FHIR.class_for(resource_type)

--- a/lib/inferno/dsl/fhir_client.rb
+++ b/lib/inferno/dsl/fhir_client.rb
@@ -138,7 +138,6 @@ module Inferno
       # @param client [Symbol]
       # @param name [Symbol] Name for this request to allow it to be used by
       #   other tests
-      # @param _options [Hash] TODO
       # @return [Inferno::Entities::Request]
       def fhir_delete(resource_type, id = nil, client: :default, name: nil)
         store_request('outgoing', name) do

--- a/lib/inferno/dsl/http_client.rb
+++ b/lib/inferno/dsl/http_client.rb
@@ -111,8 +111,6 @@ module Inferno
       # @param client [Symbol]
       # @param name [Symbol] Name for this request to allow it to be used by
       #   other tests
-      # @option options [Hash] Input headers here - headers are optional and
-      #   must be entered as the last piece of input to this method
       # @return [Inferno::Entities::Request]
       def delete(url = '', client: :default, name: :nil, **options)
         store_request('outgoing', name) do

--- a/lib/inferno/dsl/http_client.rb
+++ b/lib/inferno/dsl/http_client.rb
@@ -124,9 +124,9 @@ module Inferno
             Faraday.delete(url, nil, options[:headers])
           else
             raise StandardError, 'Must use an absolute url or define an HTTP client with a base url'
-          end 
+          end
         end
-      end 
+      end
 
       # Perform an HTTP GET request and stream the response
       #
@@ -135,7 +135,7 @@ module Inferno
       #   made without a defined client
       # @param block [Proc] A code block to be executed on the String chunks
       #   returned piecewise by the get request. Best practice entails creating
-      #   a variable outside the block and using it to persist storage from 
+      #   a variable outside the block and using it to persist storage from
       #   within the block.
       # @param client [Symbol]
       # @param name [Symbol] Name for this request to allow it to be used by
@@ -148,13 +148,13 @@ module Inferno
           client = http_client(client)
 
           if client
-            client.get(url, nil, options[:headers]) { |req| req.options.on_data = block } 
+            client.get(url, nil, options[:headers]) { |req| req.options.on_data = block }
           elsif url.match?(%r{\Ahttps?://})
             Faraday.get(url, nil, options[:headers]) { |req| req.options.on_data = block }
-          else 
+          else
             raise StandardError, 'Must use an absolute url or define an HTTP client with a base url'
-          end 
-        end 
+          end
+        end
       end
 
       module ClassMethods

--- a/lib/inferno/dsl/http_client.rb
+++ b/lib/inferno/dsl/http_client.rb
@@ -128,28 +128,40 @@ module Inferno
 
       # Perform an HTTP GET request and stream the response
       #
-      # @param block [Proc] A code block to be executed on the String chunks
-      #   returned piecewise by the get request.
+      # @param block [Proc] A Proc object whose input will be the string chunks
+      #   received while streaming response to the get request.
       # @param url [String] If this request is using a defined client, this will
       #   be appended to the client's url. Must be an absolute url for requests
       #   made without a defined client
+      # @param limit [Integer] The number of streamed-in chunks to be stored in
+      #   the response body. This optional input defaults to 100.
       # @param client [Symbol]
       # @param name [Symbol] Name for this request to allow it to be used by
       #   other tests
       # @option options [Hash] Input headers here - headers are optional and
       #   must be entered as the last piece of input to this method
       # @return [Inferno::Entities::Request]
-      def stream(block, url = '', client: :default, name: nil, **options)
+      def stream(block, url = '', limit = 100, client: :default, name: nil, **options)
+        streamed = []
+
+        collector = proc do |chunk, bytes|
+          streamed << chunk if limit.positive?
+          limit -= 1
+          block.call(chunk, bytes)
+        end
+
         store_request('outgoing', name) do
           client = http_client(client)
 
           if client
-            client.get(url, nil, options[:headers]) { |req| req.options.on_data = block }
+            response = client.get(url, nil, options[:headers]) { |req| req.options.on_data = collector }
           elsif url.match?(%r{\Ahttps?://})
-            Faraday.get(url, nil, options[:headers]) { |req| req.options.on_data = block }
+            response = Faraday.get(url, nil, options[:headers]) { |req| req.options.on_data = collector }
           else
             raise StandardError, 'Must use an absolute url or define an HTTP client with a base url'
           end
+          response.env.body = streamed.join
+          response
         end
       end
 

--- a/lib/inferno/dsl/http_client.rb
+++ b/lib/inferno/dsl/http_client.rb
@@ -103,6 +103,60 @@ module Inferno
         end
       end
 
+      # Perform an HTTP DELETE request
+      #
+      # @param url [String] if this request is using a defined client, this will
+      #   be appended to the client's url. Must be an absolute url for requests
+      #   made without a defined client
+      # @param client [Symbol]
+      # @param name [Symbol] Name for this request to allow it to be used by
+      #   other tests
+      # @option options [Hash] Input headers here - headers are optional and
+      #   must be entered as the last piece of input to this method
+      # @return [Inferno::Entities::Request]
+      def delete(url = '', client: :default, name: :nil, **options)
+        store_request('outgoing', name) do
+          client = http_client(client)
+
+          if client
+            client.delete(url, nil, options[:headers])
+          elsif url.match?(%r{\Ahttps?://})
+            Faraday.delete(url, nil, options[:headers])
+          else
+            raise StandardError, 'Must use an absolute url or define an HTTP client with a base url'
+          end 
+        end
+      end 
+
+      # Perform an HTTP GET request and stream the response
+      #
+      # @param url [String] if this request is using a defined client, this will
+      #   be appended to the client's url. Must be an absolute url for requests
+      #   made without a defined client
+      # @param block [Proc] A code block to be executed on the String chunks
+      #   returned piecewise by the get request. Best practice entails creating
+      #   a variable outside the block and using it to persist storage from 
+      #   within the block.
+      # @param client [Symbol]
+      # @param name [Symbol] Name for this request to allow it to be used by
+      #   other tests
+      # @option options [Hash] Input headers here - headers are optional and
+      #   must be entered as the last piece of input to this method
+      # @return [Inferno::Entities::Request]
+      def stream(url = '', block, client: :default, name: nil, **options)
+        store_request('outgoing', name) do
+          client = http_client(client)
+
+          if client
+            client.get(url, nil, options[:headers]) { |req| req.options.on_data = block } 
+          elsif url.match?(%r{\Ahttps?://})
+            Faraday.get(url, nil, options[:headers]) { |req| req.options.on_data = block }
+          else 
+            raise StandardError, 'Must use an absolute url or define an HTTP client with a base url'
+          end 
+        end 
+      end
+
       module ClassMethods
         # @private
         def http_client_definitions

--- a/lib/inferno/dsl/http_client.rb
+++ b/lib/inferno/dsl/http_client.rb
@@ -130,20 +130,18 @@ module Inferno
 
       # Perform an HTTP GET request and stream the response
       #
-      # @param url [String] if this request is using a defined client, this will
+      # @param block [Proc] A code block to be executed on the String chunks
+      #   returned piecewise by the get request.
+      # @param url [String] If this request is using a defined client, this will
       #   be appended to the client's url. Must be an absolute url for requests
       #   made without a defined client
-      # @param block [Proc] A code block to be executed on the String chunks
-      #   returned piecewise by the get request. Best practice entails creating
-      #   a variable outside the block and using it to persist storage from
-      #   within the block.
       # @param client [Symbol]
       # @param name [Symbol] Name for this request to allow it to be used by
       #   other tests
       # @option options [Hash] Input headers here - headers are optional and
       #   must be entered as the last piece of input to this method
       # @return [Inferno::Entities::Request]
-      def stream(url = '', block, client: :default, name: nil, **options)
+      def stream(block = proc { |s| s }, url = '', client: :default, name: nil, **options)
         store_request('outgoing', name) do
           client = http_client(client)
 

--- a/lib/inferno/dsl/http_client.rb
+++ b/lib/inferno/dsl/http_client.rb
@@ -141,7 +141,7 @@ module Inferno
       # @option options [Hash] Input headers here - headers are optional and
       #   must be entered as the last piece of input to this method
       # @return [Inferno::Entities::Request]
-      def stream(block = proc { |s| s }, url = '', client: :default, name: nil, **options)
+      def stream(block, url = '', client: :default, name: nil, **options)
         store_request('outgoing', name) do
           client = http_client(client)
 

--- a/spec/inferno/dsl/fhir_client_spec.rb
+++ b/spec/inferno/dsl/fhir_client_spec.rb
@@ -374,6 +374,53 @@ RSpec.describe Inferno::DSL::FHIRClient do
     end
   end
 
+  describe '#fhir_delete' do
+    let(:stub_delete_request) do
+      stub_request(:delete, "#{base_url}/#{resource.resourceType}/#{resource_id}")
+        .to_return(status: 202)
+    end
+
+    before do
+      setup_default_client
+      stub_delete_request
+    end
+
+    it 'performs a FHIR delete' do
+      group.fhir_delete(resource.resourceType, resource_id)
+
+      expect(stub_delete_request).to have_been_made.once
+    end
+
+    it 'returns an Inferno::Entities::Request' do
+      result = group.fhir_delete(resource.resourceType, resource_id)
+
+      expect(result).to be_a(Inferno::Entities::Request)
+    end
+
+    it 'adds the request to the list of requests' do 
+      result = group.fhir_delete(resource.resourceType, resource_id)
+
+      expect(group.requests).to include(result)
+      expect(group.request).to eq(result)
+    end 
+
+    context 'with the client parameter' do 
+      it 'uses that client' do
+        other_url = 'http://www.example.com/fhir/r4'
+        group.fhir_clients[:other_client] = FHIR::Client.new(other_url)
+
+        other_request_stub =
+          stub_request(:delete, "#{other_url}/#{resource.resourceType}/#{resource_id}")
+            .to_return(status: 202)
+
+        group.fhir_delete(resource.resourceType, resource_id, client: :other_client)
+
+        expect(other_request_stub).to have_been_made
+        expect(stub_delete_request).to_not have_been_made
+      end
+    end 
+  end
+
   describe '#requests' do
     it 'returns an array of the requests made' do
       ids = [1, 2, 3]

--- a/spec/inferno/dsl/fhir_client_spec.rb
+++ b/spec/inferno/dsl/fhir_client_spec.rb
@@ -397,14 +397,14 @@ RSpec.describe Inferno::DSL::FHIRClient do
       expect(result).to be_a(Inferno::Entities::Request)
     end
 
-    it 'adds the request to the list of requests' do 
+    it 'adds the request to the list of requests' do
       result = group.fhir_delete(resource.resourceType, resource_id)
 
       expect(group.requests).to include(result)
       expect(group.request).to eq(result)
-    end 
+    end
 
-    context 'with the client parameter' do 
+    context 'with the client parameter' do
       it 'uses that client' do
         other_url = 'http://www.example.com/fhir/r4'
         group.fhir_clients[:other_client] = FHIR::Client.new(other_url)
@@ -418,7 +418,7 @@ RSpec.describe Inferno::DSL::FHIRClient do
         expect(other_request_stub).to have_been_made
         expect(stub_delete_request).to_not have_been_made
       end
-    end 
+    end
   end
 
   describe '#requests' do

--- a/spec/inferno/dsl/fhir_client_spec.rb
+++ b/spec/inferno/dsl/fhir_client_spec.rb
@@ -381,7 +381,6 @@ RSpec.describe Inferno::DSL::FHIRClient do
     end
 
     before do
-      setup_default_client
       stub_delete_request
     end
 

--- a/spec/inferno/dsl/http_client_spec.rb
+++ b/spec/inferno/dsl/http_client_spec.rb
@@ -323,6 +323,284 @@ RSpec.describe Inferno::DSL::HTTPClient do
     end
   end
 
+  describe '#stream' do
+    let(:generic_block) { Proc.new { |chunk| } }
+    let(:streamed) { [] }
+    let(:block) { proc { |chunk|  
+      streamed << chunk
+    } }
+    context 'with a default client defined' do
+      before do 
+        setup_default_client
+      end 
+
+      context 'without a url argument' do 
+        let(:stub_get_request) do
+          stub_request(:get, base_url)
+            .to_return(status: 200, body: response_body)
+        end 
+
+        before { stub_get_request }
+
+        it "performs a HTTP GET to the default client's base url" do
+          group.stream(generic_block)
+
+          expect(stub_get_request).to have_been_made.once
+        end
+
+        it 'receives and stores a chunk of the response via :block' do
+          group.stream(block) 
+
+          expect(streamed).to eq([response_body])
+        end 
+
+        it 'returns an Inferno::Entities::Request' do
+          result = group.stream(generic_block)
+
+          expect(result).to be_a(Inferno::Entities::Request)
+        end
+
+        it 'adds the request to the list of requests' do
+          result = group.stream(generic_block)
+
+          expect(group.requests).to include(result)
+          expect(group.request).to eq(result)
+        end
+      end 
+
+      context 'with a url argument' do
+        it 'performs a GET to the base_url + path' do
+          path = 'abc'
+          stubbed_request =
+            stub_request(:get, "#{base_url}/#{path}")
+              .to_return(status: 200, body: response_body, headers: {})
+
+          group.stream(path, generic_block)
+
+          expect(stubbed_request).to have_been_made.once
+        end
+      end
+
+      context 'with custom headers' do
+        it "performs a HTTP GET to the default client's base url" do
+          stub_get_header_request =
+            stub_request(:get, base_url)
+              .with(headers: { 'Warning' => 'Placeholder warning' })
+              .to_return(status: 200, body: '', headers: {})
+
+          group.stream(generic_block, headers: { 'Warning' => 'Placeholder warning' })
+          expect(stub_get_header_request).to have_been_made.once
+        end
+
+        it "perfoms a HTTP GET that includes the default client's existing headers" do
+          stub_get_header_request =
+            stub_request(:get, base_url)
+              .with(headers: { 'Clientheader' => 'DefaultHeader', 'Customheader' => 'MergedCustom' })
+              .to_return(status: 200, body: '', headers: {})
+
+          group.http_clients[:client_with_header] = client_with_header
+          group.stream(generic_block, client: :client_with_header, headers: { 'CustomHeader' => 'MergedCustom' })
+
+          expect(stub_get_header_request).to have_been_made.once
+        end
+      end
+
+      context 'with the client parameter' do
+        it 'uses that client' do
+          stub_get_request =
+            stub_request(:get, other_url)
+              .to_return(status: 200, body: '', headers: {})
+          group.http_clients[:other_client] = other_client
+
+          group.stream(generic_block, client: :other_client)
+
+          expect(stub_get_request).to have_been_made.once
+        end
+
+        it 'uses that client and its headers' do
+          stub_get_header_request =
+            stub_request(:get, base_url)
+              .with(headers: { 'ClientHeader' => 'DefaultHeader' })
+              .to_return(status: 200, body: '', headers: {})
+
+          group.http_clients[:client_with_header] = client_with_header
+          group.stream(generic_block, client: :client_with_header)
+
+          expect(stub_get_header_request).to have_been_made.once
+        end
+      end
+    end
+
+    context 'without a default client defined' do
+      it 'makes a request to an absolute url' do
+        url = 'https://example.com/abc'
+        stubbed_request =
+          stub_request(:get, url)
+            .to_return(status: 200, body: response_body)
+
+        group.stream(url, generic_block)
+
+        expect(stubbed_request).to have_been_made.once
+      end
+
+      it 'receives and stores a chunk of the response via :block' do
+        url = 'https://example.com/abc'
+        stubbed_request =
+          stub_request(:get, url)
+            .to_return(status: 200, body: response_body)
+
+        group.stream(url, block) 
+
+        expect(streamed).to eq([response_body])
+      end 
+
+      it 'raises an error if given a relative url' do
+        url = 'abc'
+
+        expect { group.stream(url, generic_block) }.to raise_error(/absolute url/)
+      end
+
+      it 'makes a request to an asbolute url with custom headers' do
+        url = 'https://example.com/abc'
+        stub_get_header_request =
+          stub_request(:get, url)
+            .with(headers: { 'Warning' => 'Placeholder warning' })
+            .to_return(status: 200, body: '', headers: {})
+
+        group.stream(url, generic_block, headers: { 'Warning' => 'Placeholder warning' })
+        expect(stub_get_header_request).to have_been_made.once
+      end
+    end
+  end 
+
+  describe '#delete' do
+    context 'with a default client defined' do
+      before do
+        setup_default_client
+      end
+
+      context 'without a url argument' do
+        let(:stub_delete_request) do
+          stub_request(:delete, base_url)
+            .to_return(status: 202)
+        end
+
+        before { stub_delete_request }
+
+        it "performs a HTTP DELETE to the default client's base url" do 
+          group.delete
+
+          expect(stub_delete_request).to have_been_made.once
+        end 
+
+        it 'returns an Inferno::Entities::Request' do
+          result = group.delete
+
+          expect(result).to be_a(Inferno::Entities::Request)
+        end 
+
+        it 'adds the request to the list of requests' do
+          result = group.delete
+
+          expect(group.requests).to include(result)
+          expect(group.request).to eq(result)
+        end
+      end
+
+      context 'with a url argument' do
+        it 'performs a DELETE to the base_url + path' do 
+          path = 'abc'
+          stubbed_request =
+            stub_request(:delete, "#{base_url}/#{path}")
+              .to_return(status: 202)
+
+          group.delete(path)
+
+          expect(stubbed_request).to have_been_made.once
+        end 
+      end
+
+      context 'with custom headers' do
+        it "performs a HTTP Delete to the default client's base url using existing headers" do
+          stub_delete_header_request =
+            stub_request(:delete, base_url)
+              .with(headers: { 'Warning' => 'Placeholder warning' })
+              .to_return(status: 202)
+
+          group.delete(headers: { 'Warning' => 'Placeholder warning' })
+          expect(stub_delete_header_request).to have_been_made.once
+        end
+
+        it "performs a HTTP DELETE to the default client's base url using both default and custom headers" do
+          stub_delete_header_request =
+            stub_request(:delete, base_url)
+              .with(headers: { 'Clientheader' => 'DefaultHeader', 'Customheader' => 'MergedCustom' })
+              .to_return(status: 202)
+
+          group.http_clients[:client_with_header] = client_with_header
+          group.delete(client: :client_with_header, headers: { 'CustomHeader' => 'MergedCustom' })
+
+          expect(stub_delete_header_request).to have_been_made.once
+        end 
+      end
+
+      context 'with the client parameter' do
+        it 'uses that client' do
+          stub_delete_request =
+            stub_request(:delete, other_url)
+              .to_return(status: 202)
+          group.http_clients[:other_client] = other_client
+
+          group.delete(client: :other_client)
+
+          expect(stub_delete_request).to have_been_made.once
+        end
+
+        it 'uses that client and its headers' do
+          stub_delete_header_request =
+            stub_request(:delete, base_url)
+              .with(headers: { 'ClientHeader' => 'DefaultHeader' })
+              .to_return(status: 202)
+
+          group.http_clients[:client_with_header] = client_with_header
+          group.delete(client: :client_with_header)
+
+          expect(stub_delete_header_request).to have_been_made.once
+        end
+      end
+    end
+
+    context 'without a default client defined' do
+      it 'makes a request to an absolute url' do
+        url = 'https://example.com/abc'
+        stubbed_request =
+          stub_request(:delete, url)
+            .to_return(status: 200)
+
+        group.delete(url)
+
+        expect(stubbed_request).to have_been_made.once
+      end
+
+      it 'raises an error if given a relative url' do
+        url = 'abc'
+
+        expect { group.delete(url) }.to raise_error(/absolute url/)
+      end
+
+      it 'makes a request to an absolute url with custom headers' do 
+        url = 'https://example.com/abc'
+        stub_delete_header_request =
+          stub_request(:delete, url)
+            .with(headers: { 'Warning' => 'Placeholder warning' })
+            .to_return(status: 200)
+
+        group.delete(url, headers: { 'Warning' => 'Placeholder warning' })
+        expect(stub_delete_header_request).to have_been_made.once
+      end 
+    end
+  end
+
   describe '#requests' do
     it 'returns an array of the requests made' do
       stub_request(:get, base_url)

--- a/spec/inferno/dsl/http_client_spec.rb
+++ b/spec/inferno/dsl/http_client_spec.rb
@@ -351,7 +351,7 @@ RSpec.describe Inferno::DSL::HTTPClient do
           expect(stub_get_request).to have_been_made.once
         end
 
-        it 'receives and stores a chunk of the response via :block' do
+        it 'receives a chunk of the response via :block' do
           group.stream(block)
 
           expect(streamed).to eq([response_body])
@@ -368,6 +368,13 @@ RSpec.describe Inferno::DSL::HTTPClient do
 
           expect(group.requests).to include(result)
           expect(group.request).to eq(result)
+        end
+
+        it 'stores the streamed chunk in the request response body' do
+          result = group.stream(generic_block)
+
+          expect(group.requests).to include(result)
+          expect(group.request.response_body).to eq(response_body)
         end
       end
 
@@ -471,6 +478,17 @@ RSpec.describe Inferno::DSL::HTTPClient do
 
         group.stream(generic_block, url, headers: { 'Warning' => 'Placeholder warning' })
         expect(stub_get_header_request).to have_been_made.once
+      end
+
+      it 'stores the streamed chunk in the request response body' do
+        url = 'https://example.com/abc'
+        stub_request(:get, url)
+          .to_return(status: 200, body: response_body)
+
+        result = group.stream(block, url)
+
+        expect(group.requests).to include(result)
+        expect(group.request.response_body).to eq(response_body)
       end
     end
   end

--- a/spec/inferno/dsl/http_client_spec.rb
+++ b/spec/inferno/dsl/http_client_spec.rb
@@ -324,21 +324,24 @@ RSpec.describe Inferno::DSL::HTTPClient do
   end
 
   describe '#stream' do
-    let(:generic_block) { Proc.new { |chunk| } }
+    let(:generic_block) { proc { |chunk| chunk } }
     let(:streamed) { [] }
-    let(:block) { proc { |chunk|  
-      streamed << chunk
-    } }
-    context 'with a default client defined' do
-      before do 
-        setup_default_client
-      end 
+    let(:block) do
+      proc { |chunk|
+        streamed << chunk
+      }
+    end
 
-      context 'without a url argument' do 
+    context 'with a default client defined' do
+      before do
+        setup_default_client
+      end
+
+      context 'without a url argument' do
         let(:stub_get_request) do
           stub_request(:get, base_url)
             .to_return(status: 200, body: response_body)
-        end 
+        end
 
         before { stub_get_request }
 
@@ -349,10 +352,10 @@ RSpec.describe Inferno::DSL::HTTPClient do
         end
 
         it 'receives and stores a chunk of the response via :block' do
-          group.stream(block) 
+          group.stream(block)
 
           expect(streamed).to eq([response_body])
-        end 
+        end
 
         it 'returns an Inferno::Entities::Request' do
           result = group.stream(generic_block)
@@ -366,7 +369,7 @@ RSpec.describe Inferno::DSL::HTTPClient do
           expect(group.requests).to include(result)
           expect(group.request).to eq(result)
         end
-      end 
+      end
 
       context 'with a url argument' do
         it 'performs a GET to the base_url + path' do
@@ -375,7 +378,7 @@ RSpec.describe Inferno::DSL::HTTPClient do
             stub_request(:get, "#{base_url}/#{path}")
               .to_return(status: 200, body: response_body, headers: {})
 
-          group.stream(path, generic_block)
+          group.stream(generic_block, path)
 
           expect(stubbed_request).to have_been_made.once
         end
@@ -438,26 +441,25 @@ RSpec.describe Inferno::DSL::HTTPClient do
           stub_request(:get, url)
             .to_return(status: 200, body: response_body)
 
-        group.stream(url, generic_block)
+        group.stream(generic_block, url)
 
         expect(stubbed_request).to have_been_made.once
       end
 
       it 'receives and stores a chunk of the response via :block' do
         url = 'https://example.com/abc'
-        stubbed_request =
-          stub_request(:get, url)
-            .to_return(status: 200, body: response_body)
+        stub_request(:get, url)
+          .to_return(status: 200, body: response_body)
 
-        group.stream(url, block) 
+        group.stream(block, url)
 
         expect(streamed).to eq([response_body])
-      end 
+      end
 
       it 'raises an error if given a relative url' do
         url = 'abc'
 
-        expect { group.stream(url, generic_block) }.to raise_error(/absolute url/)
+        expect { group.stream(generic_block, url) }.to raise_error(/absolute url/)
       end
 
       it 'makes a request to an asbolute url with custom headers' do
@@ -467,11 +469,11 @@ RSpec.describe Inferno::DSL::HTTPClient do
             .with(headers: { 'Warning' => 'Placeholder warning' })
             .to_return(status: 200, body: '', headers: {})
 
-        group.stream(url, generic_block, headers: { 'Warning' => 'Placeholder warning' })
+        group.stream(generic_block, url, headers: { 'Warning' => 'Placeholder warning' })
         expect(stub_get_header_request).to have_been_made.once
       end
     end
-  end 
+  end
 
   describe '#delete' do
     context 'with a default client defined' do
@@ -487,17 +489,17 @@ RSpec.describe Inferno::DSL::HTTPClient do
 
         before { stub_delete_request }
 
-        it "performs a HTTP DELETE to the default client's base url" do 
+        it "performs a HTTP DELETE to the default client's base url" do
           group.delete
 
           expect(stub_delete_request).to have_been_made.once
-        end 
+        end
 
         it 'returns an Inferno::Entities::Request' do
           result = group.delete
 
           expect(result).to be_a(Inferno::Entities::Request)
-        end 
+        end
 
         it 'adds the request to the list of requests' do
           result = group.delete
@@ -508,7 +510,7 @@ RSpec.describe Inferno::DSL::HTTPClient do
       end
 
       context 'with a url argument' do
-        it 'performs a DELETE to the base_url + path' do 
+        it 'performs a DELETE to the base_url + path' do
           path = 'abc'
           stubbed_request =
             stub_request(:delete, "#{base_url}/#{path}")
@@ -517,7 +519,7 @@ RSpec.describe Inferno::DSL::HTTPClient do
           group.delete(path)
 
           expect(stubbed_request).to have_been_made.once
-        end 
+        end
       end
 
       context 'with custom headers' do
@@ -541,7 +543,7 @@ RSpec.describe Inferno::DSL::HTTPClient do
           group.delete(client: :client_with_header, headers: { 'CustomHeader' => 'MergedCustom' })
 
           expect(stub_delete_header_request).to have_been_made.once
-        end 
+        end
       end
 
       context 'with the client parameter' do
@@ -588,7 +590,7 @@ RSpec.describe Inferno::DSL::HTTPClient do
         expect { group.delete(url) }.to raise_error(/absolute url/)
       end
 
-      it 'makes a request to an absolute url with custom headers' do 
+      it 'makes a request to an absolute url with custom headers' do
         url = 'https://example.com/abc'
         stub_delete_header_request =
           stub_request(:delete, url)
@@ -597,7 +599,7 @@ RSpec.describe Inferno::DSL::HTTPClient do
 
         group.delete(url, headers: { 'Warning' => 'Placeholder warning' })
         expect(stub_delete_header_request).to have_been_made.once
-      end 
+      end
     end
   end
 


### PR DESCRIPTION
Added delete support to both http_client and fhir_client and added stream support to http_client using Faraday's on_data method. Created unit tests implemented for these new methods. Also added an extraneous assertion that kept coming up in Bulk Data and I thought could be useful elsewhere. 