### PR TITLE
Add version to TestSuite

### DIFF
--- a/dev_suites/dev_infrastructure_test/infrastructure_test.rb
+++ b/dev_suites/dev_infrastructure_test/infrastructure_test.rb
@@ -15,6 +15,7 @@ module InfrastructureTest
       * Here
       `code here`
     )
+    version '42.0'
 
     input :suite_input
     output :suite_output

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -430,18 +430,18 @@ definitions:
         items:
           type: "object"
           properties:
-            name: 
+            name:
               type: "string"
-            value: 
+            value:
               type: "string"
       response_headers:
         type: "array"
         items:
           type: "object"
           properties:
-            name: 
+            name:
               type: "string"
-            value: 
+            value:
               type: "string"
       request_body:
         type: "string"
@@ -487,6 +487,8 @@ definitions:
       test_count:
         type: "number"
         readOnly: true
+      version:
+        type: "string"
   TestGroup:
     type: "object"
     required:

--- a/lib/inferno/apps/web/serializers/test_suite.rb
+++ b/lib/inferno/apps/web/serializers/test_suite.rb
@@ -10,6 +10,7 @@ module Inferno
           field :short_description
           field :input_instructions
           field :test_count
+          field :version
         end
 
         view :full do

--- a/lib/inferno/entities/test_suite.rb
+++ b/lib/inferno/entities/test_suite.rb
@@ -54,6 +54,12 @@ module Inferno
           }
         end
 
+        def version(version = nil)
+          return @version if version.nil?
+
+          @version = version
+        end
+
         def find_validator(validator_name)
           validator = fhir_validators[validator_name]
 

--- a/spec/inferno/entities/test_suite_spec.rb
+++ b/spec/inferno/entities/test_suite_spec.rb
@@ -84,4 +84,17 @@ RSpec.describe Inferno::Entities::TestSuite do
       expect(suite_class.default_group.tests).to eq([test_class])
     end
   end
+
+  describe '.version' do
+    let!(:example_test_suite_class) { Class.new(described_class) }
+
+    let(:test_suite) do
+      example_test_suite_class.version 'VERSION'
+      example_test_suite_class
+    end
+
+    specify 'it gets/sets the version' do
+      expect(test_suite.version).to eq('VERSION')
+    end
+  end
 end


### PR DESCRIPTION
So users can have something to reference when communicating an issue or request.