### PR TITLE
FI-1456: Fix navigation

### DIFF
--- a/.env
+++ b/.env
@@ -3,7 +3,7 @@ VALIDATOR_URL=https://inferno.healthit.gov/validatorapi
 
 # The base path where inferno will be hosted. Leave blank to host inferno at the
 # root of its host.
-BASE_PATH=inferno
+# BASE_PATH=inferno
 
 # Set the scheme/host for inferno. Tests which need an absolute url for an
 # inferno route will use this value for the scheme/host.

--- a/.env
+++ b/.env
@@ -3,7 +3,7 @@ VALIDATOR_URL=https://inferno.healthit.gov/validatorapi
 
 # The base path where inferno will be hosted. Leave blank to host inferno at the
 # root of its host.
-# BASE_PATH=inferno
+BASE_PATH=inferno
 
 # Set the scheme/host for inferno. Tests which need an absolute url for an
 # inferno route will use this value for the scheme/host.

--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,4 @@
 LOAD_DEV_SUITES=*
 VALIDATOR_URL=https://inferno.healthit.gov/validatorapi
 JS_HOST=http://localhost:3000
+BASE_PATH=inferno

--- a/README.md
+++ b/README.md
@@ -35,28 +35,28 @@ npm run dev
 ```
 
 Inferno Core can then be accessed by navigating to
-[http://localhost:4567](http://localhost:4567)
+[http://localhost:4567/inferno](http://localhost:4567)
 
 To only run the server (JSON API with no UI): `bundle exec puma`
 
 ## Running tests via JSON API
 With the server running, first retrieve a list of available test suites:
 ```
-GET http://localhost:4567/api/test_suites
+GET http://localhost:4567/inferno/api/test_suites
 ```
 See the details of a test suite:
 ```
-GET http://localhost:4567/api/test_suites/TEST_SUITE_ID
+GET http://localhost:4567/inferno/api/test_suites/TEST_SUITE_ID
 ```
 Then create a test session for the suite you want to use:
 ```
-POST http://localhost:4567/api/test_sessions?test_suite_id=TEST_SUITE_ID
+POST http://localhost:4567/inferno/api/test_sessions?test_suite_id=TEST_SUITE_ID
 ```
 Tests within a suite are organized in groups. Create a test run to run an entire
 suite, a group, or an individual test. Only one of `test_suite_id`,
 `test_group_id`, or `test_id` should be provided.
 ```
-POST http://localhost:4567/api/test_runs
+POST http://localhost:4567/inferno/api/test_runs
 {
   "test_session_id": "TEST_SESSION_ID",
   "test_suite_id": "TEST_SUITE_ID",
@@ -76,9 +76,9 @@ POST http://localhost:4567/api/test_runs
 ```
 Then you can view the results of the test run:
 ```
-GET http://localhost:4567/api/test_runs/TEST_RUN_ID/results
+GET http://localhost:4567/inferno/api/test_runs/TEST_RUN_ID/results
 or
-GET http://localhost:4567/api/test_sessions/TEST_SESSION_ID/results
+GET http://localhost:4567/inferno/api/test_sessions/TEST_SESSION_ID/results
 ```
 
 ## Development

--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupListItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupListItem.tsx
@@ -18,7 +18,6 @@ import { Request, RunnableType, Test, TestGroup } from 'models/testSuiteModels';
 import ResultIcon from './ResultIcon';
 import TestRunButton from '../TestRunButton/TestRunButton';
 import TestListItem from './TestListItem/TestListItem';
-import { getPath } from 'api/infernoApiService';
 import ReactMarkdown from 'react-markdown';
 
 interface TestGroupListItemProps {
@@ -157,11 +156,7 @@ const TestGroupListItem: FC<TestGroupListItemProps> = ({
           primary={
             <Box sx={{ display: 'flex' }}>
               <FolderIcon className={styles.folderIcon} />
-              <Link
-                color="inherit"
-                href={getPath(`${location.pathname}#${testGroup.id}`)}
-                underline="hover"
-              >
+              <Link color="inherit" href={`${location.pathname}#${testGroup.id}`} underline="hover">
                 {testGroup.title}
               </Link>
             </Box>


### PR DESCRIPTION
This branch fixes an error where inferno's base path was being added twice to group links in the UI.

**NOTE:** This branch also updates inferno's default base path so that these errors will be found more quickly in the future. By default inferno will be hosted at `localhost:4567/inferno`.