### PR TITLE
FI-1438: Fix missing input issue

### DIFF
--- a/dev_suites/dev_demo_ig_stu1/demo_suite.rb
+++ b/dev_suites/dev_demo_ig_stu1/demo_suite.rb
@@ -256,5 +256,34 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
         end
       end
     end
+
+    group do
+      title 'missing_inputs group'
+      description %(
+        This group demonstrates a bug with missing inputs. If the bug is fixed,
+        you should be able to run this group with no problems. If the bug is
+        present, you will get a 422 when attempting to run this group.
+      )
+      input :url1
+
+      test do
+        title 'TEST 1'
+        output :url2
+
+        run do
+          output url2: 'abc'
+        end
+      end
+
+      test do
+        title 'TEST 2'
+        input :url1, name: :url2
+
+        run do
+          info url1
+          pass
+        end
+      end
+    end
   end
 end

--- a/lib/inferno/apps/web/controllers/test_runs/create.rb
+++ b/lib/inferno/apps/web/controllers/test_runs/create.rb
@@ -21,6 +21,8 @@ module Inferno
               return
             end
 
+            # TODO: This test run shouldn't be created until after the inputs
+            # and runnable are validated
             test_run = repo.create(create_params(params).merge(status: 'queued'))
             missing_inputs = test_run.runnable.missing_inputs(params[:inputs])
 

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -456,12 +456,13 @@ module Inferno
 
       # @private
       def required_inputs(prior_outputs = [])
-        required_inputs = inputs.select do |input|
-          !input_definitions[input][:optional] && !prior_outputs.include?(input)
-        end
-        required_inputs.map! { |input_identifier| input_definitions[input_identifier][:name] }
+        required_inputs =
+          inputs
+            .reject { |input| input_definitions[input][:optional] }
+            .map { |input| config.input_name(input) }
+            .reject { |input| prior_outputs.include?(input) }
         children_required_inputs = children.flat_map { |child| child.required_inputs(prior_outputs) }
-        prior_outputs.concat(outputs)
+        prior_outputs.concat(outputs.map { |output| config.output_name(output) })
         (required_inputs + children_required_inputs).flatten.uniq
       end
 

--- a/spec/inferno/dsl/runnable_spec.rb
+++ b/spec/inferno/dsl/runnable_spec.rb
@@ -159,6 +159,21 @@ RSpec.describe Inferno::DSL::Runnable do
       missing_inputs = example_test_group.missing_inputs([{ name: 'b', value: 'b' }])
       expect(missing_inputs).to eq(['a'])
     end
+
+    it 'handles renamed inputs' do
+      example_test_group = Class.new(Inferno::Entities::TestGroup)
+      example_test_group.input :url1
+      example_test_group.test 'child test' do
+        output :url2
+      end
+      example_test_group.test 'child test with output' do
+        input :url1, name: :url2
+      end
+
+      missing_inputs = example_test_group.missing_inputs([{ name: 'url1', value: 'xyz' }])
+
+      expect(missing_inputs).to eq([])
+    end
   end
 
   describe '.user_runnable?' do


### PR DESCRIPTION
There was a bug with `missing_inputs` not properly handling renamed inputs. When checking whether an input was supplied by a prior output, the input's original name, rather than it's new name was being used. For instance:

```ruby
input :abcd, name: :defg
```

would check prior outputs for an output `abcd` when it should be checking for a prior output named `defg`.