### PR TITLE
Improve test sidebar

### DIFF
--- a/client/src/components/TestSuite/TestSuiteTree/CondensedResultIcon.tsx
+++ b/client/src/components/TestSuite/TestSuiteTree/CondensedResultIcon.tsx
@@ -1,6 +1,7 @@
-import React, { FC, Fragment } from 'react';
+import React, { FC } from 'react';
 import { Result } from 'models/testSuiteModels';
 import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord';
+import TripOriginIcon from '@mui/icons-material/TripOrigin';
 import { Tooltip } from '@mui/material';
 import { red, orange, green, purple, grey } from '@mui/material/colors';
 
@@ -9,87 +10,91 @@ export interface CondensedResultIconProps {
 }
 
 const CondensedResultIcon: FC<CondensedResultIconProps> = ({ result }) => {
-  if (result) {
-    switch (result.result) {
-      case 'pass':
-        return (
-          <Tooltip title="passed">
-            <FiberManualRecordIcon
-              style={{
-                color: result.optional ? green[100] : green[500],
-                width: '0.5em',
-                height: '0.5em',
-              }}
-              data-testid={`${result.id}-${result.result}`}
-            />
-          </Tooltip>
-        );
-      case 'fail':
-        return (
-          <Tooltip title="failed">
-            <FiberManualRecordIcon
-              style={{
-                color: result.optional ? grey[500] : red[500],
-                width: '0.5em',
-                height: '0.5em',
-              }}
-              data-testid={`${result.id}-${result.result}`}
-            />
-          </Tooltip>
-        );
-      case 'cancel':
-        return (
-          <Tooltip title="cancel">
-            <FiberManualRecordIcon
-              style={{
-                color: result.optional ? grey[500] : red[500],
-                width: '0.5em',
-                height: '0.5em',
-              }}
-              data-testid={`${result.id}-${result.result}`}
-            />
-          </Tooltip>
-        );
-      case 'skip':
-        return (
-          <Tooltip title="skipped">
-            <FiberManualRecordIcon
-              style={{
-                color: result.optional ? grey[500] : orange[800],
-                width: '0.5em',
-                height: '0.5em',
-              }}
-              data-testid={`${result.id}-${result.result}`}
-            />
-          </Tooltip>
-        );
-      case 'omit':
-        return (
-          <Tooltip title="omitted">
-            <FiberManualRecordIcon
-              style={{ width: '0.5em', height: '0.5em' }}
-              data-testid={`${result.id}-${result.result}`}
-            />
-          </Tooltip>
-        );
-      case 'error':
-        return (
-          <Tooltip title="error">
-            <FiberManualRecordIcon
-              style={{
-                color: result.optional ? grey[500] : purple[500],
-                width: '0.5em',
-                height: '0.5em',
-              }}
-              data-testid={`${result.id}-${result.result}`}
-            />
-          </Tooltip>
-        );
-      default:
-        return <Fragment />;
-    }
-  } else {
-    return <Fragment />;
+  switch (result?.result) {
+    case 'pass':
+      return (
+        <Tooltip title="passed">
+          <FiberManualRecordIcon
+            style={{
+              color: result.optional ? green[100] : green[500],
+              width: '.75em',
+              height: '.75em',
+            }}
+            data-testid={`${result.id}-${result.result}`}
+          />
+        </Tooltip>
+      );
+    case 'fail':
+      return (
+        <Tooltip title="failed">
+          <FiberManualRecordIcon
+            style={{
+              color: result.optional ? grey[500] : red[500],
+              width: '0.75em',
+              height: '0.75em',
+            }}
+            data-testid={`${result.id}-${result.result}`}
+          />
+        </Tooltip>
+      );
+    case 'cancel':
+      return (
+        <Tooltip title="cancel">
+          <FiberManualRecordIcon
+            style={{
+              color: result.optional ? grey[500] : red[500],
+              width: '0.75em',
+              height: '0.75em',
+            }}
+            data-testid={`${result.id}-${result.result}`}
+          />
+        </Tooltip>
+      );
+    case 'skip':
+      return (
+        <Tooltip title="skipped">
+          <FiberManualRecordIcon
+            style={{
+              color: result.optional ? grey[500] : orange[800],
+              width: '0.75em',
+              height: '0.75em',
+            }}
+            data-testid={`${result.id}-${result.result}`}
+          />
+        </Tooltip>
+      );
+    case 'omit':
+      return (
+        <Tooltip title="omitted">
+          <FiberManualRecordIcon
+            style={{ width: '0.75em', height: '0.75em' }}
+            data-testid={`${result.id}-${result.result}`}
+          />
+        </Tooltip>
+      );
+    case 'error':
+      return (
+        <Tooltip title="error">
+          <FiberManualRecordIcon
+            style={{
+              color: result.optional ? grey[500] : purple[500],
+              width: '0.75em',
+              height: '0.75em',
+            }}
+            data-testid={`${result.id}-${result.result}`}
+          />
+        </Tooltip>
+      );
+    default:
+      return (
+        <TripOriginIcon
+          style={{
+            color: grey[500],
+            width: '0.6em',
+            height: '0.6em',
+          }}
+        />
+      );
   }
 };
 

--- a/client/src/components/TestSuite/TestSuiteTree/TestGroupTreeItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteTree/TestGroupTreeItem.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 import { TestGroup, RunnableType } from 'models/testSuiteModels';
 import CustomTreeItem from '../../_common/TreeItem';
 import TreeItemLabel from './TreeItemLabel';
+import CondensedResultIcon from './CondensedResultIcon';
 
 export interface TestGroupTreeItemProps {
   testGroup: TestGroup;
@@ -15,7 +16,7 @@ const TestGroupTreeItem: FC<TestGroupTreeItemProps> = ({
   testRunInProgress,
 }) => {
   let sublist: JSX.Element[] = [];
-  if (testGroup.test_groups.length > 0) {
+  if (testGroup.test_groups.length > 0 && !testGroup.run_as_group) {
     sublist = testGroup.test_groups.map((subTestGroup, index) => (
       <TestGroupTreeItem
         testGroup={subTestGroup}
@@ -30,6 +31,7 @@ const TestGroupTreeItem: FC<TestGroupTreeItemProps> = ({
     <CustomTreeItem
       nodeId={testGroup.id}
       label={<TreeItemLabel runnable={testGroup} />}
+      icon={testGroup.run_as_group ? <CondensedResultIcon result={testGroup.result} /> : null}
       // eslint-disable-next-line max-len
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
       ContentProps={{ testId: testGroup.id } as any}

--- a/client/src/components/TestSuite/TestSuiteTree/TestGroupTreeItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteTree/TestGroupTreeItem.tsx
@@ -27,11 +27,16 @@ const TestGroupTreeItem: FC<TestGroupTreeItemProps> = ({
     ));
   }
 
+  const itemIcon =
+    testGroup.run_as_group || testGroup.test_groups.length === 0 ? (
+      <CondensedResultIcon result={testGroup.result} />
+    ) : null;
+
   return (
     <CustomTreeItem
       nodeId={testGroup.id}
       label={<TreeItemLabel runnable={testGroup} />}
-      icon={testGroup.run_as_group ? <CondensedResultIcon result={testGroup.result} /> : null}
+      icon={itemIcon}
       // eslint-disable-next-line max-len
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
       ContentProps={{ testId: testGroup.id } as any}

--- a/client/src/components/TestSuite/TestSuiteTree/TestSuiteTree.tsx
+++ b/client/src/components/TestSuite/TestSuiteTree/TestSuiteTree.tsx
@@ -1,9 +1,10 @@
 import React, { FC } from 'react';
 import { TestSuite, TestGroup, RunnableType } from 'models/testSuiteModels';
-import { CardContent, Box } from '@mui/material';
+import { Box } from '@mui/material';
 import useStyles from './styles';
 import TreeView from '@mui/lab/TreeView';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ListAltIcon from '@mui/icons-material/ListAlt';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import CustomTreeItem from '../../_common/TreeItem';
 import TestGroupTreeItem from './TestGroupTreeItem';
@@ -57,26 +58,25 @@ const TestSuiteTreeComponent: FC<TestSuiteTreeProps> = ({
 
     return (
       <Box className={styles.testSuiteTreePanel}>
-        <CardContent>
-          <TreeView
-            defaultCollapseIcon={<ExpandMoreIcon />}
-            defaultExpandIcon={<ChevronRightIcon />}
-            onNodeToggle={nodeToggle}
-            expanded={expanded}
-            selected={selectedRunnable}
+        <TreeView
+          defaultCollapseIcon={<ExpandMoreIcon />}
+          defaultExpandIcon={<ChevronRightIcon />}
+          onNodeToggle={nodeToggle}
+          expanded={expanded}
+          selected={selectedRunnable}
+        >
+          <CustomTreeItem
+            classes={{ content: styles.treeRoot }}
+            nodeId={testSuite.id}
+            label={<TreeItemLabel runnable={testSuite} />}
+            icon={<ListAltIcon />}
+            // eslint-disable-next-line max-len
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+            ContentProps={{ testId: testSuite.id } as any}
           >
-            <CustomTreeItem
-              classes={{ content: styles.treeRoot }}
-              nodeId={testSuite.id}
-              label={<TreeItemLabel runnable={testSuite} />}
-              // eslint-disable-next-line max-len
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
-              ContentProps={{ testId: testSuite.id } as any}
-            >
-              {testGroupList}
-            </CustomTreeItem>
-          </TreeView>
-        </CardContent>
+            {testGroupList}
+          </CustomTreeItem>
+        </TreeView>
       </Box>
     );
   } else {

--- a/client/src/components/TestSuite/TestSuiteTree/TreeItemLabel.tsx
+++ b/client/src/components/TestSuite/TestSuiteTree/TreeItemLabel.tsx
@@ -2,7 +2,6 @@ import React, { FC } from 'react';
 import { TestGroup, TestSuite } from 'models/testSuiteModels';
 import { Typography, Box } from '@mui/material';
 import useStyles from './styles';
-import CondensedResultIcon from './CondensedResultIcon';
 
 export interface TreeItemLabelProps {
   runnable: TestSuite | TestGroup;
@@ -22,7 +21,6 @@ const TreeItemLabel: FC<TreeItemLabelProps> = ({ runnable }) => {
           </Typography>
         )}
       </Box>
-      <CondensedResultIcon result={runnable.result} />
     </Box>
   );
 };

--- a/client/src/components/TestSuite/TestSuiteTree/styles.tsx
+++ b/client/src/components/TestSuite/TestSuiteTree/styles.tsx
@@ -36,15 +36,15 @@ export default makeStyles((theme: Theme) => ({
     marginRight: '5px',
   },
   testSuiteTreePanel: {
-    width: '400px',
+    width: '300px',
     overflowX: 'hidden',
+    marginLeft: '-10px',
   },
   treeRoot: {
     '& $labelText': {
-      fontWeight: 600,
+      textTransform: 'uppercase',
+      fontWeight: 'bold',
     },
-    '& .MuiTreeItem-iconContainer': {
-      display: 'none',
-    },
+    paddingLeft: '25px !important',
   },
 }));

--- a/client/src/components/TestSuite/styles.tsx
+++ b/client/src/components/TestSuite/styles.tsx
@@ -12,7 +12,7 @@ export default makeStyles((theme: Theme) => ({
   },
   drawer: {
     flexShrink: 0,
-    width: '400px',
+    width: '300px',
   },
   testSuiteMain: {
     display: 'flex',

--- a/client/src/components/_common/TreeItem.tsx
+++ b/client/src/components/_common/TreeItem.tsx
@@ -81,10 +81,15 @@ const CustomTreeItem = styled((props: TreeItemProps) => (
   <TreeItem ContentComponent={CustomContent} {...props} />
 ))(() => ({
   [`& .${treeItemClasses.selected}`]: {
-    backgroundColor: 'rgba(248, 139, 48, 0.42) !important',
+    backgroundColor: 'rgba(248, 139, 48, 0.1) !important',
   },
   [`& .${treeItemClasses.content}`]: {
     width: 'auto',
+    paddingLeft: '25px',
+  },
+  [`& .${treeItemClasses.group}`]: {
+    marginLeft: '0px',
+    paddingLeft: '10px',
   },
 }));
 

--- a/client/src/components/_common/TreeItem.tsx
+++ b/client/src/components/_common/TreeItem.tsx
@@ -81,7 +81,7 @@ const CustomTreeItem = styled((props: TreeItemProps) => (
   <TreeItem ContentComponent={CustomContent} {...props} />
 ))(() => ({
   [`& .${treeItemClasses.selected}`]: {
-    backgroundColor: 'rgba(248, 139, 48, 0.1) !important',
+    backgroundColor: 'rgba(248, 139, 48, 0.2) !important',
   },
   [`& .${treeItemClasses.content}`]: {
     width: 'auto',

--- a/dev_suites/ui_onc_program/additional_tests/onc_standalone_public_launch.rb
+++ b/dev_suites/ui_onc_program/additional_tests/onc_standalone_public_launch.rb
@@ -1,6 +1,7 @@
 module ONCProgram
   class ONCStandalonePublicLaunch < Inferno::TestGroup
     title 'Public Client Standalone Launch with OpenID Connect'
+    short_title 'Public Client Launch'
     description <<~DESCRIPTION
       Register Inferno as a public client with patient access and execute standalone launch.
     DESCRIPTION

--- a/dev_suites/ui_onc_program/additional_tests/onc_visual_inspection.rb
+++ b/dev_suites/ui_onc_program/additional_tests/onc_visual_inspection.rb
@@ -1,6 +1,6 @@
 module ONCProgram
   class ONCVisualInspection < Inferno::TestGroup
-    title 'Visual Inspection and Attestation'
+    title 'Visual Inspection'
     description <<~DESCRIPTION
       Verify conformance to portions of the test procedure that are not automated.
     DESCRIPTION

--- a/dev_suites/ui_onc_program/additional_tests/smart_invalid_aud.rb
+++ b/dev_suites/ui_onc_program/additional_tests/smart_invalid_aud.rb
@@ -1,6 +1,7 @@
 module ONCProgram
   class SMARTInvalidAUD < Inferno::TestGroup
     title 'SMART App Launch Error: Invalid AUD Parameter'
+    short_title 'Invalid Aud SMART Launch'
     description <<~DESCRIPTION
       # Background
 

--- a/dev_suites/ui_onc_program/additional_tests/smart_invalid_launch.rb
+++ b/dev_suites/ui_onc_program/additional_tests/smart_invalid_launch.rb
@@ -1,6 +1,7 @@
 module ONCProgram
   class SMARTInvalidLaunch < Inferno::TestGroup
     title 'SMART App Launch Error: Invalid Launch Parameter'
+    short_title 'Invalid SMART Parameter'
     description <<~DESCRIPTION
       # Background
 


### PR DESCRIPTION
The CSS is a little wonky here to make it line up in a way that I liked.  We can circle back and clean all that up though using standard units.  The biggest things are the removing the ability to drill into 'run_as_group' tests on the left bar, moving the status icon to the left, and putting in a placeholder 'not yet run' icon there too.  As long as you think this generally moves things forward I'd like to get this in by tomorrow.

BEFORE: 
![Screen Shot 2022-02-08 at 10 10 01 AM](https://user-images.githubusercontent.com/412901/153015487-a5abe90f-441f-4e34-a72e-f7a35d8ac7e5.png)

AFTER:
![Screen Shot 2022-02-08 at 10 01 52 AM](https://user-images.githubusercontent.com/412901/153013969-fbce70e9-a367-4b20-9a02-333387b5c29a.png)
