### PR TITLE
Add input_instructions, short_title, short_descripton.

### DIFF
--- a/dev_suites/dev_infrastructure_test/infrastructure_test.rb
+++ b/dev_suites/dev_infrastructure_test/infrastructure_test.rb
@@ -40,6 +40,7 @@ module InfrastructureTest
       group 'Inner inline group', id: 'inner_inline_group' do
         input :inner_group_input
         output :inner_group_output
+        short_title 'Inner inline group short title'
 
         def inner_inline_group_helper
           'INNER_INLINE_GROUP_HELPER'
@@ -52,6 +53,7 @@ module InfrastructureTest
         test 'Inline test 1', id: 'inline_test_1' do
           input :test_input
           output :test_output
+          short_title 'Inline test 1'
           description 'Inline test 1 full description'
           short_description 'Inline test 1 short description'
 

--- a/dev_suites/dev_infrastructure_test/infrastructure_test.rb
+++ b/dev_suites/dev_infrastructure_test/infrastructure_test.rb
@@ -5,8 +5,11 @@ require_relative 'mixed_optional_group'
 module InfrastructureTest
   class Suite < Inferno::TestSuite
     id 'infra_test'
-    title 'Infrastructure Test'
-    description 'An internal test suite to verify that inferno infrastructure is working'
+    title 'Infrastructure Test Suite'
+    short_title 'Infrastructure'
+    description 'An internal test suite to verify that inferno infrastructure works'
+    short_description 'Internal test suite'
+    input_instructions 'Instructions for inputs'
 
     input :suite_input
     output :suite_output
@@ -19,9 +22,12 @@ module InfrastructureTest
       url 'SUITE'
     end
 
-    group 'Outer inline group', id: 'outer_inline_group' do
+    group 'Outer inline group title', id: 'outer_inline_group' do
       input :outer_group_input
       output :outer_group_output
+      short_title 'Outer inline group short title'
+      description 'Outer inline group for testing description'
+      short_description 'Outer inline group short description'
 
       def outer_inline_group_helper
         'OUTER_INLINE_GROUP_HELPER'
@@ -46,6 +52,8 @@ module InfrastructureTest
         test 'Inline test 1', id: 'inline_test_1' do
           input :test_input
           output :test_output
+          description 'Inline test 1 full description'
+          short_description 'Inline test 1 short description'
 
           def inline_test1_helper
             'INLINE_TEST1_HELPER'

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -468,7 +468,13 @@ definitions:
         type: "string"
       title:
         type: "string"
+      short_title:
+        type: "string"
       description:
+        type: "string"
+      short_description:
+        type: "string"
+      input_instructions:
         type: "string"
       test_groups:
         type: "array"
@@ -490,7 +496,13 @@ definitions:
         type: "string"
       title:
         type: "string"
+      short_title:
+        type: "string"
       description:
+        type: "string"
+      short_description:
+        type: "string"
+      input_instructions:
         type: "string"
       run_as_group:
         type: "boolean"
@@ -525,7 +537,13 @@ definitions:
         type: "string"
       title:
         type: "string"
+      short_title:
+        type: "string"
       description:
+        type: "string"
+      short_description:
+        type: "string"
+      input_instructions:
         type: "string"
       inputs:
         type: "array"

--- a/lib/inferno/apps/web/serializers/test.rb
+++ b/lib/inferno/apps/web/serializers/test.rb
@@ -4,9 +4,12 @@ module Inferno
       class Test < Serializer
         identifier :id
         field :title
+        field :short_title
         field :input_definitions, name: :inputs, extractor: HashValueExtractor, blueprint: Input
         field :output_definitions, name: :outputs, extractor: HashValueExtractor
         field :description
+        field :short_description
+        field :input_instructions
         field :user_runnable?, name: :user_runnable
         field :optional?, name: :optional
       end

--- a/lib/inferno/apps/web/serializers/test_group.rb
+++ b/lib/inferno/apps/web/serializers/test_group.rb
@@ -5,7 +5,10 @@ module Inferno
         identifier :id
 
         field :title
+        field :short_title
         field :description
+        field :short_description
+        field :input_instructions
         field :test_count
         field :run_as_group?, name: :run_as_group
         field :user_runnable?, name: :user_runnable

--- a/lib/inferno/apps/web/serializers/test_suite.rb
+++ b/lib/inferno/apps/web/serializers/test_suite.rb
@@ -5,7 +5,10 @@ module Inferno
         view :summary do
           identifier :id
           field :title
+          field :short_title
           field :description
+          field :short_description
+          field :input_instructions
           field :test_count
         end
 

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -213,6 +213,17 @@ module Inferno
         @title = new_title
       end
 
+      # Set/Get a runnable's short title
+      #
+      # @param new_short_title [String]
+      # @return [String] short title, or title if no short title defined
+      def short_title(new_short_title = nil)
+        return @title if new_short_title.nil? && @short_title.nil?
+        return @short_title if new_short_title.nil?
+
+        @short_title = new_short_title
+      end
+
       # Set/Get a runnable's description
       #
       # @param new_description [String]
@@ -221,6 +232,26 @@ module Inferno
         return @description if new_description.nil?
 
         @description = format_markdown(new_description)
+      end
+
+      # Set/Get a runnable's short one-sentence description
+      #
+      # @param new_short_description [String]
+      # @return [String] the one-sentence description
+      def short_description(new_short_description = nil)
+        return @short_description if new_short_description.nil?
+
+        @short_description = format_markdown(new_short_description)
+      end
+
+      # Set/Get a runnable's input instructions
+      #
+      # @param new_input_instructions [String]
+      # @return [String] the input instructions
+      def input_instructions(new_input_instructions = nil)
+        return @input_instructions if new_input_instructions.nil?
+
+        @input_instructions = format_markdown(new_input_instructions)
       end
 
       # Define inputs

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -216,9 +216,8 @@ module Inferno
       # Set/Get a runnable's short title
       #
       # @param new_short_title [String]
-      # @return [String] short title, or title if no short title defined
+      # @return [String] the short title
       def short_title(new_short_title = nil)
-        return @title if new_short_title.nil? && @short_title.nil?
         return @short_title if new_short_title.nil?
 
         @short_title = new_short_title

--- a/spec/inferno/dsl/test_creation_spec.rb
+++ b/spec/inferno/dsl/test_creation_spec.rb
@@ -17,8 +17,11 @@ RSpec.describe InfrastructureTest::Suite do
 
       it 'contains correct metadata' do
         expect(suite.id).to eq('infra_test')
-        expect(suite.title).to eq('Infrastructure Test')
-        expect(suite.description).to start_with('An internal test suite')
+        expect(suite.title).to eq('Infrastructure Test Suite')
+        expect(suite.short_title).to eq('Infrastructure')
+        expect(suite.description).to start_with('An internal test suite to verify that inferno infrastructure works')
+        expect(suite.short_description).to start_with('Internal test suite')
+        expect(suite.input_instructions).to eq('Instructions for inputs')
       end
 
       it 'contains the correct inputs' do
@@ -73,7 +76,10 @@ RSpec.describe InfrastructureTest::Suite do
       end
 
       it 'contains the correct metadata' do
-        expect(outer_inline_group.title).to eq('Outer inline group')
+        expect(outer_inline_group.title).to eq('Outer inline group title')
+        expect(outer_inline_group.short_title).to eq('Outer inline group short title')
+        expect(outer_inline_group.description).to eq('Outer inline group for testing description')
+        expect(outer_inline_group.short_description).to eq('Outer inline group short description')
         expect(outer_inline_group.id).to eq("#{suite.id}-outer_inline_group")
       end
 
@@ -119,6 +125,7 @@ RSpec.describe InfrastructureTest::Suite do
 
       it 'contains the correct metadata' do
         expect(inner_inline_group.title).to eq('Inner inline group')
+        expect(inner_inline_group.short_title).to eq('Inner inline group')
         expect(inner_inline_group.id).to eq("#{suite.id}-outer_inline_group-inner_inline_group")
       end
 
@@ -169,6 +176,9 @@ RSpec.describe InfrastructureTest::Suite do
 
       it 'contains the correct metadata' do
         expect(inline_test1.title).to eq('Inline test 1')
+        expect(inline_test1.short_title).to eq('Inline test 1')
+        expect(inline_test1.description).to eq('Inline test 1 full description')
+        expect(inline_test1.short_description).to eq('Inline test 1 short description')
         expect(inline_test1.id).to eq("#{suite.id}-outer_inline_group-inner_inline_group-inline_test_1")
       end
 

--- a/spec/inferno/dsl/test_creation_spec.rb
+++ b/spec/inferno/dsl/test_creation_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe InfrastructureTest::Suite do
 
       it 'contains the correct metadata' do
         expect(inner_inline_group.title).to eq('Inner inline group')
-        expect(inner_inline_group.short_title).to eq('Inner inline group')
+        expect(inner_inline_group.short_title).to eq('Inner inline group short title')
         expect(inner_inline_group.id).to eq("#{suite.id}-outer_inline_group-inner_inline_group")
       end
 

--- a/spec/inferno/web/serializers/test_group_spec.rb
+++ b/spec/inferno/web/serializers/test_group_spec.rb
@@ -5,13 +5,17 @@ RSpec.describe Inferno::Web::Serializers::TestGroup do
   it 'serializes a group' do
     serialized_group = JSON.parse(described_class.render(group))
 
-    expected_keys = ['id', 'description', 'inputs', 'outputs', 'title', 'test_count', 'test_groups', 'tests',
-                     'run_as_group', 'user_runnable', 'optional']
+    expected_keys = ['id', 'description', 'inputs', 'outputs', 'title',
+                     'test_count', 'test_groups', 'tests', 'run_as_group', 'user_runnable',
+                     'optional', 'short_title', 'short_description', 'input_instructions']
 
     expect(serialized_group.keys).to match_array(expected_keys)
     expect(serialized_group['id']).to eq(group.id.to_s)
     expect(serialized_group['title']).to eq(group.title)
+    expect(serialized_group['short_title']).to eq(group.short_title)
     expect(serialized_group['description']).to eq(group.description)
+    expect(serialized_group['short_description']).to eq(group.short_description)
+    expect(serialized_group['input_instructions']).to eq(group.input_instructions)
     expect(serialized_group['inputs'].length).to eq(group.inputs.length)
     expect(serialized_group['outputs'].length).to eq(group.outputs.length)
     expect(serialized_group['test_count']).to eq(group.tests.length)

--- a/spec/inferno/web/serializers/test_spec.rb
+++ b/spec/inferno/web/serializers/test_spec.rb
@@ -4,12 +4,17 @@ RSpec.describe Inferno::Web::Serializers::Test do
   it 'serializes a test' do
     serialized_test = JSON.parse(described_class.render(test))
 
-    expected_keys = ['id', 'description', 'inputs', 'outputs', 'title', 'user_runnable', 'optional']
+    expected_keys = ['id', 'description', 'inputs', 'outputs', 'title',
+                     'user_runnable', 'optional', 'short_description', 'short_title',
+                     'input_instructions']
 
     expect(serialized_test.keys).to match_array(expected_keys)
     expect(serialized_test['id']).to eq(test.id.to_s)
     expect(serialized_test['title']).to eq(test.title)
+    expect(serialized_test['short_title']).to eq(test.short_title)
     expect(serialized_test['description']).to eq(test.description)
+    expect(serialized_test['short_description']).to eq(test.short_description)
+    expect(serialized_test['input_instructions']).to eq(test.input_instructions)
     expect(serialized_test['inputs'].length).to eq(test.inputs.length)
     expect(serialized_test['outputs'].length).to eq(test.outputs.length)
 


### PR DESCRIPTION
Adds `input_instructions`, `short_title`, and `short description`.  Areas where this shows up in the legacy program interface in screenshots below.  Note that `short_title` wouldn't be in the top progress area because we do not have that in inferno-core, but it is still useful to have this option for our nav menus on the left / and potentially if we use breadcrumbs.

All are optional.  ~~`short_title `is used in place of `title `in some places.  If a `short_title` doesn't exist, `title` is used instead.  If `short_description` doesn't exist, the area would be blank in the interface, as `description` may be *very* long. It may be a little strange that these two similar concepts behave differently, but I modeled it after our legacy implementation for now.~~  Update: now there is no special behavior on the back end if `short_title` is not defined.  The UI can decide what to do if `short_title` does not exist.

I updated the ruby backend and swagger.  I did not incorporate this into the front end, as that is mixed in with another visual update I"m working on now.

<img width="996" alt="Screen Shot 2022-01-24 at 10 40 27 PM" src="https://user-images.githubusercontent.com/412901/150906952-efc1b157-4ff5-4aac-924c-9c44687d8233.png">
<img width="835" alt="Screen Shot 2022-01-24 at 10 41 31 PM" src="https://user-images.githubusercontent.com/412901/150906954-e8be893c-1ca7-4555-afc1-742d5192209b.png">
