### PR TITLE
remove required label from radio button

### DIFF
--- a/client/src/components/InputsModal/InputsRadioGroup.tsx
+++ b/client/src/components/InputsModal/InputsRadioGroup.tsx
@@ -1,3 +1,4 @@
+import React, { FC, Fragment } from 'react';
 import {
   FormControl,
   FormControlLabel,
@@ -8,7 +9,6 @@ import {
 } from '@mui/material';
 import LockIcon from '@mui/icons-material/Lock';
 import { TestInput } from 'models/testSuiteModels';
-import React, { FC, Fragment } from 'react';
 import useStyles from './styles';
 
 export interface InputRadioGroupProps {
@@ -25,18 +25,21 @@ const InputRadioGroup: FC<InputRadioGroupProps> = ({
   setInputsMap,
 }) => {
   const styles = useStyles();
+  const firstValue =
+    requirement.options?.list_options && requirement.options?.list_options?.length > 0
+      ? requirement.options?.list_options[0]?.value
+      : '';
   const [value, setValue] = React.useState(
-    inputsMap.get(requirement.name) || requirement.default || ''
+    inputsMap.get(requirement.name) || requirement.default || firstValue
   );
+
   const fieldLabelText = requirement.title || requirement.name;
   const lockedIcon = requirement.locked && (
     <LockIcon fontSize="small" className={styles.lockedIcon} />
   );
-  const requiredLabel = !requirement.optional && !requirement.locked ? ' (required)' : '';
   const fieldLabel = (
     <Fragment>
       {fieldLabelText}
-      {requiredLabel}
       {lockedIcon}
     </Fragment>
   );
@@ -53,7 +56,6 @@ const InputRadioGroup: FC<InputRadioGroupProps> = ({
       <FormControl
         component="fieldset"
         id={`requirement${index}_input`}
-        required={!requirement.optional && !requirement.locked}
         disabled={requirement.locked}
         fullWidth
       >

--- a/client/src/components/TestSuite/TestSession.tsx
+++ b/client/src/components/TestSuite/TestSession.tsx
@@ -93,7 +93,7 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
   useEffect(() => {
     const allInputs = getAllContainedInputs(test_suite.test_groups as TestGroup[]);
     allInputs.forEach((input: TestInput) => {
-      const defaultValue = input.default ? input.default : '';
+      const defaultValue = input.default || '';
       sessionData.set(input.name, defaultValue);
     });
     initialSessionData?.forEach((initialSessionData: TestOutput) => {

--- a/dev_suites/dev_demo_ig_stu1/groups/demo_group.rb
+++ b/dev_suites/dev_demo_ig_stu1/groups/demo_group.rb
@@ -254,7 +254,6 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
             title: 'Radio Group Input Example',
             type: 'radio',
             optional: false,
-            default: 'value1',
             options: {
               list_options: [
                 {


### PR DESCRIPTION
Removes the required label from radio button inputs and defaults selection to the first option value.