### PR TITLE
FI-1420: Support presets

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,7 @@
   "overrides": [{
     "files": ["**/*.test.tsx"],
     "rules": {
+      "@typescript-eslint/no-empty-function": ["off"],
       "@typescript-eslint/no-unsafe-assignment": ["off"],
       "@typescript-eslint/no-explicit-any": ["off"]
     }

--- a/client/src/api/TestSessionApi.ts
+++ b/client/src/api/TestSessionApi.ts
@@ -69,6 +69,20 @@ export function getTestSessionData(test_session_id: string): Promise<TestOutput[
     });
 }
 
+export function applyPreset(test_session_id: string, preset_id: string): Promise<null> {
+  const endpoint = getApiEndpoint(
+    `/test_sessions/${test_session_id}/session_data/apply_preset?preset_id=${preset_id}`
+  );
+
+  return fetch(endpoint, { method: 'PUT' }).then((response) => {
+    if (response.status === 200) {
+      return null;
+    }
+    // TODO: handle failures
+    return null;
+  });
+}
+
 /* Populate additional properties for API results */
 function addProperties(session: TestSession): TestSession {
   let groups = session.test_suite.test_groups;

--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -1,22 +1,61 @@
 import React, { FC } from 'react';
 import useStyles from './styles';
 import icon from 'images/inferno_icon.png';
-import { AppBar, Box, Button, Link, Toolbar, Typography } from '@mui/material';
+import { AppBar, Box, Button, Link, Stack, Toolbar, Typography } from '@mui/material';
 import { useHistory } from 'react-router-dom';
 import NoteAddIcon from '@mui/icons-material/NoteAdd';
 import { getStaticPath } from 'api/infernoApiService';
+import { PresetSummary } from 'models/testSuiteModels';
+import PresetsModal from 'components/PresetsModal/PresetsModal';
 
 export interface HeaderProps {
   suiteTitle?: string;
   suiteVersion?: string;
+  presets?: PresetSummary[];
+  testSessionId?: string;
+  getSessionData?: (testSessionId: string) => void;
 }
 
-const Header: FC<HeaderProps> = ({ suiteTitle, suiteVersion }) => {
+const Header: FC<HeaderProps> = ({
+  suiteTitle,
+  suiteVersion,
+  presets,
+  testSessionId,
+  getSessionData
+}) => {
   const styles = useStyles();
   const history = useHistory();
+  const [presetModalVisible, setPresetModalVisible] = React.useState(false);
 
   const returnHome = () => {
     history.push('/');
+  };
+
+  const presetButton = () => {
+    if (!presets || presets.length < 1 || !testSessionId || !getSessionData) {
+      return <></>;
+    } else {
+      return (
+        <Box>
+          <Button
+            color="secondary"
+            onClick={() => setPresetModalVisible(true)}
+            variant="outlined"
+            disableElevation
+            size="small"
+          >
+            Use predefined input
+          </Button>
+          <PresetsModal
+            modalVisible={presetModalVisible}
+            presets={presets}
+            testSessionId={testSessionId}
+            getSessionData={getSessionData}
+            setModalVisible={setPresetModalVisible}
+          />
+        </Box>
+      );
+    }
   };
 
   return suiteTitle ? (
@@ -37,7 +76,8 @@ const Header: FC<HeaderProps> = ({ suiteTitle, suiteVersion }) => {
             )}
           </Box>
         </Box>
-        <Box>
+        <Stack direction="row" spacing={2}>
+          {presetButton()}
           <Button
             color="secondary"
             onClick={returnHome}
@@ -48,7 +88,7 @@ const Header: FC<HeaderProps> = ({ suiteTitle, suiteVersion }) => {
           >
             New Session
           </Button>
-        </Box>
+        </Stack>
       </Toolbar>
     </AppBar>
   ) : (

--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -21,7 +21,7 @@ const Header: FC<HeaderProps> = ({
   suiteVersion,
   presets,
   testSessionId,
-  getSessionData
+  getSessionData,
 }) => {
   const styles = useStyles();
   const history = useHistory();

--- a/client/src/components/PresetsModal/PresetsModal.tsx
+++ b/client/src/components/PresetsModal/PresetsModal.tsx
@@ -1,0 +1,81 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  Select,
+  MenuItem,
+} from '@mui/material';
+import { applyPreset } from 'api/TestSessionApi';
+import { PresetSummary } from 'models/testSuiteModels';
+import React, { FC } from 'react';
+
+export interface PresetsModalProps {
+  modalVisible: boolean;
+  presets: PresetSummary[];
+  testSessionId: string;
+  getSessionData: (testSessionId: string) => void;
+  setModalVisible: (visible: boolean) => void;
+}
+
+const PresetsModal: FC<PresetsModalProps> = ({
+  modalVisible,
+  presets,
+  testSessionId,
+  getSessionData,
+  setModalVisible,
+}) => {
+  const null_preset_id = 'NULL_PRESET';
+  const [selectedPreset, setSelectedPreset] = React.useState(null_preset_id);
+
+  const applyPresetToSession = () => {
+    applyPreset(testSessionId, selectedPreset)
+      .then(() => {
+        getSessionData(testSessionId);
+      })
+      .catch((e) => console.log(e))
+      .finally(() => setModalVisible(false));
+  };
+
+  const presetOptions = [{ id: null_preset_id, title: 'None' }, ...presets].map((preset, index) => {
+    return (
+      <MenuItem value={preset.id} key={index}>
+        {preset.title}
+      </MenuItem>
+    );
+  });
+
+  return (
+    <Dialog open={modalVisible} fullWidth maxWidth="sm">
+      <DialogTitle>Select Preset Inputs</DialogTitle>
+      <DialogContent>
+        <FormControl>
+          <Select value={selectedPreset} onChange={(e) => setSelectedPreset(e.target.value)}>
+            {presetOptions}
+          </Select>
+        </FormControl>
+      </DialogContent>
+      <DialogActions>
+        <Button
+          color="primary"
+          onClick={applyPresetToSession}
+          data-testid="preset-apply-button"
+          disabled={selectedPreset === null_preset_id}
+        >
+          Apply
+        </Button>
+        <Button
+          color="primary"
+          onClick={() => setModalVisible(false)}
+          data-testid="preset-cancel-button"
+        >
+          Cancel
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default PresetsModal;

--- a/client/src/components/TestSuite/TestSession.tsx
+++ b/client/src/components/TestSuite/TestSession.tsx
@@ -68,14 +68,16 @@ export interface TestSessionComponentProps {
   testSession: TestSession;
   previousResults: Result[];
   initialTestRun: TestRun | null;
-  initialSessionData: TestOutput[] | undefined;
+  sessionData: Map<string, unknown>;
+  setSessionData: (data: Map<string, unknown>) => void;
 }
 
 const TestSessionComponent: FC<TestSessionComponentProps> = ({
   testSession,
   previousResults,
   initialTestRun,
-  initialSessionData,
+  sessionData,
+  setSessionData,
 }) => {
   const styles = useStyles();
   const { test_suite, id } = testSession;
@@ -88,19 +90,13 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
     resultsToMap(previousResults)
   );
   const [testRun, setTestRun] = React.useState<TestRun | null>(null);
-  const [sessionData, setSessionData] = React.useState<Map<string, unknown>>(new Map());
   const [showProgressBar, setShowProgressBar] = React.useState<boolean>(false);
 
   useEffect(() => {
     const allInputs = getAllContainedInputs(test_suite.test_groups as TestGroup[]);
     allInputs.forEach((input: TestInput) => {
       const defaultValue = input.default || '';
-      sessionData.set(input.name, defaultValue);
-    });
-    initialSessionData?.forEach((initialSessionData: TestOutput) => {
-      if (initialSessionData.value) {
-        sessionData.set(initialSessionData.name, initialSessionData.value);
-      }
+      sessionData.set(input.name, sessionData.get(input.name) || defaultValue);
     });
     setSessionData(new Map(sessionData));
   }, [testSession]);

--- a/client/src/components/TestSuite/TestSessionWrapper.tsx
+++ b/client/src/components/TestSuite/TestSessionWrapper.tsx
@@ -19,7 +19,7 @@ const TestSessionWrapper: FC<unknown> = () => {
   const [testRun, setTestRun] = React.useState<TestRun | null>(null);
   const [testSession, setTestSession] = React.useState<TestSession>();
   const [testResults, setTestResults] = React.useState<Result[]>();
-  const [sessionData, setSessionData] = React.useState<TestOutput[]>();
+  const [sessionData, setSessionData] = React.useState<Map<string, unknown>>(new Map());
   const [attemptedGetRun, setAttemptedGetRun] = React.useState(false);
   const [attemptedGetSession, setAttemptedGetSession] = React.useState(false);
   const [attemptedGetResults, setAttemptedGetResults] = React.useState(false);
@@ -80,7 +80,12 @@ const TestSessionWrapper: FC<unknown> = () => {
     getTestSessionData(testSessionId)
       .then((session_data) => {
         if (session_data) {
-          setSessionData(session_data);
+          session_data?.forEach((initialSessionData: TestOutput) => {
+            if (initialSessionData.value) {
+              sessionData.set(initialSessionData.name, initialSessionData.value);
+            }
+          });
+          setSessionData(new Map(sessionData));
         } else {
           console.log('failed to load session data');
         }
@@ -95,12 +100,16 @@ const TestSessionWrapper: FC<unknown> = () => {
         <Header
           suiteTitle={testSession.test_suite.title}
           suiteVersion={testSession.test_suite.version}
+          presets={testSession.test_suite.presets}
+          getSessionData={tryGetSessionData}
+          testSessionId={testSession.id}
         />
         <TestSessionComponent
           testSession={testSession}
           previousResults={testResults}
           initialTestRun={testRun}
-          initialSessionData={sessionData}
+          sessionData={sessionData}
+          setSessionData={setSessionData}
         />
         <Footer version={coreVersion} />
       </Box>

--- a/client/src/components/TestSuite/TestSuiteDetails/TestSuiteMessages.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestSuiteMessages.tsx
@@ -17,9 +17,9 @@ const TestSuiteMessages: FC<TestSuiteMessagesProps> = ({ messages }) => {
 
   const sortedMessages = [...errorMessages, ...warningMessages, ...infoMessages];
 
-  const alerts = sortedMessages.map((message) => {
+  const alerts = sortedMessages.map((message, index) => {
     return (
-      <Alert variant="filled" severity={message.type}>
+      <Alert variant="filled" key={index} severity={message.type}>
         {message.message}
       </Alert>
     );

--- a/client/src/components/TestSuite/__tests__/TestSession.test.tsx
+++ b/client/src/components/TestSuite/__tests__/TestSession.test.tsx
@@ -16,7 +16,8 @@ test('Test session renders', () => {
           testSession={mockedTestSession}
           previousResults={mockedResultsList}
           initialTestRun={null}
-          initialSessionData={undefined}
+          sessionData={new Map()}
+          setSessionData={() => {}}
         />
       </ThemeProvider>
     </Router>

--- a/client/src/models/testSuiteModels.ts
+++ b/client/src/models/testSuiteModels.ts
@@ -113,6 +113,7 @@ export interface TestSuite {
   input_instructions?: string;
   configuration_messages?: Message[];
   version?: string;
+  presets?: PresetSummary[];
 }
 
 export interface TestSession {
@@ -145,6 +146,11 @@ export interface OAuthCredentials {
   client_id?: string;
   client_secret?: string;
   token_url?: string;
+}
+
+export interface PresetSummary {
+  id: string;
+  title: string;
 }
 
 export function runnableIsTestSuite(runnable: TestSuite | TestGroup | Test): runnable is TestSuite {

--- a/config/presets/demo_preset.json
+++ b/config/presets/demo_preset.json
@@ -1,0 +1,88 @@
+{
+  "title": "Preset for Demonstration Suite",
+  "id": "demo_preset",
+  "test_suite_id": "demo",
+  "inputs": [
+    {
+      "name": "url",
+      "type": "text",
+      "title": "URL",
+      "description": "Insert url of FHIR server",
+      "value": "https://inferno.healthit.gov/reference-server/r4"
+    },
+    {
+      "name": "patient_id",
+      "type": "text",
+      "title": "Patient ID",
+      "value": "85"
+    },
+    {
+      "name": "bearer_token",
+      "type": "text",
+      "optional": true,
+      "value": "SAMPLE_TOKEN"
+    },
+    {
+      "name": "textarea",
+      "type": "textarea",
+      "title": "Textarea Input Example",
+      "description": "Insert something like a patient resource json here",
+      "optional": true,
+      "value": null
+    },
+    {
+      "name": "radio",
+      "type": "radio",
+      "title": "Radio Group Input Example",
+      "optional": false,
+      "options": {
+        "list_options": [
+          {
+            "label": "Label 1",
+            "value": "value1"
+          },
+          {
+            "label": "Label 2",
+            "value": "value2"
+          }
+        ]
+      },
+      "value": null
+    },
+    {
+      "name": "patient_name",
+      "type": "text",
+      "title": "Patient Name",
+      "description": "Example of locked, empty input field",
+      "locked": true,
+      "optional": true,
+      "value": null
+    },
+    {
+      "name": "url_locked",
+      "type": "text",
+      "title": "URL",
+      "description": "Example of locked, filled input field",
+      "locked": true,
+      "value": "https://inferno.healthit.gov/reference-server/r4"
+    },
+    {
+      "name": "textarea_locked",
+      "type": "textarea",
+      "title": "Textarea Input",
+      "description": "Example of locked, filled input field",
+      "locked": true,
+      "value": "Hello Inferno demo user."
+    },
+    {
+      "name": "cancel_pause_time",
+      "type": "text",
+      "value": "30"
+    },
+    {
+      "name": "url1",
+      "type": "text",
+      "value": null
+    }
+  ]
+}

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -98,6 +98,11 @@ paths:
         name: "test_suite_id"
         description: "ID of the test suite being run in this test session"
         required: true
+      - in: "query"
+        type: "string"
+        name: "preset_id"
+        description: "ID of a preset to use with this test session"
+        required: false
       responses:
         "201":
           description: "Success"
@@ -177,6 +182,28 @@ paths:
               $ref: "#/definitions/SessionData"
         "404":
           description: "Test session not found"
+  /test_sessions/{test_session_id}/session_data/apply_preset:
+    get:
+      tags:
+      - "Session Data"
+      summary: "Apply preset inputs to a test session"
+      description: "Use a set of predefined inputs in a test session."
+      parameters:
+      - in: "path"
+        type: "string"
+        name: "test_session_id"
+        description: "ID of the test session"
+        required: true
+      - in: "query"
+        type: "string"
+        name: "preset_id"
+        description: "ID of the preset"
+        required: true
+      responses:
+        "200":
+          description: "Success"
+        "404":
+          description: "Test session or preset not found"
   /test_runs:
     post:
       tags:
@@ -496,6 +523,16 @@ definitions:
         enum: [error, warning, info]
       message:
         type: "string"
+  PresetSummary:
+    type: "object"
+    required:
+    - "id"
+    - "title"
+    properties:
+      id:
+        type: "string"
+      title:
+        type: "string"
   TestSuite:
     type: "object"
     required:
@@ -531,6 +568,10 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/Message"
+      presets:
+        type: "array"
+        items:
+          $ref: "#/definitions/PresetSummary"
   TestGroup:
     type: "object"
     required:

--- a/lib/inferno/apps/cli/main.rb
+++ b/lib/inferno/apps/cli/main.rb
@@ -1,5 +1,7 @@
 require_relative 'console'
 require_relative 'migration'
+require_relative 'suite'
+require_relative 'suites'
 
 module Inferno
   module CLI
@@ -13,6 +15,14 @@ module Inferno
       def migrate
         Migration.new.run
       end
+
+      desc 'suites', 'List available test suites'
+      def suites
+        Suites.new.run
+      end
+
+      desc 'suite SUBCOMMAND ...ARGS', 'Perform suite-based operations'
+      subcommand 'suite', Suite
     end
   end
 end

--- a/lib/inferno/apps/cli/suite.rb
+++ b/lib/inferno/apps/cli/suite.rb
@@ -1,0 +1,19 @@
+require_relative 'suite_input_template'
+
+module Inferno
+  module CLI
+    class Suite < Thor
+      desc 'input_template SUITE_ID', 'Create a template for preset inputs'
+      long_desc <<~LONGDESC
+        Generates a template for creating an input preset for a Test Suite.
+
+        With -f option, the preset template is written to the specified
+        filename.
+      LONGDESC
+      option :filename, banner: '<filename>', aliases: [:f]
+      def input_template(suite_id)
+        SuiteInputTemplate.new.run(suite_id, options)
+      end
+    end
+  end
+end

--- a/lib/inferno/apps/cli/suite_input_template.rb
+++ b/lib/inferno/apps/cli/suite_input_template.rb
@@ -1,0 +1,30 @@
+require_relative '../../utils/preset_template_generator'
+
+module Inferno
+  module CLI
+    class SuiteInputTemplate
+      def run(suite_id, options)
+        require_relative '../../../inferno'
+
+        Inferno::Application.start(:suites)
+
+        suite = Inferno::Repositories::TestSuites.new.find(suite_id)
+        if suite.nil?
+          puts "No Test Suite found with id: #{suite_id}"
+          return 1
+        end
+
+        output = JSON.pretty_generate(Inferno::Utils::PresetTemplateGenerator.new(suite).generate)
+
+        if options[:filename].present?
+          path = File.join(Dir.pwd, 'config', 'presets', options[:filename])
+          FileUtils.mkdir_p(File.dirname(path))
+
+          File.open(path, 'w') { |f| f.puts(output) }
+        else
+          puts output
+        end
+      end
+    end
+  end
+end

--- a/lib/inferno/apps/cli/suites.rb
+++ b/lib/inferno/apps/cli/suites.rb
@@ -1,0 +1,23 @@
+module Inferno
+  module CLI
+    class Suites
+      def run
+        require_relative '../../../inferno'
+
+        Inferno::Application.start(:suites)
+
+        suites = Inferno::Repositories::TestSuites.new.all
+        suite_hash = suites.each_with_object({}) { |suite, hash| hash[suite.id] = suite.title }
+
+        id_column_length = suite_hash.keys.map(&:length).max + 1
+        title_column_length = suite_hash.values.map(&:length).max
+
+        puts "#{'ID'.ljust(id_column_length)}| Title"
+        puts "#{'-' * id_column_length}+-#{'-' * title_column_length}"
+        suite_hash.each do |id, title|
+          puts "#{id.ljust(id_column_length)}| #{title}"
+        end
+      end
+    end
+  end
+end

--- a/lib/inferno/apps/web/controllers/test_sessions/create.rb
+++ b/lib/inferno/apps/web/controllers/test_sessions/create.rb
@@ -6,8 +6,11 @@ module Inferno
           PARAMS = [:test_suite_id].freeze
 
           def call(params)
-            result = repo.create(create_params(params))
-            self.body = serialize(result)
+            session = repo.create(create_params(params))
+
+            repo.apply_preset(session.id, params[:preset_id]) if params[:preset_id].present?
+
+            self.body = serialize(session)
           rescue Sequel::ValidationFailed, Sequel::ForeignKeyConstraintViolation => e
             self.body = { errors: e.message }.to_json
             self.status = 422

--- a/lib/inferno/apps/web/controllers/test_sessions/session_data/apply_preset.rb
+++ b/lib/inferno/apps/web/controllers/test_sessions/session_data/apply_preset.rb
@@ -1,0 +1,43 @@
+module Inferno
+  module Web
+    module Controllers
+      module TestSessions
+        module SessionData
+          class ApplyPreset < Controller
+            include Import[
+                      test_sessions_repo: 'repositories.test_sessions',
+                      presets_repo: 'repositories.presets'
+                    ]
+
+            def self.resource_class
+              'SessionData'
+            end
+
+            def call(params)
+              test_session_id = params[:test_session_id]
+              test_session = test_sessions_repo.find(test_session_id)
+
+              if test_session.nil?
+                Application[:logger].error("Unknown test session #{test_session_id}")
+                self.status = 404
+                return
+              end
+
+              preset_id = params[:preset_id]
+              preset = presets_repo.find(preset_id)
+
+              if preset.nil?
+                Application[:logger].error("Unknown preset #{preset_id}")
+                self.status = 404
+                return
+              end
+
+              test_sessions_repo.apply_preset(test_session_id, preset_id)
+              self.status = 200
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/inferno/apps/web/router.rb
+++ b/lib/inferno/apps/web/router.rb
@@ -14,7 +14,13 @@ module Inferno
 
           resources 'test_sessions', only: [:create, :show] do
             resources 'results', only: [:index]
-            resources 'session_data', only: [:index]
+            resources 'session_data', only: [:index] do
+              collection do
+                put '/apply_preset',
+                    to: Inferno::Web::Controllers::TestSessions::SessionData::ApplyPreset,
+                    as: :apply_preset
+              end
+            end
           end
           get 'test_sessions/:test_session_id/last_test_run',
               to: Inferno::Web::Controllers::TestSessions::LastTestRun,

--- a/lib/inferno/apps/web/serializers/preset.rb
+++ b/lib/inferno/apps/web/serializers/preset.rb
@@ -1,0 +1,17 @@
+module Inferno
+  module Web
+    module Serializers
+      class Preset < Serializer
+        view :summary do
+          identifier :id
+          field :title
+        end
+
+        # view :full do
+        #   include_view :summary
+        #   field :inputs, blueprint: Input
+        # end
+      end
+    end
+  end
+end

--- a/lib/inferno/apps/web/serializers/test_suite.rb
+++ b/lib/inferno/apps/web/serializers/test_suite.rb
@@ -11,6 +11,7 @@ module Inferno
           field :input_instructions
           field :test_count
           field :version
+          association :presets, view: :summary, blueprint: Preset
         end
 
         view :full do

--- a/lib/inferno/config/boot/presets.rb
+++ b/lib/inferno/config/boot/presets.rb
@@ -1,0 +1,15 @@
+require_relative '../../repositories/presets'
+
+Inferno::Application.boot(:presets) do
+  init do
+    use :suites
+
+    files_to_load = Dir.glob(File.join(Dir.pwd, 'config', 'presets', '*.json'))
+    files_to_load.map! { |path| File.realpath(path) }
+    presets_repo = Inferno::Repositories::Presets.new
+
+    files_to_load.each do |path|
+      presets_repo.insert_from_file(path)
+    end
+  end
+end

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -479,6 +479,24 @@ module Inferno
                            !parent.respond_to?(:run_as_group?) ||
                            (parent.user_runnable? && !parent.run_as_group?)
       end
+
+      # @private
+      def available_input_definitions(prior_outputs = [])
+        available_input_definitions =
+          inputs
+            .each_with_object({}) do |input, definitions|
+              definitions[config.input_name(input)] =
+                config.input_config(input)
+            end
+        available_input_definitions.reject! { |input, _| prior_outputs.include? input }
+
+        children_available_input_definitions =
+          children.each_with_object({}) do |child, definitions|
+            definitions.merge!(child.available_input_definitions(prior_outputs))
+          end
+        prior_outputs.concat(outputs.map { |output| config.output_name(output) })
+        children_available_input_definitions.merge(available_input_definitions)
+      end
     end
   end
 end

--- a/lib/inferno/entities/preset.rb
+++ b/lib/inferno/entities/preset.rb
@@ -1,0 +1,24 @@
+require_relative 'attributes'
+require_relative 'entity'
+require_relative 'has_runnable'
+
+module Inferno
+  module Entities
+    # A `Preset` represents a set of input values for a runnable.
+    class Preset < Entity
+      ATTRIBUTES = [
+        :id,
+        :test_suite_id,
+        :inputs,
+        :title
+      ].freeze
+
+      include Inferno::Entities::Attributes
+      include Inferno::Entities::HasRunnable
+
+      def initialize(params)
+        super(params, ATTRIBUTES)
+      end
+    end
+  end
+end

--- a/lib/inferno/entities/test_suite.rb
+++ b/lib/inferno/entities/test_suite.rb
@@ -91,6 +91,10 @@ module Inferno
         def check_configuration(&block)
           @check_configuration_block = block
         end
+
+        def presets
+          @presets ||= Repositories::Presets.new.presets_for_suite(id)
+        end
       end
     end
   end

--- a/lib/inferno/repositories/in_memory_repository.rb
+++ b/lib/inferno/repositories/in_memory_repository.rb
@@ -7,8 +7,9 @@ module Inferno
 
       def_delegators 'self.class', :all, :all_by_id
 
-      def insert(klass)
-        all << klass
+      def insert(entity)
+        all << entity
+        entity
       end
 
       def find(id)

--- a/lib/inferno/repositories/presets.rb
+++ b/lib/inferno/repositories/presets.rb
@@ -1,0 +1,22 @@
+require_relative 'in_memory_repository'
+require_relative '../entities/preset'
+
+module Inferno
+  module Repositories
+    # Repository that deals with persistence for the `Preset` entity.
+    class Presets < InMemoryRepository
+      def insert_from_file(path)
+        preset_hash = JSON.parse(File.read(path))
+        preset_hash.deep_symbolize_keys!
+        preset_hash[:id] ||= SecureRandom.uuid
+        preset = Entities::Preset.new(preset_hash)
+
+        insert(preset)
+      end
+
+      def presets_for_suite(suite_id)
+        all.select { |preset| preset.test_suite_id.to_s == suite_id.to_s }
+      end
+    end
+  end
+end

--- a/lib/inferno/repositories/test_sessions.rb
+++ b/lib/inferno/repositories/test_sessions.rb
@@ -4,7 +4,11 @@ module Inferno
   module Repositories
     # Repository that deals with persistence for the `TestSession` entity.
     class TestSessions < Repository
-      include Import[results_repo: 'repositories.results']
+      include Import[
+                results_repo: 'repositories.results',
+                session_data_repo: 'repositories.session_data',
+                presets_repo: 'repositories.presets'
+              ]
 
       def json_serializer_options
         {
@@ -24,6 +28,13 @@ module Inferno
 
         test_session_hash[:results]
           .map! { |result| results_repo.build_entity(result) }
+      end
+
+      def apply_preset(test_session_id, preset_id)
+        preset = presets_repo.find(preset_id)
+        preset.inputs.each do |input|
+          session_data_repo.save(input.merge(test_session_id: test_session_id))
+        end
       end
 
       class Model < Sequel::Model(db)

--- a/lib/inferno/utils/preset_template_generator.rb
+++ b/lib/inferno/utils/preset_template_generator.rb
@@ -1,0 +1,38 @@
+module Inferno
+  module Utils
+    class PresetTemplateGenerator
+      attr_accessor :runnable
+
+      def initialize(runnable)
+        self.runnable = runnable
+      end
+
+      def input_definitions
+        @input_definitions ||= runnable.available_input_definitions
+      end
+
+      def inputs
+        # The rubocop rule is disabled because `each_value` returns the hash,
+        # while `values.each` will return the array of values. We want the array
+        # of values here.
+        input_definitions.values.each do |input_definition| # rubocop:disable Style/HashEachMethods
+          input_definition[:value] =
+            (input_definition.delete(:default) if input_definition.key? :default)
+        end
+      end
+
+      def metadata
+        {
+          title: "Preset for #{runnable.title}",
+          id: nil
+        }.merge(runnable.reference_hash)
+      end
+
+      def generate
+        metadata.merge(
+          inputs: inputs
+        )
+      end
+    end
+  end
+end

--- a/spec/inferno/web/serializers/test_suite_spec.rb
+++ b/spec/inferno/web/serializers/test_suite_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe Inferno::Web::Serializers::TestSuite do
       'short_description',
       'input_instructions',
       'test_count',
-      'version'
+      'version',
+      'presets'
     ]
   end
   let(:full_keys) do
@@ -28,6 +29,7 @@ RSpec.describe Inferno::Web::Serializers::TestSuite do
     expect(serialized_suite['input_instructions']).to eq(suite.input_instructions)
     expect(serialized_suite['test_count']).to eq(suite.test_count)
     expect(serialized_suite['version']).to eq(suite.version)
+    expect(serialized_suite['presets']).to eq([])
   end
 
   it 'serializes a full suite view' do
@@ -49,6 +51,16 @@ RSpec.describe Inferno::Web::Serializers::TestSuite do
     expect(serialized_suite['test_count']).to eq(suite.test_count)
     expect(serialized_suite['version']).to eq(suite.version)
     expect(serialized_suite['configuration_messages']).to eq(expected_messages)
-    expect(serialized_suite['test_groups'].length).to eq(suite.groups.length)
+    expect(serialized_suite['presets']).to eq([])
+  end
+
+  it 'includes preset summaries' do
+    demo_suite = DemoIG_STU1::DemoSuite
+    serialized_suite = JSON.parse(described_class.render(demo_suite, view: :summary))
+    expect(serialized_suite['presets']).to be_an(Array)
+    expect(serialized_suite['presets']).to be_present
+    expect(serialized_suite['presets'].length).to eq(demo_suite.presets.length)
+    expect(serialized_suite['presets']).to all(have_key('id'))
+    expect(serialized_suite['presets']).to all(have_key('title'))
   end
 end


### PR DESCRIPTION
This branch adds initial support for presets.
```
# list suites so you can find out a suite id
bundle exec bin/inferno suites
# generate a preset template in config/presets
bundle exec bin/inferno suite input_template SUITE_ID -f FILENAME.json
```
You can then fill in values in the preset and give it a title.

When you fetch suites via the json api, they include a list of their presets with the name & id so the UI can present them as options.

When creating a test session, you can add `?preset_id=PRESET_ID`, which will create session data for all of the inputs in the preset.

In a test session, if a suite has presets defined, there will be a button next to the `New Session` button that allows you to select a preset.