### PR TITLE
FI-1392: Apply config updates to children

### DIFF
--- a/lib/inferno/dsl/configurable.rb
+++ b/lib/inferno/dsl/configurable.rb
@@ -13,6 +13,10 @@ module Inferno
         return @config if new_configuration.blank?
 
         @config.apply(new_configuration)
+
+        children.each { |child| child.config(new_configuration) }
+
+        @config
       end
 
       # @private

--- a/spec/inferno/dsl/configurable_spec.rb
+++ b/spec/inferno/dsl/configurable_spec.rb
@@ -1,5 +1,9 @@
 class ConfigurableTestClass
   extend Inferno::DSL::Configurable
+
+  def self.children
+    @children ||= []
+  end
 end
 
 RSpec.describe Inferno::DSL::Configurable do


### PR DESCRIPTION
This update is needed for the other SMART launches in the g10 suite (https://github.com/inferno-framework/g10-certification-test-kit/pull/11).

When a child is added to a group/suite, it inherits its parent's configuration. However, later updates to a parent's configuration were not being propagated down to its children, and this PR addresses that.