### PR TITLE
FI-1443: Add ability to check configuration for test suites

### DIFF
--- a/client/src/components/TestSuite/TestSuiteDetails/TestSuiteDetailsPanel.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestSuiteDetailsPanel.tsx
@@ -3,6 +3,7 @@ import { TestGroup, RunnableType, TestSuite, Request, Test } from 'models/testSu
 import TestGroupListItem from './TestGroupListItem';
 import TestListItem from './TestListItem/TestListItem';
 import TestGroupCard from './TestGroupCard';
+import TestSuiteMessages from './TestSuiteMessages';
 
 interface TestSuiteDetailsPanelProps {
   runnable: TestSuite | TestGroup;
@@ -43,10 +44,20 @@ const TestSuiteDetailsPanel: FC<TestSuiteDetailsPanelProps> = ({
     });
   }
 
+  const testSuiteMessages =
+    'configuration_messages' in runnable ? (
+      <TestSuiteMessages messages={runnable.configuration_messages || []} />
+    ) : (
+      <div></div>
+    );
+
   return (
-    <TestGroupCard runTests={runTests} runnable={runnable} testRunInProgress={testRunInProgresss}>
-      {listItems}
-    </TestGroupCard>
+    <div>
+      {testSuiteMessages}
+      <TestGroupCard runTests={runTests} runnable={runnable} testRunInProgress={testRunInProgresss}>
+        {listItems}
+      </TestGroupCard>
+    </div>
   );
 };
 

--- a/client/src/components/TestSuite/TestSuiteDetails/TestSuiteMessages.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestSuiteMessages.tsx
@@ -1,0 +1,31 @@
+import React, { FC } from 'react';
+import { Message } from 'models/testSuiteModels';
+import Alert from '@mui/material/Alert';
+
+interface TestSuiteMessagesProps {
+  messages: Message[];
+}
+
+const TestSuiteMessages: FC<TestSuiteMessagesProps> = ({ messages }) => {
+  if (messages.length == 0) {
+    return <div></div>;
+  }
+
+  const errorMessages = messages.filter((message) => message.type === 'error');
+  const warningMessages = messages.filter((message) => message.type === 'warning');
+  const infoMessages = messages.filter((message) => message.type === 'info');
+
+  const sortedMessages = [...errorMessages, ...warningMessages, ...infoMessages];
+
+  const alerts = sortedMessages.map((message) => {
+    return (
+      <Alert variant="filled" severity={message.type}>
+        {message.message}
+      </Alert>
+    );
+  });
+
+  return <div>{alerts}</div>;
+};
+
+export default TestSuiteMessages;

--- a/client/src/models/testSuiteModels.ts
+++ b/client/src/models/testSuiteModels.ts
@@ -1,6 +1,6 @@
 export type Message = {
   message: string;
-  type: string;
+  type: 'error' | 'warning' | 'info';
 };
 
 export type RequestHeader = {
@@ -108,6 +108,7 @@ export interface TestSuite {
   test_groups?: TestGroup[];
   optional?: boolean;
   input_instructions?: string;
+  configuration_messages?: Message[];
 }
 
 export interface TestSession {

--- a/dev_suites/dev_demo_ig_stu1/demo_suite.rb
+++ b/dev_suites/dev_demo_ig_stu1/demo_suite.rb
@@ -24,6 +24,19 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
     # This is a little too simplistic, because we want groups to be able to
     # restrict params, map params, etc
 
+    check_configuration do
+      [
+        {
+          type: 'info',
+          message: 'This suite has a configuration info message'
+        },
+        {
+          type: 'warning',
+          message: 'This suite has a configuration warning message'
+        }
+      ]
+    end
+
     validator do
       url ENV.fetch('VALIDATOR_URL')
       exclude_message { |message| message.type == 'info' }

--- a/dev_suites/dev_infrastructure_test/infrastructure_test.rb
+++ b/dev_suites/dev_infrastructure_test/infrastructure_test.rb
@@ -20,6 +20,15 @@ module InfrastructureTest
     input :suite_input
     output :suite_output
 
+    check_configuration do
+      [
+        {
+          type: 'error',
+          message: 'This suite has a configuration error message'
+        }
+      ]
+    end
+
     def suite_helper
       'SUITE_HELPER'
     end

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -489,6 +489,10 @@ definitions:
         readOnly: true
       version:
         type: "string"
+      configuration_messages:
+        type: "array"
+        items:
+          $ref: "#/definitions/Message"
   TestGroup:
     type: "object"
     required:

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -59,6 +59,29 @@ paths:
             $ref: "#/definitions/TestSuite"
         "404":
           description: "Test suite not found"
+  /test_suites/{test_suite_id}/check_configuration:
+    put:
+      tags:
+      - "Test Suite"
+      summary: "Check the configuration for a test suite"
+      description: ""
+      produces:
+      - "application/json"
+      parameters:
+      - in: "path"
+        type: "string"
+        name: "test_suite_id"
+        description: "ID of the test suite"
+        required: true
+      responses:
+        "200":
+          description: "Success"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Message"
+        "404":
+          description: "Test suite not found"
   /test_sessions:
     post:
       tags:

--- a/lib/inferno/apps/web/controllers/test_suites/check_configuration.rb
+++ b/lib/inferno/apps/web/controllers/test_suites/check_configuration.rb
@@ -1,0 +1,17 @@
+module Inferno
+  module Web
+    module Controllers
+      module TestSuites
+        class CheckConfiguration < Controller
+          def call(params)
+            test_suite = repo.find(params[:id])
+            halt 404 if test_suite.nil?
+
+            self.body =
+              Inferno::Web::Serializers::Message.render(test_suite.configuration_messages(force_recheck: true))
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/inferno/apps/web/router.rb
+++ b/lib/inferno/apps/web/router.rb
@@ -21,6 +21,9 @@ module Inferno
               as: :last_test_run
 
           resources 'test_suites', only: [:index, :show]
+          put 'test_suites/:id/check_configuration',
+              to: Inferno::Web::Controllers::TestSuites::CheckConfiguration,
+              as: :check_configuration
 
           resources 'requests', only: [:show]
         end

--- a/lib/inferno/apps/web/serializers/test_suite.rb
+++ b/lib/inferno/apps/web/serializers/test_suite.rb
@@ -16,6 +16,7 @@ module Inferno
         view :full do
           include_view :summary
           association :groups, name: :test_groups, blueprint: TestGroup
+          field :configuration_messages
         end
       end
     end

--- a/lib/inferno/entities/test_suite.rb
+++ b/lib/inferno/entities/test_suite.rb
@@ -71,10 +71,15 @@ module Inferno
             Inferno::DSL::FHIRValidation::Validator.new { |v| v.url default_validator_url }
         end
 
-        def configuration_messages(new_messages = nil)
+        def configuration_messages(new_messages = nil, force_recheck: false)
           return @configuration_messages = new_messages unless new_messages.nil?
 
-          @configuration_messages ||= @check_configuration_block ? @check_configuration_block.call : []
+          @configuration_messages =
+            if force_recheck
+              @check_configuration_block ? @check_configuration_block.call : []
+            else
+              @configuration_messages || (@check_configuration_block ? @check_configuration_block.call : [])
+            end
         end
 
         # Provide a block which will verify any configuration needed for this

--- a/lib/inferno/entities/test_suite.rb
+++ b/lib/inferno/entities/test_suite.rb
@@ -80,8 +80,9 @@ module Inferno
         # Provide a block which will verify any configuration needed for this
         # test suite to operate properly.
         #
-        # @return Array<Hash> An array of hashes containing the keys `:type` and
-        # `:message`. Type options are `info`, `warning`, and `error`.
+        # @yieldreturn [Array<Hash>] An array of message hashes containing the
+        #   keys `:type` and `:message`. Type options are `info`, `warning`, and
+        #   `error`.
         def check_configuration(&block)
           @check_configuration_block = block
         end

--- a/lib/inferno/entities/test_suite.rb
+++ b/lib/inferno/entities/test_suite.rb
@@ -70,6 +70,21 @@ module Inferno
           fhir_validators[:default] =
             Inferno::DSL::FHIRValidation::Validator.new { |v| v.url default_validator_url }
         end
+
+        def configuration_messages(new_messages = nil)
+          return @configuration_messages = new_messages unless new_messages.nil?
+
+          @configuration_messages ||= @check_configuration_block ? @check_configuration_block.call : []
+        end
+
+        # Provide a block which will verify any configuration needed for this
+        # test suite to operate properly.
+        #
+        # @return Array<Hash> An array of hashes containing the keys `:type` and
+        # `:message`. Type options are `info`, `warning`, and `error`.
+        def check_configuration(&block)
+          @check_configuration_block = block
+        end
       end
     end
   end

--- a/spec/inferno/entities/test_suite_spec.rb
+++ b/spec/inferno/entities/test_suite_spec.rb
@@ -133,12 +133,30 @@ RSpec.describe Inferno::Entities::TestSuite do
 
       it 'returns the existing configuration_messages if they are truthy' do
         block = proc { messages }
-        allow(block).to receive(:call)
+        allow(block).to receive(:call).and_return(messages)
         suite_class.configuration_messages([])
         suite_class.check_configuration(&block)
 
         expect(suite_class.configuration_messages).to eq([])
         expect(block).to_not have_received(:call)
+      end
+    end
+
+    context 'when force_recheck is true' do
+      context 'when no check_configuration_block is present' do
+        it 'returns an empty array' do
+          expect(suite_class.configuration_messages(force_recheck: true)).to eq([])
+        end
+
+        it 'calls the existing configuration block even if messages are already present' do
+          block = proc { [] }
+          allow(block).to receive(:call).and_return([])
+          suite_class.configuration_messages(messages)
+          suite_class.check_configuration(&block)
+
+          expect(suite_class.configuration_messages(force_recheck: true)).to eq([])
+          expect(block).to have_received(:call)
+        end
       end
     end
   end

--- a/spec/inferno/web/serializers/test_suite_spec.rb
+++ b/spec/inferno/web/serializers/test_suite_spec.rb
@@ -1,0 +1,54 @@
+RSpec.describe Inferno::Web::Serializers::TestSuite do
+  let(:suite) { InfrastructureTest::Suite }
+  let(:summary_keys) do
+    [
+      'id',
+      'title',
+      'short_title',
+      'description',
+      'short_description',
+      'input_instructions',
+      'test_count',
+      'version'
+    ]
+  end
+  let(:full_keys) do
+    summary_keys + ['configuration_messages', 'test_groups']
+  end
+
+  it 'serializes a suite summary view' do
+    serialized_suite = JSON.parse(described_class.render(suite, view: :summary))
+
+    expect(serialized_suite.keys).to match_array(summary_keys)
+    expect(serialized_suite['id']).to eq(suite.id.to_s)
+    expect(serialized_suite['title']).to eq(suite.title)
+    expect(serialized_suite['short_title']).to eq(suite.short_title)
+    expect(serialized_suite['description']).to eq(suite.description)
+    expect(serialized_suite['short_description']).to eq(suite.short_description)
+    expect(serialized_suite['input_instructions']).to eq(suite.input_instructions)
+    expect(serialized_suite['test_count']).to eq(suite.test_count)
+    expect(serialized_suite['version']).to eq(suite.version)
+  end
+
+  it 'serializes a full suite view' do
+    serialized_suite = JSON.parse(described_class.render(suite, view: :full))
+    expected_messages = [
+      {
+        'type' => 'error',
+        'message' => 'This suite has a configuration error message'
+      }
+    ]
+
+    expect(serialized_suite.keys).to match_array(full_keys)
+    expect(serialized_suite['id']).to eq(suite.id.to_s)
+    expect(serialized_suite['title']).to eq(suite.title)
+    expect(serialized_suite['short_title']).to eq(suite.short_title)
+    expect(serialized_suite['description']).to eq(suite.description)
+    expect(serialized_suite['short_description']).to eq(suite.short_description)
+    expect(serialized_suite['input_instructions']).to eq(suite.input_instructions)
+    expect(serialized_suite['test_count']).to eq(suite.test_count)
+    expect(serialized_suite['version']).to eq(suite.version)
+    expect(serialized_suite['configuration_messages']).to eq(expected_messages)
+    expect(serialized_suite['test_groups'].length).to eq(suite.groups.length)
+  end
+end

--- a/spec/requests/test_suites_spec.rb
+++ b/spec/requests/test_suites_spec.rb
@@ -46,4 +46,33 @@ RSpec.describe '/test_suites' do
       end
     end
   end
+
+  describe 'check_configuration' do
+    context 'when the test_suite exists' do
+      let(:test_suite_id) { 'demo' }
+
+      it 'renders the test_suite json' do
+        put router.path(:check_configuration, id: test_suite_id)
+
+        expect(last_response.status).to eq(200)
+
+        message_keys = ['type', 'message']
+
+        expect(parsed_body).to be_an(Array)
+        parsed_body.each do |message_hash|
+          expect(message_hash.keys).to match_array(message_keys)
+        end
+      end
+    end
+
+    context 'when the test_suite does not exist' do
+      let(:test_suite_id) { SecureRandom.uuid }
+
+      it 'renders a 404' do
+        get router.path(:api_test_suite, id: test_suite_id)
+
+        expect(last_response.status).to eq(404)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This branch adds the ability to check configuration for a test suite, and add messages regarding the configuration. The UI for displaying these messages is very placeholder.

The demo suite has a warning and info message, and the infrastructure suite has an error message.