### PR TITLE
Add pg and redis dirs to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /data/*.db
+/data/pg
+/data/redis
 /db/*.db
 /lib/inferno/public/assets*
 /lib/inferno/public/*.js


### PR DESCRIPTION
We may have changed to now have core run using pg/redis during development?  They started showing up in my `git status` and figured it would be easier to just add them to the `.gitignore` (even if this was a more temporary config change that caused them to show up).