### PR TITLE
FI-1445: Retry db connections

### DIFF
--- a/.env
+++ b/.env
@@ -15,3 +15,9 @@ VALIDATOR_URL=https://inferno.healthit.gov/validatorapi
 # Set to true to display the entire request/response body for each incoming HTTP
 # request in the logs.
 # VERBOSE_REQUEST_LOGGING=true
+
+# Set the maximum number of times inferno will try to connect to the database when
+# it starts, and the delay in seconds between retries. These are the default
+# values.
+# MAX_DB_CONNECTION_ATTEMPTS=10
+# DB_CONNECTION_RETRY_DELAY=5

--- a/lib/inferno/config/boot/db.rb
+++ b/lib/inferno/config/boot/db.rb
@@ -11,7 +11,22 @@ Inferno::Application.boot(:db) do
     config_path = File.expand_path('database.yml', File.join(Dir.pwd, 'config'))
     config = YAML.load_file(config_path)[ENV['APP_ENV']]
       .merge(logger: Inferno::Application['logger'])
-    connection = Sequel.connect(config)
+    connection_attempts_remaining = ENV.fetch('MAX_DB_CONNECTION_ATTEMPTS', '10').to_i
+    connection_retry_delay = ENV.fetch('DB_CONNECTION_RETRY_DELAY', '5').to_i
+    connection = nil
+      loop do
+        connection = Sequel.connect(config)
+        break
+      rescue StandardError => e
+        connection_attempts_remaining -= 1
+        if connection_attempts_remaining.positive?
+          Inferno::Application['logger'].error("Unable to connect to database: #{e.message}")
+          Inferno::Application['logger'].error("#{connection_attempts_remaining} connection attempts remaining.")
+          sleep connection_retry_delay
+          next
+        end
+        raise
+      end
     connection.sql_log_level = :debug
 
     register('db.config', config)

--- a/lib/inferno/config/boot/db.rb
+++ b/lib/inferno/config/boot/db.rb
@@ -14,19 +14,19 @@ Inferno::Application.boot(:db) do
     connection_attempts_remaining = ENV.fetch('MAX_DB_CONNECTION_ATTEMPTS', '10').to_i
     connection_retry_delay = ENV.fetch('DB_CONNECTION_RETRY_DELAY', '5').to_i
     connection = nil
-      loop do
-        connection = Sequel.connect(config)
-        break
-      rescue StandardError => e
-        connection_attempts_remaining -= 1
-        if connection_attempts_remaining.positive?
-          Inferno::Application['logger'].error("Unable to connect to database: #{e.message}")
-          Inferno::Application['logger'].error("#{connection_attempts_remaining} connection attempts remaining.")
-          sleep connection_retry_delay
-          next
-        end
-        raise
+    loop do
+      connection = Sequel.connect(config)
+      break
+    rescue StandardError => e
+      connection_attempts_remaining -= 1
+      if connection_attempts_remaining.positive?
+        Inferno::Application['logger'].error("Unable to connect to database: #{e.message}")
+        Inferno::Application['logger'].error("#{connection_attempts_remaining} connection attempts remaining.")
+        sleep connection_retry_delay
+        next
       end
+      raise
+    end
     connection.sql_log_level = :debug
 
     register('db.config', config)


### PR DESCRIPTION
This branch makes inferno retry connecting to the database when a connection fails. This is needed to more easily support a database like postgres which may not have finished starting up when inferno tries to connect.

**NOTE:** Only the first commit is part of this PR (the changes to `db.rb` and `.env`). The other commit is there so that this functionality can be more easily tested.

To test, run:
```
docker-compose build
docker-compose run inferno bundle exec rake db:migrate
docker-compose up
```
When running `docker-compose up` you may see messages about not yet being able connect to the database, but it should retry and succeed eventually.