### PR TITLE
Add report summary box and reduce print margins.

### DIFF
--- a/client/src/components/TestSuite/TestSuiteDetails/TestSuiteReport.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestSuiteReport.tsx
@@ -3,7 +3,7 @@ import TestGroupCard from 'components/TestSuite/TestSuiteDetails/TestGroupCard';
 import { TestGroup, Test, TestSuite } from 'models/testSuiteModels';
 import TestGroupListItem from './TestGroupListItem';
 import TestListItem from './TestListItem/TestListItem';
-import { Button, Card, Typography } from '@mui/material';
+import { Box, Button, Card, Typography } from '@mui/material';
 import PrintIcon from '@mui/icons-material/Print';
 import useStyles from './styles';
 
@@ -13,6 +13,7 @@ interface TestSuiteReportProps {
 
 const TestSuiteReport: FC<TestSuiteReportProps> = ({ testSuite }) => {
   const styles = useStyles();
+  const location = window?.location?.href?.split('#')?.[0];
 
   let listItems: JSX.Element[] = [];
   const testChildren = testSuite.test_groups?.map((runnable) => {
@@ -76,7 +77,35 @@ const TestSuiteReport: FC<TestSuiteReportProps> = ({ testSuite }) => {
           </Button>
         </span>
       </div>
-      {/* TODO: PUT SUMMARY RESULT, STATS AND VERSION INFO HERE */}
+      <Box className={styles.reportSummaryBox}>
+        <Box className={styles.reportSummaryItems}>
+          <Box>
+            <Typography className={styles.reportSummaryItemValue} textTransform="uppercase">
+              {testSuite.result?.result || 'pending'}
+            </Typography>
+            <Typography className={styles.reportSummaryItemLabel}>Final Result</Typography>
+          </Box>
+          {testSuite.version && (
+            <Box>
+              <Typography className={styles.reportSummaryItemValue}>{testSuite.version}</Typography>
+              <Typography className={styles.reportSummaryItemLabel}>Version</Typography>
+            </Box>
+          )}
+          <Box>
+            <Typography className={styles.reportSummaryItemValue}>
+              {Intl.DateTimeFormat('en', {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric',
+                hour: 'numeric',
+                minute: 'numeric',
+              }).format(new Date())}
+            </Typography>
+            <Typography className={styles.reportSummaryItemLabel}>Report Date</Typography>
+          </Box>
+        </Box>
+        {location && <Typography className={styles.reportSummaryURL}>{location}</Typography>}
+      </Box>
     </Card>
   );
 

--- a/client/src/components/TestSuite/TestSuiteDetails/styles.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/styles.tsx
@@ -5,6 +5,26 @@ export default makeStyles((theme: Theme) => ({
   root: {
     backgroundColor: theme.palette.background.paper,
   },
+  reportSummaryBox: {
+    padding: '5px',
+  },
+  reportSummaryItemLabel: {
+    textTransform: 'uppercase',
+  },
+  reportSummaryItemValue: {
+    fontSize: '28px',
+  },
+  reportSummaryItems: {
+    padding: '20px;',
+    display: 'flex',
+    justifyContent: 'space-around',
+    textAlign: 'center',
+  },
+  reportSummaryURL: {
+    textAlign: 'right',
+    padding: '0 10px;',
+    fontSize: '12px',
+  },
   testIcon: {
     padding: '0 8px 0 0',
     display: 'inline-flex',

--- a/client/src/components/TestSuite/styles.tsx
+++ b/client/src/components/TestSuite/styles.tsx
@@ -9,6 +9,9 @@ export default makeStyles((theme: Theme) => ({
   contentContainer: {
     flexGrow: 1,
     margin: '24px 48px',
+    '@media print': {
+      margin: 0,
+    },
   },
   drawer: {
     flexShrink: 0,


### PR DESCRIPTION
Add a report box to the top.  Note, if no version on the test kit exists, it just won't show that column.

![Screen Shot 2022-02-25 at 1 59 25 PM](https://user-images.githubusercontent.com/412901/155772613-c3d0a5d1-5fa9-4a3a-bd0c-a8c1158bbef7.png)

Also reduced the side margins on the print view (probably could use some work but we can hold off until if/when we add more features to the report view, like including messages/http requests as an option for advanced users.

![Screen Shot 2022-02-25 at 1 59 51 PM](https://user-images.githubusercontent.com/412901/155772548-961f86be-8fda-471e-b366-8d4667e98a47.png)
