### PR TITLE
Add new session button.

### DIFF
--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -1,8 +1,9 @@
 import React, { FC } from 'react';
 import useStyles from './styles';
 import icon from 'images/inferno_icon.png';
-import { AppBar, Box, Container, Typography } from '@mui/material';
+import { AppBar, Box, Button, Container, Typography } from '@mui/material';
 import { useHistory } from 'react-router-dom';
+import NoteAddIcon from '@mui/icons-material/NoteAdd';
 
 export interface HeaderProps {
   suiteTitle?: string;
@@ -16,7 +17,9 @@ const Header: FC<HeaderProps> = ({ suiteTitle }) => {
     history.push('/');
   };
 
-  return (
+  return !suiteTitle ? (
+    <></>
+  ) : (
     <AppBar position="sticky" color="default" className={styles.appbar}>
       <Container>
         <Box display="flex" justifyContent="center">
@@ -27,8 +30,20 @@ const Header: FC<HeaderProps> = ({ suiteTitle }) => {
             onClick={returnHome}
           />
           <Typography variant="h6" component="div">
-            {suiteTitle || 'Inferno'}
+            {suiteTitle}
           </Typography>
+        </Box>
+        <Box>
+          <Button
+            color="secondary"
+            onClick={returnHome}
+            sx={{ marginTop: '10px' }}
+            variant="outlined"
+            disableElevation
+            startIcon={<NoteAddIcon />}
+          >
+            New Session
+          </Button>
         </Box>
       </Container>
     </AppBar>

--- a/client/src/components/Header/__tests__/Header.test.tsx
+++ b/client/src/components/Header/__tests__/Header.test.tsx
@@ -6,7 +6,7 @@ import Header from '../Header';
 test('renders Inferno Header', () => {
   render(
     <ThemeProvider>
-      <Header />
+      <Header suiteTitle="Suite Title" />
     </ThemeProvider>
   );
 

--- a/client/src/components/TestSuite/TestRunButton/TestRunButton.tsx
+++ b/client/src/components/TestSuite/TestRunButton/TestRunButton.tsx
@@ -31,7 +31,7 @@ const TestRunButton: FC<TestRunButtonProps> = ({
           <Button
             variant="contained"
             disabled={testRunInProgress}
-            color="primary"
+            color="secondary"
             disableElevation
             onClick={() => {
               runTests(runnableType, runnable.id);

--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
@@ -43,7 +43,7 @@ const TestGroupCard: FC<TestGroupCardProps> = ({
           testRunInProgress={testRunInProgress}
         />
       </div>
-      <Box margin="20px">{description}</Box>
+      {description && <Box margin="20px">{description}</Box>}
       <List className={styles.testGroupCardList}>{children}</List>
     </Card>
   );


### PR DESCRIPTION
I just added a 'New Session' button on the top right to make it obvious how to get out of this interface.  This doesn't look great, and should probably be more generic if there is more than one suite loaded, but I think its good to favor obvious functionality right now.

<img width="1122" alt="Screen Shot 2022-02-08 at 3 10 50 PM" src="https://user-images.githubusercontent.com/412901/153067929-ad75d783-7049-4e76-a61e-a425f5b16889.png">
