### PR TITLE
Add modal when a test in a wait state.

### DIFF
--- a/client/src/components/ActionModal/ActionModal.tsx
+++ b/client/src/components/ActionModal/ActionModal.tsx
@@ -25,7 +25,7 @@ const ActionModal: FC<ActionModalProps> = ({ modalVisible, message, cancelTest }
         </DialogContentText>
       </DialogContent>
       <DialogActions>
-        <Button color="primary" onClick={() => cancelTest()} data-testid="cancel-button">
+        <Button color="primary" onClick={cancelTest} data-testid="cancel-button">
           Cancel
         </Button>
       </DialogActions>

--- a/client/src/components/ActionModal/ActionModal.tsx
+++ b/client/src/components/ActionModal/ActionModal.tsx
@@ -21,7 +21,7 @@ const ActionModal: FC<ActionModalProps> = ({ modalVisible, message, cancelTest }
       <DialogTitle>User Action Required</DialogTitle>
       <DialogContent>
         <DialogContentText>
-          <ReactMarkdown>{message ? message : ''}</ReactMarkdown>
+          <ReactMarkdown>{message || ''}</ReactMarkdown>
         </DialogContentText>
       </DialogContent>
       <DialogActions>

--- a/client/src/components/ActionModal/ActionModal.tsx
+++ b/client/src/components/ActionModal/ActionModal.tsx
@@ -17,7 +17,7 @@ export interface ActionModalProps {
 
 const ActionModal: FC<ActionModalProps> = ({ modalVisible, message, cancelTest }) => {
   return (
-    <Dialog open={modalVisible} fullWidth={true} maxWidth="sm">
+    <Dialog open={modalVisible} fullWidth maxWidth="sm">
       <DialogTitle>User Action Required</DialogTitle>
       <DialogContent>
         <DialogContentText>

--- a/client/src/components/ActionModal/ActionModal.tsx
+++ b/client/src/components/ActionModal/ActionModal.tsx
@@ -1,0 +1,36 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from '@mui/material';
+import React, { FC } from 'react';
+import ReactMarkdown from 'react-markdown';
+
+export interface ActionModalProps {
+  modalVisible: boolean;
+  message?: string;
+  cancelTest: () => void;
+}
+
+const ActionModal: FC<ActionModalProps> = ({ modalVisible, message, cancelTest }) => {
+  return (
+    <Dialog open={modalVisible} fullWidth={true} maxWidth="sm">
+      <DialogTitle>User Action Required</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          <ReactMarkdown>{message ? message : ''}</ReactMarkdown>
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button color="primary" onClick={() => cancelTest()} data-testid="cancel-button">
+          Cancel
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ActionModal;

--- a/client/src/components/InputsModal/InputsModal.tsx
+++ b/client/src/components/InputsModal/InputsModal.tsx
@@ -88,7 +88,7 @@ const InputsModal: FC<InputsModalProps> = ({
   });
 
   return (
-    <Dialog open={modalVisible} onClose={() => hideModal()} fullWidth={true} maxWidth="sm">
+    <Dialog open={modalVisible} onClose={hideModal} fullWidth maxWidth="sm">
       <DialogTitle>Test Inputs</DialogTitle>
       <DialogContent>
         <DialogContentText>
@@ -97,10 +97,10 @@ const InputsModal: FC<InputsModalProps> = ({
         <List>{inputFields}</List>
       </DialogContent>
       <DialogActions>
-        <Button color="primary" onClick={() => hideModal()} data-testid="cancel-button">
+        <Button color="primary" onClick={hideModal} data-testid="cancel-button">
           Cancel
         </Button>
-        <Button color="primary" onClick={() => submitClicked()} disabled={missingRequiredInput}>
+        <Button color="primary" onClick={submitClicked} disabled={missingRequiredInput}>
           Submit
         </Button>
       </DialogActions>

--- a/client/src/components/TestSuite/TestSession.tsx
+++ b/client/src/components/TestSuite/TestSession.tsx
@@ -289,7 +289,7 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
         <ActionModal
           cancelTest={() => alert('TODO: CANCEL TEST')}
           message={waitingTestId ? resultsMap.get(waitingTestId)?.result_message : ''}
-          modalVisible={waitingTestId !== null}
+          modalVisible={waitingTestId != null}
         />
       </Box>
     </Box>

--- a/client/src/components/TestSuite/TestSession.tsx
+++ b/client/src/components/TestSuite/TestSession.tsx
@@ -11,6 +11,7 @@ import {
   Request,
   TestOutput,
 } from 'models/testSuiteModels';
+import ActionModal from 'components/ActionModal/ActionModal';
 import InputsModal from 'components/InputsModal/InputsModal';
 import useStyles from './styles';
 import TestRunProgressBar from './TestRunProgressBar/TestRunProgressBar';
@@ -77,7 +78,8 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
 }) => {
   const styles = useStyles();
   const { test_suite, id } = testSession;
-  const [modalVisible, setModalVisible] = React.useState(false);
+  const [inputModalVisible, setInputModalVisible] = React.useState(false);
+  const [waitingTestId, setWaitingTestId] = React.useState<string | null>();
   const [inputs, setInputs] = React.useState<TestInput[]>([]);
   const [runnableType, setRunnableType] = React.useState<RunnableType>(RunnableType.TestSuite);
   const [runnableId, setRunnableId] = React.useState<string>('');
@@ -110,6 +112,19 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
     }
   }
 
+  useEffect(() => {
+    let waitingTestId = null;
+    if (testRun?.status === 'waiting') {
+      resultsMap.forEach((result) => {
+        if (result.test_id && result.result === 'wait') {
+          waitingTestId = result.test_id;
+        }
+      });
+    }
+
+    setWaitingTestId(waitingTestId);
+  }, [resultsMap]);
+
   const runnableMap = React.useMemo(() => mapRunnableToId(test_suite), [test_suite]);
   const location = useLocation();
   let selectedRunnable = location.hash.replace('#', '');
@@ -121,7 +136,7 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
     setInputs(inputs);
     setRunnableType(runnableType);
     setRunnableId(runnableId);
-    setModalVisible(true);
+    setInputModalVisible(true);
   }
 
   function latestResult(results: Result[] | null | undefined): Result | null {
@@ -264,12 +279,17 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
           <div>error</div>
         )}
         <InputsModal
-          hideModal={() => setModalVisible(false)}
+          hideModal={() => setInputModalVisible(false)}
           createTestRun={createTestRun}
-          modalVisible={modalVisible}
+          modalVisible={inputModalVisible}
           runnableType={runnableType}
           runnableId={runnableId}
           inputs={inputs}
+        />
+        <ActionModal
+          cancelTest={() => alert('TODO: CANCEL TEST')}
+          message={waitingTestId ? resultsMap.get(waitingTestId)?.result_message : ''}
+          modalVisible={waitingTestId !== null}
         />
       </Box>
     </Box>

--- a/dev_suites/dev_demo_ig_stu1/demo_suite.rb
+++ b/dev_suites/dev_demo_ig_stu1/demo_suite.rb
@@ -28,6 +28,11 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
       exclude_message { |message| message.type == 'info' }
     end
 
+ 
+    config options: {
+      wait_test_url: "#{Inferno::Application['inferno_host']}/custom/demo/resume",
+    }
+
     group :simple_group do
       title 'Group 1'
       group from: 'DemoIG_STU1::DemoGroup', title: 'Demo Group Instance 1'
@@ -62,7 +67,15 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
         title 'Wait test'
         receives_request :resume
 
-        run { wait(identifier: 'abc') }
+        run do
+          wait(
+            identifier: 'abc',
+            message: %(
+              [Follow this link to proceed](#{config.options[:wait_test_url]}?xyz=abc).
+              Waiting to receive a request at ```#{config.options[:wait_test_url]}?xyz=abc```.
+            )
+          )
+        end
       end
 
       test do

--- a/dev_suites/dev_demo_ig_stu1/demo_suite.rb
+++ b/dev_suites/dev_demo_ig_stu1/demo_suite.rb
@@ -28,9 +28,8 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
       exclude_message { |message| message.type == 'info' }
     end
 
- 
     config options: {
-      wait_test_url: "#{Inferno::Application['inferno_host']}/custom/demo/resume",
+      wait_test_url: "#{Inferno::Application['inferno_host']}/custom/demo/resume"
     }
 
     group :simple_group do


### PR DESCRIPTION
If a test is in a 'wait' state, the user must perform action (I suppose theoretically you could create wait states where the tester isn't supposed to do anything and there is some other external thing that is supposed to go on, but i think this is the best way to describe this situation).  Previous to this PR, the 'wait' state was just shown as a message in the test result, and the user would have to know to find that result int the interface.  It needs to be more obvious.

This PR moves the wait message that tells the user what to do into a modal.  it is rendered as markdown, allowing a little bit of flexibilty in presentaion. The user cannot perform any other action in the interface (this is on purpose), except cancel the test.  Since we do not yet have test cancellation functionality, I have a TODO: alert in place if you try to cancel.

I believe this is probably good enough for us to fully implement g10 tests.  In the future it may make sense to have these work more like [CDS cards](https://cds-hooks.org/) so the test writer has a more rich API for describing what actions the tester needs to take.

To try it out, run the 'Wait' group in the demo suite:

<img width="1573" alt="Screen Shot 2021-12-15 at 5 11 01 PM" src="https://user-images.githubusercontent.com/412901/146273772-9ee159d6-ff5d-4c49-98ae-4b3811dac092.png">

I do not currently have any tests around this, and I don't love how much work this has to do to pull out the test message (loop through all tests with results to find the one with the message).  But this is the lightest touch I could think of without refactoring.
