### PR TITLE
Refine behavior of oauth required/optional fields.

### DIFF
--- a/client/src/components/InputsModal/InputOAuthCredentials.tsx
+++ b/client/src/components/InputsModal/InputOAuthCredentials.tsx
@@ -64,26 +64,31 @@ const InputOAuthCredentials: FC<InputOAuthCredentialsProps> = ({
     {
       name: 'refresh_token',
       label: 'Refresh Token (will automatically refresh if available)',
+      required: false,
     },
     {
       name: 'token_url',
       label: 'Token Endpoint',
       hide: !showRefreshDetails,
+      required: true,
     },
     {
       name: 'expires_in',
       label: 'Expires in (seconds)',
       hide: !showRefreshDetails,
+      required: false,
     },
     {
       name: 'client_id',
       label: 'Client ID',
       hide: !showRefreshDetails,
+      required: true,
     },
     {
       name: 'client_secret',
       label: 'Client Secret',
       hide: !showRefreshDetails,
+      required: false,
     },
   ];
 

--- a/client/src/components/InputsModal/InputOAuthCredentials.tsx
+++ b/client/src/components/InputsModal/InputOAuthCredentials.tsx
@@ -73,12 +73,6 @@ const InputOAuthCredentials: FC<InputOAuthCredentialsProps> = ({
       required: true,
     },
     {
-      name: 'expires_in',
-      label: 'Expires in (seconds)',
-      hide: !showRefreshDetails,
-      required: false,
-    },
-    {
       name: 'client_id',
       label: 'Client ID',
       hide: !showRefreshDetails,
@@ -87,6 +81,12 @@ const InputOAuthCredentials: FC<InputOAuthCredentialsProps> = ({
     {
       name: 'client_secret',
       label: 'Client Secret',
+      hide: !showRefreshDetails,
+      required: false,
+    },
+    {
+      name: 'expires_in',
+      label: 'Expires in (seconds)',
       hide: !showRefreshDetails,
       required: false,
     },

--- a/client/src/components/InputsModal/InputsModal.tsx
+++ b/client/src/components/InputsModal/InputsModal.tsx
@@ -51,15 +51,12 @@ const InputsModal: FC<InputsModalProps> = ({
       const accessTokenIsEmpty = oAuthJSON.access_token === '';
       const refreshIsEmpty =
         oAuthJSON.refresh_token !== '' &&
-        (oAuthJSON.token_url === '' ||
-          oAuthJSON.expires_in === '' ||
-          oAuthJSON.client_id === '' ||
-          oAuthJSON.client_secret === '');
-      oAuthMissingRequiredInput = accessTokenIsEmpty || refreshIsEmpty;
+        (oAuthJSON.token_url === '' || oAuthJSON.client_id === '');
+      oAuthMissingRequiredInput = (accessTokenIsEmpty && !input.optional) || refreshIsEmpty;
     } catch (e) {
       // if JSON.parse fails, then assume field is not OAuth and move on
     }
-    return !input.optional && (!inputsMap.get(input.name) || oAuthMissingRequiredInput);
+    return (!input.optional && !inputsMap.get(input.name)) || oAuthMissingRequiredInput;
   });
 
   function submitClicked(): void {


### PR DESCRIPTION
After approving the oauth credential fronted PR, I realized that the behavior wasn't quite right.

No matter what, if the 'refresh token' field is filled in, 'token endpoint' and 'client id' MUST be filled in, because otherwise the refresh token is useless.  This applies if the oauth credential field is marked as optional or required.  Also, I made sure the 'required' tag shows up on these fields when the refresh token is filled in, because otherwise its not clear why you can't submit the form.

expires in / client secret never are required, because they may not be necessary to make the refresh token work.