### PR TITLE
FI-1419: Make individual tests runnable

### DIFF
--- a/client/src/components/TestSuite/TestRunButton/TestRunButton.tsx
+++ b/client/src/components/TestSuite/TestRunButton/TestRunButton.tsx
@@ -11,6 +11,7 @@ import {
 
 export interface TestRunButtonProps {
   runnable: TestSuite | TestGroup | Test;
+  runnableType: RunnableType;
   runTests: (runnableType: RunnableType, runnableId: string) => void;
   testRunInProgress: boolean;
   buttonText?: string;
@@ -19,10 +20,10 @@ export interface TestRunButtonProps {
 const TestRunButton: FC<TestRunButtonProps> = ({
   runTests,
   runnable,
+  runnableType,
   testRunInProgress,
   buttonText,
 }) => {
-  const runnableType = 'tests' in runnable ? RunnableType.TestGroup : RunnableType.TestSuite;
   const showRunButton = runnableIsTestSuite(runnable) || (runnable as TestGroup).user_runnable;
   const runButton = showRunButton ? (
     <Tooltip title={testRunInProgress ? 'Disabled - Ongoing Test.' : ''} arrow>

--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
@@ -63,6 +63,8 @@ const TestGroupCard: FC<TestGroupCardProps> = ({
     <></>
   );
 
+  const runnableType = 'tests' in runnable ? RunnableType.TestGroup : RunnableType.TestSuite;
+
   return (
     <Card className={styles.testGroupCard} variant="outlined">
       <div className={styles.testGroupCardHeader}>
@@ -76,6 +78,7 @@ const TestGroupCard: FC<TestGroupCardProps> = ({
           <TestRunButton
             buttonText={buttonText}
             runnable={runnable}
+            runnableType={runnableType}
             runTests={runTests}
             testRunInProgress={testRunInProgress}
           />

--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupListItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupListItem.tsx
@@ -37,6 +37,7 @@ const TestGroupListItem: FC<TestGroupListItemProps> = ({
       <div className={styles.testIcon}>{<ResultIcon result={testGroup.result} />}</div>
       <TestRunButton
         runnable={testGroup}
+        runnableType={RunnableType.TestGroup}
         runTests={runTests}
         testRunInProgress={testRunInProgress}
       />

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
@@ -112,6 +112,7 @@ const TestListItem: FC<TestListItemProps> = ({
           {requestsBadge}
           <TestRunButton
             runnable={test}
+            runnableType={RunnableType.Test}
             runTests={runTests}
             testRunInProgress={testRunInProgress}
           />


### PR DESCRIPTION
Fix a bug which prevented running individual tests from the UI. The `TestRunButton` had faulty logic which made it think that tests were test suites.