### PR TITLE
FI-1398: Support postgres

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -98,3 +98,7 @@ RSpec/NestedGroups:
 
 RSpec/NotToNot:
   EnforcedStyle: to_not
+
+# Following this rule's suggestions breaks postgres support
+Sequel/ConcurrentIndex:
+  Enabled: false

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,14 +2,15 @@ development:
   adapter: sqlite
   database: data/inferno_development.db
   max_connections: 10
-  # user:
-  # password:
-  # host:
-  # port:
+  # adapter: postgres
+  # database: inferno_development
+  # max_connections: 10
+  # user: postgres
+  # host: 127.0.0.1
 
 production:
   adapter: sqlite
-  database: ':memory:'
+  database: data/inferno_production.db
   max_connections: 10
 
 test:

--- a/dev_suites/dev_demo_ig_stu1/groups/demo_group.rb
+++ b/dev_suites/dev_demo_ig_stu1/groups/demo_group.rb
@@ -19,6 +19,7 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
 
     input :url, title: 'URL', description: 'Insert url of FHIR server', default: 'https://inferno.healthit.gov/reference-server/r4'
     input :patient_id, title: 'Patient ID', default: '85'
+    input :bearer_token, optional: true, default: 'SAMPLE_TOKEN'
 
     output :observation_id,
            :encounter_id,

--- a/lib/inferno/db/migrations/001_create_initial_structure.rb
+++ b/lib/inferno/db/migrations/001_create_initial_structure.rb
@@ -21,7 +21,7 @@ Sequel.migration do
     create_table :test_runs do
       column :id, String, primary_key: true, null: false, size: 255
       column :status, String, size: 255
-      foreign_key :test_session_id, :test_sessions, index: true, type: String
+      foreign_key :test_session_id, :test_sessions, index: true, type: String, size: 255, key: [:id]
       index [:test_session_id, :status] # Searching by unfinished test runs seems like it will be a likely query
 
       column :test_suite_id, String, index: true, size: 255
@@ -34,7 +34,7 @@ Sequel.migration do
 
     create_table :test_run_inputs do
       column :id, String, primary_key: true, null: false, size: 255
-      foreign_key :test_run_id, :test_runs, index: true, type: String
+      foreign_key :test_run_id, :test_runs, index: true, type: String, key: [:id]
       column :test_input_id, String, size: 255
       column :value, String, text: true
 
@@ -45,8 +45,8 @@ Sequel.migration do
     create_table :results do
       column :id, String, primary_key: true, null: false, size: 255
 
-      foreign_key :test_run_id, :test_runs, index: true, type: String, size: 255
-      foreign_key :test_session_id, :test_sessions, index: true, type: String, size: 255
+      foreign_key :test_run_id, :test_runs, index: true, type: String, size: 255, key: [:id]
+      foreign_key :test_session_id, :test_sessions, index: true, type: String, size: 255, key: [:id]
 
       column :result, String, size: 255
       column :result_message, String, text: true
@@ -61,7 +61,7 @@ Sequel.migration do
 
     create_table :result_inputs do
       column :id, String, primary_key: true, null: false, size: 255
-      foreign_key :result_id, :results, index: true, type: String, size: 255
+      foreign_key :result_id, :results, index: true, type: String, size: 255, key: [:id]
       column :test_input_id, String, size: 255
       column :value, String, text: true
 
@@ -71,7 +71,7 @@ Sequel.migration do
 
     create_table :result_outputs do
       column :id, String, primary_key: true, null: false, size: 255
-      foreign_key :result_id, :results, index: true, type: String, size: 255
+      foreign_key :result_id, :results, index: true, type: String, size: 255, key: [:id]
       column :test_output_id, String, size: 255
       column :value, String, text: true
 
@@ -82,7 +82,7 @@ Sequel.migration do
     create_table :result_prompt_values do
       column :id, String, primary_key: true, null: false, size: 255
 
-      foreign_key :result_id, :results, index: true, type: String, size: 255
+      foreign_key :result_id, :results, index: true, type: String, size: 255, key: [:id]
 
       column :test_prompt_id, String, null: false, size: 255
       column :value, String, null: false, text: true
@@ -94,7 +94,7 @@ Sequel.migration do
     create_table :messages do
       primary_key :index
       column :id, String, index: true, null: false, size: 255
-      foreign_key :result_id, :results, index: true, type: String, size: 255
+      foreign_key :result_id, :results, index: true, type: String, size: 255, key: [:id]
       column :type, String, size: 255
       column :message, String, text: true
 
@@ -115,8 +115,8 @@ Sequel.migration do
       index [:id], unique: true
 
       # Requires requests to be a part of tests now.
-      foreign_key :result_id, :results, index: true, type: String, size: 255
-      foreign_key :test_session_id, :test_sessions, index: true, type: String, size: 255
+      foreign_key :result_id, :results, index: true, type: String, size: 255, key: [:id]
+      foreign_key :test_session_id, :test_sessions, index: true, type: String, size: 255, key: [:id]
       index [:test_session_id, :name]
 
 
@@ -127,7 +127,7 @@ Sequel.migration do
 
     create_table :headers do
       column :id, String, index: true, null: false, size: 255
-      foreign_key :request_id, :requests, index: true, type: Integer
+      foreign_key :request_id, :requests, index: true, type: Integer, key: [:index]
       column :type, String, size: 255 # request / response
       column :name, String, size: 255
       column :value, String, text: true
@@ -138,7 +138,7 @@ Sequel.migration do
 
     create_table :session_data do
       column :id, String, index: true, null: false, size: 255
-      foreign_key :test_session_id, :test_sessions, index: true, type: String, size: 255
+      foreign_key :test_session_id, :test_sessions, index: true, type: String, size: 255, key: [:id]
       column :name, String, size: 255
       column :value, String, text: true
       index [:test_session_id, :name]

--- a/lib/inferno/db/migrations/001_create_initial_structure.rb
+++ b/lib/inferno/db/migrations/001_create_initial_structure.rb
@@ -104,7 +104,7 @@ Sequel.migration do
 
     create_table :requests do
       primary_key :index
-      column :id, String, index: true, null: false
+      column :id, String, index: true, unique: true, null: false
       column :verb, String
       column :url, String
       column :direction, String
@@ -116,7 +116,7 @@ Sequel.migration do
       # Requires requests to be a part of tests now.
       foreign_key :result_id, :results, index: true, type: String
       foreign_key :test_session_id, :test_sessions, index: true, type: String
-      index [:test_session_id, :name], concurrently: true
+      index [:test_session_id, :name]
 
       column :created_at, DateTime, null: false
       column :updated_at, DateTime, null: false
@@ -124,7 +124,7 @@ Sequel.migration do
 
     create_table :headers do
       column :id, String, index: true, null: false
-      foreign_key :request_id, :requests, index: true, type: String
+      foreign_key :request_id, :requests, index: true, type: Integer
       column :type, String # request / response
       column :name, String
       column :value, String

--- a/lib/inferno/db/migrations/001_create_initial_structure.rb
+++ b/lib/inferno/db/migrations/001_create_initial_structure.rb
@@ -104,7 +104,7 @@ Sequel.migration do
 
     create_table :requests do
       primary_key :index
-      column :id, String, index: true, unique: true, null: false, size: 255
+      column :id, String, null: false, size: 255
       column :verb, String, size: 255
       column :url, String, text: true
       column :direction, String, size: 255
@@ -112,11 +112,14 @@ Sequel.migration do
       column :name, String, size: 255
       column :request_body, String, text: true
       column :response_body, String, text: true # It would be nice if we could store this on disk
+      index [:id], unique: true
 
       # Requires requests to be a part of tests now.
       foreign_key :result_id, :results, index: true, type: String, size: 255
       foreign_key :test_session_id, :test_sessions, index: true, type: String, size: 255
       index [:test_session_id, :name]
+
+
 
       column :created_at, DateTime, null: false
       column :updated_at, DateTime, null: false

--- a/lib/inferno/db/migrations/001_create_initial_structure.rb
+++ b/lib/inferno/db/migrations/001_create_initial_structure.rb
@@ -11,81 +11,81 @@ Sequel.migration do
     # end
 
     create_table :test_sessions do
-      column :id, String, primary_key: true, null: false
-      column :test_suite_id, String
+      column :id, String, primary_key: true, null: false, size: 255
+      column :test_suite_id, String, size: 255
 
       column :created_at, DateTime, null: false
       column :updated_at, DateTime, null: false
     end
 
     create_table :test_runs do
-      column :id, String, primary_key: true, null: false
-      column :status, String
+      column :id, String, primary_key: true, null: false, size: 255
+      column :status, String, size: 255
       foreign_key :test_session_id, :test_sessions, index: true, type: String
       index [:test_session_id, :status] # Searching by unfinished test runs seems like it will be a likely query
 
-      column :test_suite_id, String, index: true
-      column :test_group_id, String, index: true
-      column :test_id, String, index: true
+      column :test_suite_id, String, index: true, size: 255
+      column :test_group_id, String, index: true, size: 255
+      column :test_id, String, index: true, size: 255
 
       column :created_at, DateTime, null: false
       column :updated_at, DateTime, null: false
     end
 
     create_table :test_run_inputs do
-      column :id, String, primary_key: true, null: false
+      column :id, String, primary_key: true, null: false, size: 255
       foreign_key :test_run_id, :test_runs, index: true, type: String
-      column :test_input_id, String
-      column :value, String
+      column :test_input_id, String, size: 255
+      column :value, String, text: true
 
       column :created_at, DateTime, null: false
       column :updated_at, DateTime, null: false
     end
 
     create_table :results do
-      column :id, String, primary_key: true, null: false
+      column :id, String, primary_key: true, null: false, size: 255
 
-      foreign_key :test_run_id, :test_runs, index: true, type: String
-      foreign_key :test_session_id, :test_sessions, index: true, type: String
+      foreign_key :test_run_id, :test_runs, index: true, type: String, size: 255
+      foreign_key :test_session_id, :test_sessions, index: true, type: String, size: 255
 
-      column :result, String
-      column :result_message, String
+      column :result, String, size: 255
+      column :result_message, String, text: true
 
-      column :test_suite_id, String
-      column :test_group_id, String
-      column :test_id, String
+      column :test_suite_id, String, size: 255
+      column :test_group_id, String, size: 255
+      column :test_id, String, size: 255
 
       column :created_at, DateTime, null: false
       column :updated_at, DateTime, null: false
     end
 
     create_table :result_inputs do
-      column :id, String, primary_key: true, null: false
-      foreign_key :result_id, :results, index: true, type: String
-      column :test_input_id, String
-      column :value, String
+      column :id, String, primary_key: true, null: false, size: 255
+      foreign_key :result_id, :results, index: true, type: String, size: 255
+      column :test_input_id, String, size: 255
+      column :value, String, text: true
 
       column :created_at, DateTime, null: false
       column :updated_at, DateTime, null: false
     end
 
     create_table :result_outputs do
-      column :id, String, primary_key: true, null: false
-      foreign_key :result_id, :results, index: true, type: String
-      column :test_output_id, String
-      column :value, String
+      column :id, String, primary_key: true, null: false, size: 255
+      foreign_key :result_id, :results, index: true, type: String, size: 255
+      column :test_output_id, String, size: 255
+      column :value, String, text: true
 
       column :created_at, DateTime, null: false
       column :updated_at, DateTime, null: false
     end
 
     create_table :result_prompt_values do
-      column :id, String, primary_key: true, null: false
+      column :id, String, primary_key: true, null: false, size: 255
 
-      foreign_key :result_id, :results, index: true, type: String
+      foreign_key :result_id, :results, index: true, type: String, size: 255
 
-      column :test_prompt_id, String, null: false
-      column :value, String, null: false
+      column :test_prompt_id, String, null: false, size: 255
+      column :value, String, null: false, text: true
 
       column :created_at, DateTime, null: false
       column :updated_at, DateTime, null: false
@@ -93,10 +93,10 @@ Sequel.migration do
 
     create_table :messages do
       primary_key :index
-      column :id, String, index: true, null: false
-      foreign_key :result_id, :results, index: true, type: String
-      column :type, String
-      column :message, String
+      column :id, String, index: true, null: false, size: 255
+      foreign_key :result_id, :results, index: true, type: String, size: 255
+      column :type, String, size: 255
+      column :message, String, text: true
 
       column :created_at, DateTime, null: false
       column :updated_at, DateTime, null: false
@@ -104,18 +104,18 @@ Sequel.migration do
 
     create_table :requests do
       primary_key :index
-      column :id, String, index: true, unique: true, null: false
-      column :verb, String
-      column :url, String
-      column :direction, String
+      column :id, String, index: true, unique: true, null: false, size: 255
+      column :verb, String, size: 255
+      column :url, String, text: true
+      column :direction, String, size: 255
       column :status, Integer
-      column :name, String
+      column :name, String, size: 255
       column :request_body, String, text: true
       column :response_body, String, text: true # It would be nice if we could store this on disk
 
       # Requires requests to be a part of tests now.
-      foreign_key :result_id, :results, index: true, type: String
-      foreign_key :test_session_id, :test_sessions, index: true, type: String
+      foreign_key :result_id, :results, index: true, type: String, size: 255
+      foreign_key :test_session_id, :test_sessions, index: true, type: String, size: 255
       index [:test_session_id, :name]
 
       column :created_at, DateTime, null: false
@@ -123,21 +123,21 @@ Sequel.migration do
     end
 
     create_table :headers do
-      column :id, String, index: true, null: false
+      column :id, String, index: true, null: false, size: 255
       foreign_key :request_id, :requests, index: true, type: Integer
-      column :type, String # request / response
-      column :name, String
-      column :value, String
+      column :type, String, size: 255 # request / response
+      column :name, String, size: 255
+      column :value, String, text: true
 
       column :created_at, DateTime, null: false
       column :updated_at, DateTime, null: false
     end
 
     create_table :session_data do
-      column :id, String, index: true, null: false
-      foreign_key :test_session_id, :test_sessions, index: true, type: String
-      column :name, String
-      column :value, String
+      column :id, String, index: true, null: false, size: 255
+      foreign_key :test_session_id, :test_sessions, index: true, type: String, size: 255
+      column :name, String, size: 255
+      column :value, String, text: true
       index [:test_session_id, :name]
     end
   end

--- a/lib/inferno/db/migrations/001_create_initial_structure.rb
+++ b/lib/inferno/db/migrations/001_create_initial_structure.rb
@@ -11,7 +11,7 @@ Sequel.migration do
     # end
 
     create_table :test_sessions do
-      column :id, String, primary_key: true, null: false, size: 255
+      column :id, String, primary_key: true, null: false, size: 36
       column :test_suite_id, String, size: 255
 
       column :created_at, DateTime, null: false
@@ -19,9 +19,9 @@ Sequel.migration do
     end
 
     create_table :test_runs do
-      column :id, String, primary_key: true, null: false, size: 255
+      column :id, String, primary_key: true, null: false, size: 36
       column :status, String, size: 255
-      foreign_key :test_session_id, :test_sessions, index: true, type: String, size: 255, key: [:id]
+      foreign_key :test_session_id, :test_sessions, index: true, type: String, size: 36, key: [:id]
       index [:test_session_id, :status] # Searching by unfinished test runs seems like it will be a likely query
 
       column :test_suite_id, String, index: true, size: 255
@@ -33,7 +33,7 @@ Sequel.migration do
     end
 
     create_table :test_run_inputs do
-      column :id, String, primary_key: true, null: false, size: 255
+      column :id, String, primary_key: true, null: false, size: 36
       foreign_key :test_run_id, :test_runs, index: true, type: String, key: [:id]
       column :test_input_id, String, size: 255
       column :value, String, text: true
@@ -43,10 +43,10 @@ Sequel.migration do
     end
 
     create_table :results do
-      column :id, String, primary_key: true, null: false, size: 255
+      column :id, String, primary_key: true, null: false, size: 36
 
-      foreign_key :test_run_id, :test_runs, index: true, type: String, size: 255, key: [:id]
-      foreign_key :test_session_id, :test_sessions, index: true, type: String, size: 255, key: [:id]
+      foreign_key :test_run_id, :test_runs, index: true, type: String, size: 36, key: [:id]
+      foreign_key :test_session_id, :test_sessions, index: true, type: String, size: 36, key: [:id]
 
       column :result, String, size: 255
       column :result_message, String, text: true
@@ -60,8 +60,8 @@ Sequel.migration do
     end
 
     create_table :result_inputs do
-      column :id, String, primary_key: true, null: false, size: 255
-      foreign_key :result_id, :results, index: true, type: String, size: 255, key: [:id]
+      column :id, String, primary_key: true, null: false, size: 36
+      foreign_key :result_id, :results, index: true, type: String, size: 36, key: [:id]
       column :test_input_id, String, size: 255
       column :value, String, text: true
 
@@ -70,8 +70,8 @@ Sequel.migration do
     end
 
     create_table :result_outputs do
-      column :id, String, primary_key: true, null: false, size: 255
-      foreign_key :result_id, :results, index: true, type: String, size: 255, key: [:id]
+      column :id, String, primary_key: true, null: false, size: 36
+      foreign_key :result_id, :results, index: true, type: String, size: 36, key: [:id]
       column :test_output_id, String, size: 255
       column :value, String, text: true
 
@@ -80,9 +80,9 @@ Sequel.migration do
     end
 
     create_table :result_prompt_values do
-      column :id, String, primary_key: true, null: false, size: 255
+      column :id, String, primary_key: true, null: false, size: 36
 
-      foreign_key :result_id, :results, index: true, type: String, size: 255, key: [:id]
+      foreign_key :result_id, :results, index: true, type: String, size: 36, key: [:id]
 
       column :test_prompt_id, String, null: false, size: 255
       column :value, String, null: false, text: true
@@ -93,8 +93,8 @@ Sequel.migration do
 
     create_table :messages do
       primary_key :index
-      column :id, String, index: true, null: false, size: 255
-      foreign_key :result_id, :results, index: true, type: String, size: 255, key: [:id]
+      column :id, String, index: true, null: false, size: 36
+      foreign_key :result_id, :results, index: true, type: String, size: 36, key: [:id]
       column :type, String, size: 255
       column :message, String, text: true
 
@@ -104,7 +104,7 @@ Sequel.migration do
 
     create_table :requests do
       primary_key :index
-      column :id, String, null: false, size: 255
+      column :id, String, null: false, size: 36
       column :verb, String, size: 255
       column :url, String, text: true
       column :direction, String, size: 255
@@ -115,8 +115,8 @@ Sequel.migration do
       index [:id], unique: true
 
       # Requires requests to be a part of tests now.
-      foreign_key :result_id, :results, index: true, type: String, size: 255, key: [:id]
-      foreign_key :test_session_id, :test_sessions, index: true, type: String, size: 255, key: [:id]
+      foreign_key :result_id, :results, index: true, type: String, size: 36, key: [:id]
+      foreign_key :test_session_id, :test_sessions, index: true, type: String, size: 36, key: [:id]
       index [:test_session_id, :name]
 
 
@@ -126,7 +126,7 @@ Sequel.migration do
     end
 
     create_table :headers do
-      column :id, String, index: true, null: false, size: 255
+      column :id, String, index: true, null: false, size: 36
       foreign_key :request_id, :requests, index: true, type: Integer, key: [:index]
       column :type, String, size: 255 # request / response
       column :name, String, size: 255
@@ -138,7 +138,7 @@ Sequel.migration do
 
     create_table :session_data do
       column :id, String, index: true, null: false, size: 255
-      foreign_key :test_session_id, :test_sessions, index: true, type: String, size: 255, key: [:id]
+      foreign_key :test_session_id, :test_sessions, index: true, type: String, size: 36, key: [:id]
       column :name, String, size: 255
       column :value, String, text: true
       index [:test_session_id, :name]

--- a/lib/inferno/db/migrations/001_create_initial_structure.rb
+++ b/lib/inferno/db/migrations/001_create_initial_structure.rb
@@ -119,8 +119,6 @@ Sequel.migration do
       foreign_key :test_session_id, :test_sessions, index: true, type: String, size: 36, key: [:id]
       index [:test_session_id, :name]
 
-
-
       column :created_at, DateTime, null: false
       column :updated_at, DateTime, null: false
     end

--- a/lib/inferno/db/migrations/002_add_wait_support.rb
+++ b/lib/inferno/db/migrations/002_add_wait_support.rb
@@ -2,6 +2,6 @@ Sequel.migration do
   change do
     add_column :test_runs, :identifier, String, text: true
     add_column :test_runs, :wait_timeout, DateTime
-    add_index :test_runs, [:status, :identifier, :wait_timeout, :updated_at], concurrently: true
+    add_index :test_runs, [:status, :identifier, :wait_timeout, :updated_at]
   end
 end

--- a/lib/inferno/db/migrations/002_add_wait_support.rb
+++ b/lib/inferno/db/migrations/002_add_wait_support.rb
@@ -1,6 +1,6 @@
 Sequel.migration do
   change do
-    add_column :test_runs, :identifier, String, text: true
+    add_column :test_runs, :identifier, String, text: true, size: 255
     add_column :test_runs, :wait_timeout, DateTime
     add_index :test_runs, [:status, :identifier, :wait_timeout, :updated_at]
   end

--- a/lib/inferno/db/migrations/003_update_session_data.rb
+++ b/lib/inferno/db/migrations/003_update_session_data.rb
@@ -4,15 +4,15 @@ Sequel.migration do
     drop_table :result_inputs
 
     set_column_type :session_data, :value, String, text: true
-    drop_index :session_data, [:test_session_id, :name], concurrently: true
-    add_index :session_data, [:test_session_id, :name], unique: true, concurrently: true
-    drop_index :session_data, :id, concurrently: true
-    add_index :session_data, :id, unique: true, concurrently: true
+    drop_index :session_data, [:test_session_id, :name]
+    add_index :session_data, [:test_session_id, :name], unique: true
+    drop_index :session_data, :id
+    add_index :session_data, :id, unique: true
 
     add_column :results, :input_json, String, text: true
     add_column :results, :output_json, String, text: true
-    add_index :results, [:test_session_id, :test_id], concurrently: true
-    add_index :results, [:test_session_id, :test_group_id], concurrently: true
-    add_index :results, [:test_session_id, :test_suite_id], concurrently: true
+    add_index :results, [:test_session_id, :test_id]
+    add_index :results, [:test_session_id, :test_group_id]
+    add_index :results, [:test_session_id, :test_suite_id]
   end
 end

--- a/lib/inferno/db/migrations/004_add_request_results_table.rb
+++ b/lib/inferno/db/migrations/004_add_request_results_table.rb
@@ -2,8 +2,8 @@ Sequel.migration do
   change do
     create_table :requests_results do
       # using results_id instead of result_id to avoid ambiguous column error
-      foreign_key :results_id, :results, index: true, type: String, null: false
-      foreign_key :requests_id, :requests, index: true, type: Integer, null: false
+      foreign_key :results_id, :results, index: true, type: String, null: false, size: 255
+      foreign_key :requests_id, :requests, index: true, type: Integer, null: false, size: 255
     end
   end
 end

--- a/lib/inferno/db/migrations/004_add_request_results_table.rb
+++ b/lib/inferno/db/migrations/004_add_request_results_table.rb
@@ -2,8 +2,8 @@ Sequel.migration do
   change do
     create_table :requests_results do
       # using results_id instead of result_id to avoid ambiguous column error
-      foreign_key :results_id, :results, index: true, type: String, null: false, size: 255, key: [:id]
-      foreign_key :requests_id, :requests, index: true, type: Integer, null: false, size: 255, key: [:index]
+      foreign_key :results_id, :results, index: true, type: String, null: false, size: 36, key: [:id]
+      foreign_key :requests_id, :requests, index: true, type: Integer, null: false, size: 36, key: [:index]
     end
   end
 end

--- a/lib/inferno/db/migrations/004_add_request_results_table.rb
+++ b/lib/inferno/db/migrations/004_add_request_results_table.rb
@@ -3,7 +3,7 @@ Sequel.migration do
     create_table :requests_results do
       # using results_id instead of result_id to avoid ambiguous column error
       foreign_key :results_id, :results, index: true, type: String, null: false
-      foreign_key :requests_id, :requests, index: true, type: String, null: false
+      foreign_key :requests_id, :requests, index: true, type: Integer, null: false
     end
   end
 end

--- a/lib/inferno/db/migrations/004_add_request_results_table.rb
+++ b/lib/inferno/db/migrations/004_add_request_results_table.rb
@@ -2,8 +2,8 @@ Sequel.migration do
   change do
     create_table :requests_results do
       # using results_id instead of result_id to avoid ambiguous column error
-      foreign_key :results_id, :results, index: true, type: String, null: false, size: 255
-      foreign_key :requests_id, :requests, index: true, type: Integer, null: false, size: 255
+      foreign_key :results_id, :results, index: true, type: String, null: false, size: 255, key: [:id]
+      foreign_key :requests_id, :requests, index: true, type: Integer, null: false, size: 255, key: [:index]
     end
   end
 end

--- a/lib/inferno/db/migrations/005_add_updated_at_index_to_results.rb
+++ b/lib/inferno/db/migrations/005_add_updated_at_index_to_results.rb
@@ -1,5 +1,5 @@
 Sequel.migration do
   change do
-    add_index :results, [:test_run_id, :updated_at], concurrently: true
+    add_index :results, [:test_run_id, :updated_at]
   end
 end

--- a/lib/inferno/db/migrations/006_remove_unused_tables.rb
+++ b/lib/inferno/db/migrations/006_remove_unused_tables.rb
@@ -2,5 +2,37 @@ Sequel.migration do
   change do
     drop_table :result_outputs
     drop_table :result_prompt_values
+
+    alter_table(:test_sessions) { set_column_not_null :test_suite_id }
+
+    alter_table(:results) do
+      set_column_not_null :test_run_id
+      set_column_not_null :test_session_id
+    end
+
+    alter_table(:messages) do
+      set_column_not_null :result_id
+      set_column_not_null :type
+      set_column_not_null :message
+    end
+
+    alter_table(:requests) do
+      set_column_not_null :verb
+      set_column_not_null :url
+      set_column_not_null :direction
+      set_column_not_null :result_id
+      set_column_not_null :test_session_id
+    end
+
+    alter_table(:headers) do
+      set_column_not_null :request_id
+      set_column_not_null :type
+      set_column_not_null :name
+    end
+
+    alter_table(:session_data) do
+      set_column_not_null :test_session_id
+      set_column_not_null :name
+    end
   end
 end

--- a/lib/inferno/db/migrations/006_remove_unused_tables.rb
+++ b/lib/inferno/db/migrations/006_remove_unused_tables.rb
@@ -1,0 +1,6 @@
+Sequel.migration do
+  change do
+    drop_table :result_outputs
+    drop_table :result_prompt_values
+  end
+end

--- a/lib/inferno/db/schema.rb
+++ b/lib/inferno/db/schema.rb
@@ -15,7 +15,7 @@ Sequel.migration do
     
     create_table(:session_data, :ignore_index_errors=>true) do
       String :id, :size=>255, :null=>false
-      foreign_key :test_session_id, :test_sessions, :type=>String, :size=>255
+      foreign_key :test_session_id, :test_sessions, :type=>String, :size=>255, :key=>[:id]
       String :name, :size=>255
       String :value, :text=>true
       
@@ -27,7 +27,7 @@ Sequel.migration do
     create_table(:test_runs, :ignore_index_errors=>true) do
       String :id, :size=>255, :null=>false
       String :status, :size=>255
-      foreign_key :test_session_id, :test_sessions, :type=>String, :size=>255
+      foreign_key :test_session_id, :test_sessions, :type=>String, :size=>255, :key=>[:id]
       String :test_suite_id, :size=>255
       String :test_group_id, :size=>255
       String :test_id, :size=>255
@@ -48,8 +48,8 @@ Sequel.migration do
     
     create_table(:results, :ignore_index_errors=>true) do
       String :id, :size=>255, :null=>false
-      foreign_key :test_run_id, :test_runs, :type=>String, :size=>255
-      foreign_key :test_session_id, :test_sessions, :type=>String, :size=>255
+      foreign_key :test_run_id, :test_runs, :type=>String, :size=>255, :key=>[:id]
+      foreign_key :test_session_id, :test_sessions, :type=>String, :size=>255, :key=>[:id]
       String :result, :size=>255
       String :result_message, :text=>true
       String :test_suite_id, :size=>255
@@ -73,7 +73,7 @@ Sequel.migration do
     create_table(:messages, :ignore_index_errors=>true) do
       primary_key :index
       String :id, :size=>255, :null=>false
-      foreign_key :result_id, :results, :type=>String, :size=>255
+      foreign_key :result_id, :results, :type=>String, :size=>255, :key=>[:id]
       String :type, :size=>255
       String :message, :text=>true
       DateTime :created_at, :null=>false
@@ -93,8 +93,8 @@ Sequel.migration do
       String :name, :size=>255
       String :request_body, :text=>true
       String :response_body, :text=>true
-      foreign_key :result_id, :results, :type=>String, :size=>255
-      foreign_key :test_session_id, :test_sessions, :type=>String, :size=>255
+      foreign_key :result_id, :results, :type=>String, :size=>255, :key=>[:id]
+      foreign_key :test_session_id, :test_sessions, :type=>String, :size=>255, :key=>[:id]
       DateTime :created_at, :null=>false
       DateTime :updated_at, :null=>false
       
@@ -106,7 +106,7 @@ Sequel.migration do
     
     create_table(:headers, :ignore_index_errors=>true) do
       String :id, :size=>255, :null=>false
-      foreign_key :request_id, :requests
+      foreign_key :request_id, :requests, :key=>[:index]
       String :type, :size=>255
       String :name, :size=>255
       String :value, :text=>true
@@ -118,8 +118,8 @@ Sequel.migration do
     end
     
     create_table(:requests_results, :ignore_index_errors=>true) do
-      foreign_key :results_id, :results, :type=>String, :size=>255, :null=>false
-      foreign_key :requests_id, :requests, :null=>false
+      foreign_key :results_id, :results, :type=>String, :size=>255, :null=>false, :key=>[:id]
+      foreign_key :requests_id, :requests, :null=>false, :key=>[:index]
       
       index [:requests_id]
       index [:results_id]

--- a/lib/inferno/db/schema.rb
+++ b/lib/inferno/db/schema.rb
@@ -102,6 +102,7 @@ Sequel.migration do
       index [:result_id]
       index [:test_session_id]
       index [:test_session_id, :name]
+      index [:id], :name=>:sqlite_autoindex_requests_1, :unique=>true
     end
     
     create_table(:result_outputs, :ignore_index_errors=>true) do
@@ -132,7 +133,7 @@ Sequel.migration do
     
     create_table(:headers, :ignore_index_errors=>true) do
       String :id, :size=>255, :null=>false
-      foreign_key :request_id, :requests, :type=>String, :size=>255
+      foreign_key :request_id, :requests
       String :type, :size=>255
       String :name, :size=>255
       String :value, :size=>255
@@ -145,7 +146,7 @@ Sequel.migration do
     
     create_table(:requests_results, :ignore_index_errors=>true) do
       foreign_key :results_id, :results, :type=>String, :size=>255, :null=>false
-      foreign_key :requests_id, :requests, :type=>String, :size=>255, :null=>false
+      foreign_key :requests_id, :requests, :null=>false
       
       index [:requests_id]
       index [:results_id]

--- a/lib/inferno/db/schema.rb
+++ b/lib/inferno/db/schema.rb
@@ -6,7 +6,7 @@ Sequel.migration do
     
     create_table(:test_sessions) do
       String :id, :size=>36, :null=>false
-      String :test_suite_id, :size=>255
+      String :test_suite_id, :size=>255, :null=>false
       DateTime :created_at, :null=>false
       DateTime :updated_at, :null=>false
       
@@ -15,8 +15,8 @@ Sequel.migration do
     
     create_table(:session_data, :ignore_index_errors=>true) do
       String :id, :size=>255, :null=>false
-      foreign_key :test_session_id, :test_sessions, :type=>String, :size=>36, :key=>[:id]
-      String :name, :size=>255
+      foreign_key :test_session_id, :test_sessions, :type=>String, :size=>36, :null=>false, :key=>[:id]
+      String :name, :size=>255, :null=>false
       String :value, :text=>true
       
       index [:id], :unique=>true
@@ -48,8 +48,8 @@ Sequel.migration do
     
     create_table(:results, :ignore_index_errors=>true) do
       String :id, :size=>36, :null=>false
-      foreign_key :test_run_id, :test_runs, :type=>String, :size=>36, :key=>[:id]
-      foreign_key :test_session_id, :test_sessions, :type=>String, :size=>36, :key=>[:id]
+      foreign_key :test_run_id, :test_runs, :type=>String, :size=>36, :null=>false, :key=>[:id]
+      foreign_key :test_session_id, :test_sessions, :type=>String, :size=>36, :null=>false, :key=>[:id]
       String :result, :size=>255
       String :result_message, :text=>true
       String :test_suite_id, :size=>255
@@ -73,9 +73,9 @@ Sequel.migration do
     create_table(:messages, :ignore_index_errors=>true) do
       primary_key :index
       String :id, :size=>36, :null=>false
-      foreign_key :result_id, :results, :type=>String, :size=>36, :key=>[:id]
-      String :type, :size=>255
-      String :message, :text=>true
+      foreign_key :result_id, :results, :type=>String, :size=>36, :null=>false, :key=>[:id]
+      String :type, :size=>255, :null=>false
+      String :message, :text=>true, :null=>false
       DateTime :created_at, :null=>false
       DateTime :updated_at, :null=>false
       
@@ -86,15 +86,15 @@ Sequel.migration do
     create_table(:requests, :ignore_index_errors=>true) do
       primary_key :index
       String :id, :size=>36, :null=>false
-      String :verb, :size=>255
-      String :url, :text=>true
-      String :direction, :size=>255
+      String :verb, :size=>255, :null=>false
+      String :url, :text=>true, :null=>false
+      String :direction, :size=>255, :null=>false
       Integer :status
       String :name, :size=>255
       String :request_body, :text=>true
       String :response_body, :text=>true
-      foreign_key :result_id, :results, :type=>String, :size=>36, :key=>[:id]
-      foreign_key :test_session_id, :test_sessions, :type=>String, :size=>36, :key=>[:id]
+      foreign_key :result_id, :results, :type=>String, :size=>36, :null=>false, :key=>[:id]
+      foreign_key :test_session_id, :test_sessions, :type=>String, :size=>36, :null=>false, :key=>[:id]
       DateTime :created_at, :null=>false
       DateTime :updated_at, :null=>false
       
@@ -106,9 +106,9 @@ Sequel.migration do
     
     create_table(:headers, :ignore_index_errors=>true) do
       String :id, :size=>36, :null=>false
-      foreign_key :request_id, :requests, :key=>[:index]
-      String :type, :size=>255
-      String :name, :size=>255
+      foreign_key :request_id, :requests, :null=>false, :key=>[:index]
+      String :type, :size=>255, :null=>false
+      String :name, :size=>255, :null=>false
       String :value, :text=>true
       DateTime :created_at, :null=>false
       DateTime :updated_at, :null=>false

--- a/lib/inferno/db/schema.rb
+++ b/lib/inferno/db/schema.rb
@@ -98,11 +98,10 @@ Sequel.migration do
       DateTime :created_at, :null=>false
       DateTime :updated_at, :null=>false
       
-      index [:id]
+      index [:id], :unique=>true
       index [:result_id]
       index [:test_session_id]
       index [:test_session_id, :name]
-      index [:id], :name=>:sqlite_autoindex_requests_1, :unique=>true
     end
     
     create_table(:headers, :ignore_index_errors=>true) do

--- a/lib/inferno/db/schema.rb
+++ b/lib/inferno/db/schema.rb
@@ -5,7 +5,7 @@ Sequel.migration do
     end
     
     create_table(:test_sessions) do
-      String :id, :size=>255, :null=>false
+      String :id, :size=>36, :null=>false
       String :test_suite_id, :size=>255
       DateTime :created_at, :null=>false
       DateTime :updated_at, :null=>false
@@ -15,7 +15,7 @@ Sequel.migration do
     
     create_table(:session_data, :ignore_index_errors=>true) do
       String :id, :size=>255, :null=>false
-      foreign_key :test_session_id, :test_sessions, :type=>String, :size=>255, :key=>[:id]
+      foreign_key :test_session_id, :test_sessions, :type=>String, :size=>36, :key=>[:id]
       String :name, :size=>255
       String :value, :text=>true
       
@@ -25,9 +25,9 @@ Sequel.migration do
     end
     
     create_table(:test_runs, :ignore_index_errors=>true) do
-      String :id, :size=>255, :null=>false
+      String :id, :size=>36, :null=>false
       String :status, :size=>255
-      foreign_key :test_session_id, :test_sessions, :type=>String, :size=>255, :key=>[:id]
+      foreign_key :test_session_id, :test_sessions, :type=>String, :size=>36, :key=>[:id]
       String :test_suite_id, :size=>255
       String :test_group_id, :size=>255
       String :test_id, :size=>255
@@ -47,9 +47,9 @@ Sequel.migration do
     end
     
     create_table(:results, :ignore_index_errors=>true) do
-      String :id, :size=>255, :null=>false
-      foreign_key :test_run_id, :test_runs, :type=>String, :size=>255, :key=>[:id]
-      foreign_key :test_session_id, :test_sessions, :type=>String, :size=>255, :key=>[:id]
+      String :id, :size=>36, :null=>false
+      foreign_key :test_run_id, :test_runs, :type=>String, :size=>36, :key=>[:id]
+      foreign_key :test_session_id, :test_sessions, :type=>String, :size=>36, :key=>[:id]
       String :result, :size=>255
       String :result_message, :text=>true
       String :test_suite_id, :size=>255
@@ -72,8 +72,8 @@ Sequel.migration do
     
     create_table(:messages, :ignore_index_errors=>true) do
       primary_key :index
-      String :id, :size=>255, :null=>false
-      foreign_key :result_id, :results, :type=>String, :size=>255, :key=>[:id]
+      String :id, :size=>36, :null=>false
+      foreign_key :result_id, :results, :type=>String, :size=>36, :key=>[:id]
       String :type, :size=>255
       String :message, :text=>true
       DateTime :created_at, :null=>false
@@ -85,7 +85,7 @@ Sequel.migration do
     
     create_table(:requests, :ignore_index_errors=>true) do
       primary_key :index
-      String :id, :size=>255, :null=>false
+      String :id, :size=>36, :null=>false
       String :verb, :size=>255
       String :url, :text=>true
       String :direction, :size=>255
@@ -93,8 +93,8 @@ Sequel.migration do
       String :name, :size=>255
       String :request_body, :text=>true
       String :response_body, :text=>true
-      foreign_key :result_id, :results, :type=>String, :size=>255, :key=>[:id]
-      foreign_key :test_session_id, :test_sessions, :type=>String, :size=>255, :key=>[:id]
+      foreign_key :result_id, :results, :type=>String, :size=>36, :key=>[:id]
+      foreign_key :test_session_id, :test_sessions, :type=>String, :size=>36, :key=>[:id]
       DateTime :created_at, :null=>false
       DateTime :updated_at, :null=>false
       
@@ -105,7 +105,7 @@ Sequel.migration do
     end
     
     create_table(:headers, :ignore_index_errors=>true) do
-      String :id, :size=>255, :null=>false
+      String :id, :size=>36, :null=>false
       foreign_key :request_id, :requests, :key=>[:index]
       String :type, :size=>255
       String :name, :size=>255
@@ -118,7 +118,7 @@ Sequel.migration do
     end
     
     create_table(:requests_results, :ignore_index_errors=>true) do
-      foreign_key :results_id, :results, :type=>String, :size=>255, :null=>false, :key=>[:id]
+      foreign_key :results_id, :results, :type=>String, :size=>36, :null=>false, :key=>[:id]
       foreign_key :requests_id, :requests, :null=>false, :key=>[:index]
       
       index [:requests_id]

--- a/lib/inferno/db/schema.rb
+++ b/lib/inferno/db/schema.rb
@@ -51,7 +51,7 @@ Sequel.migration do
       foreign_key :test_run_id, :test_runs, :type=>String, :size=>255
       foreign_key :test_session_id, :test_sessions, :type=>String, :size=>255
       String :result, :size=>255
-      String :result_message, :size=>255
+      String :result_message, :text=>true
       String :test_suite_id, :size=>255
       String :test_group_id, :size=>255
       String :test_id, :size=>255
@@ -75,7 +75,7 @@ Sequel.migration do
       String :id, :size=>255, :null=>false
       foreign_key :result_id, :results, :type=>String, :size=>255
       String :type, :size=>255
-      String :message, :size=>255
+      String :message, :text=>true
       DateTime :created_at, :null=>false
       DateTime :updated_at, :null=>false
       
@@ -87,7 +87,7 @@ Sequel.migration do
       primary_key :index
       String :id, :size=>255, :null=>false
       String :verb, :size=>255
-      String :url, :size=>255
+      String :url, :text=>true
       String :direction, :size=>255
       Integer :status
       String :name, :size=>255
@@ -105,38 +105,12 @@ Sequel.migration do
       index [:id], :name=>:sqlite_autoindex_requests_1, :unique=>true
     end
     
-    create_table(:result_outputs, :ignore_index_errors=>true) do
-      String :id, :size=>255, :null=>false
-      foreign_key :result_id, :results, :type=>String, :size=>255
-      String :test_output_id, :size=>255
-      String :value, :size=>255
-      DateTime :created_at, :null=>false
-      DateTime :updated_at, :null=>false
-      
-      primary_key [:id]
-      
-      index [:result_id]
-    end
-    
-    create_table(:result_prompt_values, :ignore_index_errors=>true) do
-      String :id, :size=>255, :null=>false
-      foreign_key :result_id, :results, :type=>String, :size=>255
-      String :test_prompt_id, :size=>255, :null=>false
-      String :value, :size=>255, :null=>false
-      DateTime :created_at, :null=>false
-      DateTime :updated_at, :null=>false
-      
-      primary_key [:id]
-      
-      index [:result_id]
-    end
-    
     create_table(:headers, :ignore_index_errors=>true) do
       String :id, :size=>255, :null=>false
       foreign_key :request_id, :requests
       String :type, :size=>255
       String :name, :size=>255
-      String :value, :size=>255
+      String :value, :text=>true
       DateTime :created_at, :null=>false
       DateTime :updated_at, :null=>false
       

--- a/spec/factories/request.rb
+++ b/spec/factories/request.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :request, class: 'Inferno::Entities::Request' do
     transient do
-      result
+      result { repo_create(:result, request_count: 0) }
       header_count { 2 }
     end
 

--- a/spec/factories/result.rb
+++ b/spec/factories/result.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :result, class: 'Inferno::Entities::Result' do
     transient do
       runnable { test_run.runnable.reference_hash }
-      test_run
+      test_run { repo_create(:test_run) }
       test_session { test_run.test_session }
       message_count { 0 }
       request_count { 0 }
@@ -23,7 +23,7 @@ FactoryBot.define do
     before(:create) do |instance, evaluator|
       instance.instance_variable_set(
         :@requests,
-        repo_create_list(:request, evaluator.request_count, result_id: instance.id)
+        build_list(:request, evaluator.request_count, result: instance)
       )
     end
 

--- a/spec/inferno/repositories/requests_spec.rb
+++ b/spec/inferno/repositories/requests_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Inferno::Repositories::Requests do
         status: 200,
         request_body: 'REQUEST_BODY',
         response_body: 'RESPONSE_BODY',
+        result_id: result.id,
         test_session_id: test_session.id,
         request_headers: [{ name: 'REQUEST_HEADER_NAME', value: 'REQUEST_HEADER_VALUE', type: 'request' }],
         response_headers: [{ name: 'RESPONSE_HEADER_NAME', value: 'RESPONSE_HEADER_VALUE', type: 'response' }]

--- a/spec/inferno/repositories/results_spec.rb
+++ b/spec/inferno/repositories/results_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Inferno::Repositories::Results do
       status: 200,
       request_body: 'REQUEST_BODY',
       response_body: 'RESPONSE_BODY',
+      test_session_id: test_session.id,
       headers: [{ name: 'REQUEST_HEADER_NAME', value: 'REQUEST_HEADER_VALUE', type: 'request' },
                 { name: 'RESPONSE_HEADER_NAME', value: 'RESPONSE_HEADER_VALUE', type: 'response' }]
     }


### PR DESCRIPTION
This branch updates inferno so that it works with postgres. SQLite is much more permissive, so migrations had to be updated in order to be compatible with postgres. Steps to test:

- run postgres:
```
docker run -p 5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust -e POSTGRES_DB=inferno_development postgres:14.1-alpine
```
- in `config/database.yml`, comment out the sqlite config and uncomment the postgres config
- add `gem 'pg'` to `Gemfile`
- `bundle install`
- `bundle exec bin/inferno migrate`
- `npm run dev` and everything should run normally.

You can also run the unit tests with postgres if you copy the postgres `development` config in `config/database.yml` to `test`.