### PR TITLE
Add ability to cancel test runs.

### DIFF
--- a/client/src/api/TestRunsApi.ts
+++ b/client/src/api/TestRunsApi.ts
@@ -48,6 +48,14 @@ export function postTestRun(
     });
 }
 
+export function deleteTestRun(testRunId: string): void {
+  const endpoint = getEndpoint(`/test_runs/${testRunId}`);
+  fetch(endpoint, { method: 'DELETE' }).catch((e) => {
+    console.log(e);
+    return null;
+  });
+}
+
 export function getTestRunWithResults(
   testRunId: string,
   time: string | null | undefined

--- a/client/src/components/ActionModal/ActionModal.tsx
+++ b/client/src/components/ActionModal/ActionModal.tsx
@@ -12,10 +12,10 @@ import ReactMarkdown from 'react-markdown';
 export interface ActionModalProps {
   modalVisible: boolean;
   message?: string;
-  cancelTest: () => void;
+  cancelTestRun: () => void;
 }
 
-const ActionModal: FC<ActionModalProps> = ({ modalVisible, message, cancelTest }) => {
+const ActionModal: FC<ActionModalProps> = ({ modalVisible, message, cancelTestRun }) => {
   return (
     <Dialog open={modalVisible} fullWidth maxWidth="sm">
       <DialogTitle>User Action Required</DialogTitle>
@@ -25,7 +25,7 @@ const ActionModal: FC<ActionModalProps> = ({ modalVisible, message, cancelTest }
         </DialogContentText>
       </DialogContent>
       <DialogActions>
-        <Button color="primary" onClick={cancelTest} data-testid="cancel-button">
+        <Button color="primary" onClick={cancelTestRun} data-testid="cancel-button">
           Cancel
         </Button>
       </DialogActions>

--- a/client/src/components/TestSuite/TestRunProgressBar/TestRunProgressBar.tsx
+++ b/client/src/components/TestSuite/TestRunProgressBar/TestRunProgressBar.tsx
@@ -42,6 +42,12 @@ const StatusIndicator = (status: string | null | undefined) => {
           <CircularProgress size={24} />
         </Tooltip>
       );
+    case 'cancelling':
+      return (
+        <Tooltip title="Cancelling">
+          <CircularProgress size={24} />
+        </Tooltip>
+      );
     case 'waiting':
       return (
         <Tooltip title="Waiting">
@@ -52,12 +58,6 @@ const StatusIndicator = (status: string | null | undefined) => {
       return (
         <Tooltip title="Queued">
           <QueueIcon color="primary" />
-        </Tooltip>
-      );
-    case 'cancelling':
-      return (
-        <Tooltip title="Cancelling">
-          <CancelIcon color="primary" />
         </Tooltip>
       );
     case 'done':
@@ -116,8 +116,12 @@ const TestRunProgressBar: FC<TestRunProgressBarProps> = ({
         <Box mr={1} mt={0.3}>
           {statusIndicator}
         </Box>
-        <Box minWidth={200} mr={1}>
-          <StyledProgressBar variant="determinate" value={value} />
+        <Box minWidth={200} mr={1} color="background.paper">
+          {testRun?.status == 'cancelling' ? (
+            <Typography variant="body1">Cancelling Test Run...</Typography>
+          ) : (
+            <StyledProgressBar variant="determinate" value={value} />
+          )}
         </Box>
         <Box color="background.paper">
           <Typography variant="body1">

--- a/client/src/components/TestSuite/TestRunProgressBar/TestRunProgressBar.tsx
+++ b/client/src/components/TestSuite/TestRunProgressBar/TestRunProgressBar.tsx
@@ -60,12 +60,6 @@ const StatusIndicator = (status: string | null | undefined) => {
           <CancelIcon color="primary" />
         </Tooltip>
       );
-    case 'cancelled':
-      return (
-        <Tooltip title="Cancelled">
-          <CancelIcon color="primary" />
-        </Tooltip>
-      );
     case 'done':
       return (
         <Tooltip title="Done">
@@ -101,9 +95,7 @@ const TestRunProgressBar: FC<TestRunProgressBarProps> = ({
   const value = testCount !== 0 ? (100 * completedCount) / testCount : 0;
 
   const cancellable = () => {
-    return (
-      testRun?.status != 'cancelling' && testRun?.status != 'done' && testRun?.status != 'cancelled'
-    );
+    return testRun?.status != 'cancelling' && testRun?.status != 'done';
   };
 
   return (

--- a/client/src/components/TestSuite/TestRunProgressBar/TestRunProgressBar.tsx
+++ b/client/src/components/TestSuite/TestRunProgressBar/TestRunProgressBar.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 import { TestRun, Result } from 'models/testSuiteModels';
 import {
   Box,
+  IconButton,
   CircularProgress,
   LinearProgress,
   Snackbar,
@@ -9,6 +10,7 @@ import {
   Typography,
 } from '@mui/material';
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
+import CancelIcon from '@mui/icons-material/Cancel';
 import DoneIcon from '@mui/icons-material/Done';
 import QueueIcon from '@mui/icons-material/Queue';
 import withStyles from '@mui/styles/withStyles';
@@ -16,6 +18,7 @@ import withStyles from '@mui/styles/withStyles';
 export interface TestRunProgressBarProps {
   showProgressBar: boolean;
   setShowProgressBar: (show: boolean) => void;
+  cancelTestRun: () => void;
   duration: number | null;
   testRun: TestRun | null;
   resultsMap: Map<string, Result>;
@@ -51,6 +54,18 @@ const StatusIndicator = (status: string | null | undefined) => {
           <QueueIcon color="primary" />
         </Tooltip>
       );
+    case 'cancelling':
+      return (
+        <Tooltip title="Cancelling">
+          <CancelIcon color="primary" />
+        </Tooltip>
+      );
+    case 'cancelled':
+      return (
+        <Tooltip title="Cancelled">
+          <CancelIcon color="primary" />
+        </Tooltip>
+      );
     case 'done':
       return (
         <Tooltip title="Done">
@@ -75,6 +90,7 @@ const completedTestCount = (resultsMap: Map<string, Result>, testRun: TestRun | 
 const TestRunProgressBar: FC<TestRunProgressBarProps> = ({
   showProgressBar,
   setShowProgressBar,
+  cancelTestRun,
   duration,
   testRun,
   resultsMap,
@@ -83,6 +99,12 @@ const TestRunProgressBar: FC<TestRunProgressBarProps> = ({
   const testCount = testRun?.test_count || 0;
   const completedCount = completedTestCount(resultsMap, testRun);
   const value = testCount !== 0 ? (100 * completedCount) / testCount : 0;
+
+  const cancellable = () => {
+    return (
+      testRun?.status != 'cancelling' && testRun?.status != 'done' && testRun?.status != 'cancelled'
+    );
+  };
 
   return (
     <Snackbar
@@ -110,6 +132,16 @@ const TestRunProgressBar: FC<TestRunProgressBarProps> = ({
             {completedCount}/{testCount}
           </Typography>
         </Box>
+        <Tooltip title="Cancel Test Run">
+          <IconButton
+            aria-label="cancel"
+            disabled={!cancellable()}
+            color="secondary"
+            onClick={cancelTestRun}
+          >
+            <CancelIcon />
+          </IconButton>
+        </Tooltip>
       </Box>
     </Snackbar>
   );

--- a/client/src/components/TestSuite/TestSession.tsx
+++ b/client/src/components/TestSuite/TestSession.tsx
@@ -19,7 +19,7 @@ import TestSuiteTreeComponent from './TestSuiteTree/TestSuiteTree';
 import TestSuiteDetailsPanel from './TestSuiteDetails/TestSuiteDetailsPanel';
 import { getAllContainedInputs } from './TestSuiteUtilities';
 import { useLocation } from 'react-router-dom';
-import { getTestRunWithResults, postTestRun } from 'api/TestRunsApi';
+import { deleteTestRun, getTestRunWithResults, postTestRun } from 'api/TestRunsApi';
 import { Drawer, Toolbar, Box } from '@mui/material';
 
 function mapRunnableRecursive(
@@ -239,7 +239,9 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
   }
 
   function testRunNeedsProgressBar(testRun: TestRun | null): boolean {
-    return testRun?.status ? ['running', 'queued', 'waiting'].includes(testRun?.status) : false;
+    return testRun?.status
+      ? ['running', 'queued', 'waiting', 'cancelling'].includes(testRun?.status)
+      : false;
   }
 
   function testRunProgressBar() {
@@ -248,6 +250,9 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
       <TestRunProgressBar
         showProgressBar={showProgressBar}
         setShowProgressBar={setShowProgressBar}
+        cancelTestRun={() => {
+          testRun && deleteTestRun(testRun.id);
+        }}
         duration={duration}
         testRun={testRun}
         resultsMap={resultsMap}
@@ -287,7 +292,9 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
           inputs={inputs}
         />
         <ActionModal
-          cancelTest={() => alert('TODO: CANCEL TEST')}
+          cancelTestRun={() => {
+            testRun && deleteTestRun(testRun.id);
+          }}
           message={waitingTestId ? resultsMap.get(waitingTestId)?.result_message : ''}
           modalVisible={waitingTestId != null}
         />

--- a/client/src/components/TestSuite/TestSuiteDetails/ResultIcon.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/ResultIcon.tsx
@@ -66,6 +66,15 @@ const ResultIcon: FC<ResultIconProps> = ({ result }) => {
             <AccessTimeIcon data-testid={`${result.id}-${result.result}`} />
           </Tooltip>
         );
+      case 'cancel':
+        return (
+          <Tooltip title="cancelled">
+            <CancelIcon
+              style={{ color: result.optional ? grey[500] : red[500] }}
+              data-testid={`${result.id}-${result.result}`}
+            />
+          </Tooltip>
+        );
       default:
         return <Fragment />;
     }

--- a/client/src/components/TestSuite/TestSuiteDetails/ResultIcon.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/ResultIcon.tsx
@@ -68,7 +68,7 @@ const ResultIcon: FC<ResultIconProps> = ({ result }) => {
         );
       case 'cancel':
         return (
-          <Tooltip title="cancelled">
+          <Tooltip title="cancel">
             <CancelIcon
               style={{ color: result.optional ? grey[500] : red[500] }}
               data-testid={`${result.id}-${result.result}`}

--- a/client/src/components/TestSuite/TestSuiteTree/CondensedResultIcon.tsx
+++ b/client/src/components/TestSuite/TestSuiteTree/CondensedResultIcon.tsx
@@ -37,6 +37,19 @@ const CondensedResultIcon: FC<CondensedResultIconProps> = ({ result }) => {
             />
           </Tooltip>
         );
+      case 'cancel':
+        return (
+          <Tooltip title="cancel">
+            <FiberManualRecordIcon
+              style={{
+                color: result.optional ? grey[500] : red[500],
+                width: '0.5em',
+                height: '0.5em',
+              }}
+              data-testid={`${result.id}-${result.result}`}
+            />
+          </Tooltip>
+        );
       case 'skip':
         return (
           <Tooltip title="skipped">

--- a/client/src/models/testSuiteModels.ts
+++ b/client/src/models/testSuiteModels.ts
@@ -115,7 +115,7 @@ export interface TestRun {
   id: string;
   inputs?: TestInput[] | null;
   results?: Result[] | null;
-  status?: 'queued' | 'running' | 'waiting' | 'done';
+  status?: 'queued' | 'running' | 'waiting' | 'done' | 'cancelling' | 'cancelled';
   test_count?: number;
   test_group_id?: string;
   test_suite_id?: string;

--- a/client/src/models/testSuiteModels.ts
+++ b/client/src/models/testSuiteModels.ts
@@ -115,7 +115,7 @@ export interface TestRun {
   id: string;
   inputs?: TestInput[] | null;
   results?: Result[] | null;
-  status?: 'queued' | 'running' | 'waiting' | 'done' | 'cancelling' | 'cancelled';
+  status?: 'queued' | 'running' | 'waiting' | 'cancelling' | 'done';
   test_count?: number;
   test_group_id?: string;
   test_suite_id?: string;

--- a/dev_suites/dev_demo_ig_stu1/demo_suite.rb
+++ b/dev_suites/dev_demo_ig_stu1/demo_suite.rb
@@ -177,6 +177,29 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
     end
 
     group do
+      id 'easily_cancelled_test'
+      title 'Tests that should be easily cancelled'
+
+      test do
+        title 'Pass Test'
+        run { pass }
+      end
+
+      test do
+        title 'Pausing test'
+        input :cancel_pause_time, default: '30'
+
+        run { sleep(cancel_pause_time.to_i) }
+      end
+
+      test do
+        title 'Test after pause that would pass'
+
+        run { pass }
+      end
+    end
+
+    group do
       id 'run_as_group_examples'
       title 'Run as Group Examples'
 

--- a/lib/inferno/apps/web/controllers/test_runs/destroy.rb
+++ b/lib/inferno/apps/web/controllers/test_runs/destroy.rb
@@ -11,8 +11,8 @@ module Inferno
           def call(params)
             test_run = test_runs_repo.find(params[:id])
 
-            if test_run.nil? || ['cancelled', 'cancelling'].include?(test_run.status)
-              # If it doesn't exist or it is already cancelled then just restate that
+            if test_run.nil? || ['done', 'cancelling'].include?(test_run.status)
+              # If it doesn't exist, already finished, or currently being cancelled
               self.status = 204
               return
             end

--- a/lib/inferno/apps/web/controllers/test_runs/destroy.rb
+++ b/lib/inferno/apps/web/controllers/test_runs/destroy.rb
@@ -1,0 +1,39 @@
+module Inferno
+  module Web
+    module Controllers
+      module TestRuns
+        class Destroy < Controller
+          include Import[
+                    test_runs_repo: 'repositories.test_runs',
+                    results_repo: 'repositories.results'
+                  ]
+
+          def call(params)
+            test_run = test_runs_repo.find(params[:id])
+
+            if test_run.nil? || ['cancelled', 'cancelling'].include?(test_run.status)
+              # If it doesn't exist or it is already cancelled then just restate that
+              self.status = 204
+              return
+            end
+
+            test_run_is_waiting = (test_run.status == 'waiting')
+            test_runs_repo.mark_as_cancelling(params[:id])
+
+            if test_run_is_waiting
+              waiting_result = results_repo.find_waiting_result(test_run_id: test_run.id)
+              results_repo.cancel_waiting_result(waiting_result.id, 'Test cancelled by user')
+              Jobs.perform(Jobs::ResumeTestRun, test_run.id)
+            end
+
+            self.status = 204
+          rescue StandardError => e
+            Application['logger'].error(e.full_message)
+            self.body = { errors: e.message }.to_json
+            self.status = 500
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/inferno/apps/web/router.rb
+++ b/lib/inferno/apps/web/router.rb
@@ -7,7 +7,7 @@ module Inferno
 
     Router = Hanami::Router.new(namespace: Inferno::Web::Controllers) do
       namespace 'api' do
-        resources 'test_runs', only: [:create, :show] do
+        resources 'test_runs', only: [:create, :show, :destroy] do
           resources 'results', only: [:index]
         end
 

--- a/lib/inferno/entities/test_run.rb
+++ b/lib/inferno/entities/test_run.rb
@@ -32,7 +32,7 @@ module Inferno
     #   @return [String, nil] identfier for a waiting `TestRun`
     # @!attribute wait_timeout
     class TestRun < Entity
-      STATUS_OPTIONS = ['queued', 'running', 'waiting', 'done'].freeze
+      STATUS_OPTIONS = ['queued', 'running', 'waiting', 'done', 'cancelling', 'cancelled'].freeze
       ATTRIBUTES = [
         :id,
         :test_session_id,

--- a/lib/inferno/entities/test_run.rb
+++ b/lib/inferno/entities/test_run.rb
@@ -32,7 +32,7 @@ module Inferno
     #   @return [String, nil] identfier for a waiting `TestRun`
     # @!attribute wait_timeout
     class TestRun < Entity
-      STATUS_OPTIONS = ['queued', 'running', 'waiting', 'done', 'cancelling', 'cancelled'].freeze
+      STATUS_OPTIONS = ['queued', 'running', 'waiting', 'cancelling', 'done'].freeze
       ATTRIBUTES = [
         :id,
         :test_session_id,

--- a/lib/inferno/repositories/results.rb
+++ b/lib/inferno/repositories/results.rb
@@ -140,6 +140,10 @@ module Inferno
         update(result_id, result: 'pass', result_message: message)
       end
 
+      def cancel_waiting_result(result_id, message = nil)
+        update(result_id, result: 'cancel', result_message: message)
+      end
+
       def json_serializer_options
         {
           include: {

--- a/lib/inferno/repositories/test_runs.rb
+++ b/lib/inferno/repositories/test_runs.rb
@@ -91,6 +91,14 @@ module Inferno
         )
       end
 
+      def mark_as_cancelling(test_run_id)
+        update(test_run_id, status: 'cancelling')
+      end
+
+      def mark_as_cancelled(test_run_id)
+        update(test_run_id, status: 'cancelled')
+      end
+
       class Model < Sequel::Model(db)
         include ValidateRunnableReference
 
@@ -119,7 +127,7 @@ module Inferno
       def active_test_run_for_session?(test_session_id)
         self.class::Model
           .where(test_session_id: test_session_id)
-          .exclude(status: 'done')
+          .exclude(status: ['done', 'cancelled'])
           .count.positive?
       end
     end

--- a/lib/inferno/repositories/test_runs.rb
+++ b/lib/inferno/repositories/test_runs.rb
@@ -95,10 +95,6 @@ module Inferno
         update(test_run_id, status: 'cancelling')
       end
 
-      def mark_as_cancelled(test_run_id)
-        update(test_run_id, status: 'cancelled')
-      end
-
       class Model < Sequel::Model(db)
         include ValidateRunnableReference
 
@@ -127,7 +123,7 @@ module Inferno
       def active_test_run_for_session?(test_session_id)
         self.class::Model
           .where(test_session_id: test_session_id)
-          .exclude(status: ['done', 'cancelled'])
+          .exclude(status: 'done')
           .count.positive?
       end
     end

--- a/lib/inferno/repositories/test_runs.rb
+++ b/lib/inferno/repositories/test_runs.rb
@@ -65,6 +65,10 @@ module Inferno
         build_entity(test_run_hash)
       end
 
+      def status_for_test_run(id)
+        self.class::Model.where(id: id).get(:status)
+      end
+
       def mark_as_running(test_run_id)
         update(test_run_id, status: 'running')
       end

--- a/lib/inferno/test_runner.rb
+++ b/lib/inferno/test_runner.rb
@@ -39,11 +39,7 @@ module Inferno
 
       run(test_run.runnable)
 
-      if test_run_current_status == 'cancelling'
-        test_runs_repo.mark_as_cancelled(test_run.id)
-      elsif run_results.values.none?(&:waiting?)
-        test_runs_repo.mark_as_done(test_run.id)
-      end
+      test_runs_repo.mark_as_done(test_run.id) unless run_results.values.any?(&:waiting?)
 
       run_results.values
     end

--- a/lib/inferno/test_runner.rb
+++ b/lib/inferno/test_runner.rb
@@ -29,9 +29,9 @@ module Inferno
       @session_data_repo ||= Repositories::SessionData.new
     end
 
-    def test_run_current_status
-      # forces db refetch of the test run status in case it has been changed to cancelled
-      test_runs_repo.find(test_run.id).status
+    def test_run_is_cancelling
+      # forces db refetch of the test run status in case it is being cancelled
+      test_runs_repo.status_for_test_run(test_run.id) == 'cancelling'
     end
 
     def start
@@ -65,7 +65,7 @@ module Inferno
       test_instance = test.new(inputs: inputs, test_session_id: test_session.id, scratch: scratch)
 
       result = begin
-        raise Exceptions::CancelException, 'Test cancelled by user' if test_run_current_status == 'cancelling'
+        raise Exceptions::CancelException, 'Test cancelled by user' if test_run_is_cancelling
 
         test_instance.load_named_requests
         test_instance.instance_eval(&test.block)

--- a/spec/requests/test_runs_spec.rb
+++ b/spec/requests/test_runs_spec.rb
@@ -124,6 +124,14 @@ RSpec.describe '/test_runs' do
     end
   end
 
+  describe 'destroy' do
+    it 'returns 204 when deleted' do
+      delete router.path(:api_test_run, id: test_run.id)
+
+      expect(last_response.status).to eq(204)
+    end
+  end
+
   describe '/:id/results' do
     let(:result) { repo_create(:result, message_count: 2) }
     let(:messages) { result.messages }


### PR DESCRIPTION
Note: I haven't added any unit tests for this functionality yet, but that is probably appropriate.

![Screen Shot 2022-01-29 at 12 04 02 AM](https://user-images.githubusercontent.com/412901/151648167-62a51dd3-b9d7-42ec-a90f-18157b598be5.png)

Note when reviewing: I believe the most critical use case for this for g10 is to get people unstuck from 'waiting' status.  If the case of cancelling any arbitrary tests that are running isn't quite perfect from a user experience, I don't think that is a huge deal at this point.

Functionally, when a test is 'cancelled', the test run is set to a 'cancelling' status. The test runner will finish the currently running test as normal, but then all of the rest of the tests will get a 'cancel' result.  And when completed, the test run will get changed to 'cancelled' status.

For tests in a 'wait' status, cancelling will start a new job, set the waiting test to 'cancel' result instead of 'pass', and then act in the same manner as regular cancellation.

Right now, I have the UI still show the test run as active when in the 'cancelling' status (but not yet 'cancelled').  This best reflects reality because there no way to kill the test that is currently in the process of being run, but also may be a little confusing.  We could have the UI pretend that 'cancelling' is essentially 'cancelled', and then maybe throw out results of the test that was currently running when the test run was cancelled.  But I feel like what we have here is probably good enough for now.

I set the 'cancel' icon to be the same as 'fail' for now.  I think that's what we do in legacy.

In the Demo suite, try out the 'Tests that should be easily cancelled' test (it will pause for X seconds), and the Wait test.

