### PR TITLE
Make input instructions render in markdown.

### DIFF
--- a/client/src/components/InputsModal/InputsModal.tsx
+++ b/client/src/components/InputsModal/InputsModal.tsx
@@ -10,6 +10,7 @@ import {
 import { OAuthCredentials, RunnableType, TestInput } from 'models/testSuiteModels';
 import React, { FC, useEffect } from 'react';
 import InputRadioGroup from './InputsRadioGroup';
+import ReactMarkdown from 'react-markdown';
 import InputTextArea from './InputTextArea';
 import InputTextField from './InputTextField';
 import InputOAuthCredentials from './InputOAuthCredentials';
@@ -134,7 +135,9 @@ const InputsModal: FC<InputsModalProps> = ({
     <Dialog open={modalVisible} onClose={hideModal} fullWidth maxWidth="sm">
       <DialogTitle>{title}</DialogTitle>
       <DialogContent>
-        <DialogContentText>{instructions}</DialogContentText>
+        <DialogContentText>
+          <ReactMarkdown>{instructions}</ReactMarkdown>
+        </DialogContentText>
         <List>{inputFields}</List>
       </DialogContent>
       <DialogActions>

--- a/dev_suites/dev_infrastructure_test/infrastructure_test.rb
+++ b/dev_suites/dev_infrastructure_test/infrastructure_test.rb
@@ -9,7 +9,12 @@ module InfrastructureTest
     short_title 'Infrastructure'
     description 'An internal test suite to verify that inferno infrastructure works'
     short_description 'Internal test suite'
-    input_instructions 'Instructions for inputs'
+    input_instructions %(
+      Instructions for inputs
+      * Bulletted List
+      * Here
+      `code here`
+    )
 
     input :suite_input
     output :suite_output

--- a/spec/inferno/dsl/test_creation_spec.rb
+++ b/spec/inferno/dsl/test_creation_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe InfrastructureTest::Suite do
         expect(suite.short_title).to eq('Infrastructure')
         expect(suite.description).to start_with('An internal test suite to verify that inferno infrastructure works')
         expect(suite.short_description).to start_with('Internal test suite')
-        expect(suite.input_instructions).to eq('Instructions for inputs')
+        expect(suite.input_instructions).to include('Instructions for inputs')
       end
 
       it 'contains the correct inputs' do


### PR DESCRIPTION

<img width="819" alt="Screen Shot 2022-02-08 at 5 03 49 PM" src="https://user-images.githubusercontent.com/412901/153083525-8647972d-3f3c-44fc-b9b2-4c6494f09fed.png">

Just renders the input instuctions using markdown because it helpful to have richtext when we need to describe things like required launch URIs.

The one mildly annoying thing is that now by default an extra `<p>` gets put in so the instructions are a bit more padded than necessary.  We can adjust how markdown is rendered in the future.