### PR TITLE
Accordion-clickable

### DIFF
--- a/client/src/components/TestSuite/TestRunButton/TestRunButton.tsx
+++ b/client/src/components/TestSuite/TestRunButton/TestRunButton.tsx
@@ -28,38 +28,36 @@ const TestRunButton: FC<TestRunButtonProps> = ({
   const showRunButton = runnableIsTestSuite(runnable) || (runnable as TestGroup).user_runnable;
   const runButton = showRunButton ? (
     <Tooltip title={testRunInProgress ? 'Disabled - Ongoing Test.' : ''} arrow>
-      <div>
-        {buttonText ? (
-          <Button
-            variant="contained"
-            disabled={testRunInProgress}
-            color="secondary"
-            size="small"
-            disableElevation
-            onClick={() => {
-              runTests(runnableType, runnable.id);
-            }}
-            endIcon={<PlayArrowIcon />}
-            data-testid={`runButton-${runnable.id}`}
-          >
-            {buttonText}
-          </Button>
-        ) : (
-          <IconButton
-            disabled={testRunInProgress}
-            color="secondary"
-            edge="end"
-            size="small"
-            onClick={() => {
-              runTests(runnableType, runnable.id);
-            }}
-            data-testid={`runButton-${runnable.id}`}
-            sx={{ margin: '0 4px' }}
-          >
-            <PlayCircleIcon />
-          </IconButton>
-        )}
-      </div>
+      {buttonText ? (
+        <Button
+          variant="contained"
+          disabled={testRunInProgress}
+          color="secondary"
+          size="small"
+          disableElevation
+          onClick={() => {
+            runTests(runnableType, runnable.id);
+          }}
+          endIcon={<PlayArrowIcon />}
+          data-testid={`runButton-${runnable.id}`}
+        >
+          {buttonText}
+        </Button>
+      ) : (
+        <IconButton
+          disabled={testRunInProgress}
+          color="secondary"
+          edge="end"
+          size="small"
+          onClick={() => {
+            runTests(runnableType, runnable.id);
+          }}
+          data-testid={`runButton-${runnable.id}`}
+          sx={{ margin: '0 4px' }}
+        >
+          <PlayCircleIcon />
+        </IconButton>
+      )}
     </Tooltip>
   ) : (
     <Fragment />

--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupListItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupListItem.tsx
@@ -36,6 +36,10 @@ const TestGroupListItem: FC<TestGroupListItemProps> = ({
   view,
 }) => {
   const styles = useStyles();
+  const openCondition =
+    testGroup.result?.result === 'fail' ||
+    testGroup.result?.result === 'error' ||
+    view === 'report';
 
   const renderGroupListItems = (): JSX.Element[] => {
     return testGroup.test_groups.map((tg: TestGroup) => (
@@ -100,7 +104,8 @@ const TestGroupListItem: FC<TestGroupListItemProps> = ({
     <Accordion
       disableGutters
       className={styles.accordion}
-      defaultExpanded={testGroup.result?.result == 'fail' || view == 'report' ? true : undefined}
+      sx={view === 'report' ? { 'pointer-events': 'none' } : {}}
+      defaultExpanded={openCondition}
       TransitionProps={{ unmountOnExit: true }}
     >
       <AccordionSummary

--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupListItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupListItem.tsx
@@ -106,19 +106,7 @@ const TestGroupListItem: FC<TestGroupListItemProps> = ({
       <AccordionSummary
         aria-controls={`${testGroup.title}-header`}
         id={`${testGroup.title}-header`}
-        // Toggle accordion expansion only on icon click
-        sx={{
-          pointerEvents: 'none',
-        }}
-        expandIcon={
-          view === 'run' && (
-            <ExpandMoreIcon
-              sx={{
-                pointerEvents: 'auto',
-              }}
-            />
-          )
-        }
+        expandIcon={view === 'run' && <ExpandMoreIcon />}
       >
         <ListItem className={styles.testGroupCardList}>
           {testGroup.result && (

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
@@ -58,44 +58,6 @@ const TestListItem: FC<TestListItemProps> = ({
     </Box>
   );
 
-  const messagesBadge = view === 'run' &&
-    test.result?.messages &&
-    test.result.messages.length > 0 && (
-      <IconButton
-        aria-label="open messages"
-        className={styles.badgeIcon}
-        onClick={(e) => {
-          e.stopPropagation();
-          setOpen(true);
-          setPanelIndex(0);
-        }}
-      >
-        <Badge badgeContent={test.result.messages.length} classes={{ badge: styles.testBadge }}>
-          <Tooltip title={`${test.result.messages.length} message(s)`}>
-            <MailIcon color="secondary" />
-          </Tooltip>
-        </Badge>
-      </IconButton>
-    );
-
-  const requestsBadge = test.result?.requests && test.result.requests.length > 0 && (
-    <IconButton
-      aria-label="open requests"
-      className={styles.badgeIcon}
-      onClick={(e) => {
-        e.stopPropagation();
-        setOpen(true);
-        setPanelIndex(1);
-      }}
-    >
-      <Badge badgeContent={test.result.requests.length} classes={{ badge: styles.testBadge }}>
-        <Tooltip title={`${test.result.requests.length} request(s)`}>
-          <PublicIcon color="secondary" />
-        </Tooltip>
-      </Badge>
-    </IconButton>
-  );
-
   const testLabel = (
     <>
       {test.short_id && <Typography className={styles.shortId}>{test.short_id}</Typography>}
@@ -115,6 +77,45 @@ const TestListItem: FC<TestListItemProps> = ({
         )
       }
     />
+  );
+
+  const messagesBadge = view === 'run' &&
+    test.result?.messages &&
+    test.result.messages.length > 0 && (
+      <IconButton
+        aria-label="open messages"
+        className={styles.badgeIcon}
+        onClick={(e) => {
+          e.stopPropagation();
+          setPanelIndex(0);
+          setOpen(true);
+        }}
+      >
+        <Badge badgeContent={test.result.messages.length} classes={{ badge: styles.testBadge }}>
+          <Tooltip title={`${test.result.messages.length} message(s)`}>
+            <MailIcon color="secondary" />
+          </Tooltip>
+        </Badge>
+      </IconButton>
+    );
+
+  const requestsBadge = test.result?.requests && test.result.requests.length > 0 && (
+    <IconButton
+      disabled={view === 'report'}
+      aria-label="open requests"
+      className={styles.badgeIcon}
+      onClick={(e) => {
+        e.stopPropagation();
+        setPanelIndex(1);
+        setOpen(true);
+      }}
+    >
+      <Badge badgeContent={test.result.requests.length} classes={{ badge: styles.testBadge }}>
+        <Tooltip title={`${test.result.requests.length} request(s)`}>
+          <PublicIcon color="secondary" />
+        </Tooltip>
+      </Badge>
+    </IconButton>
   );
 
   const testRunButton = view === 'run' && runTests && (

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
@@ -49,9 +49,10 @@ const TestListItem: FC<TestListItemProps> = ({
     test.result?.messages &&
     test.result.messages.length > 0 && (
       <IconButton
+        disabled
         className={styles.badgeIcon}
         onClick={() => {
-          setPanelIndex(1);
+          setPanelIndex(0);
           setOpen(true);
         }}
       >
@@ -65,10 +66,10 @@ const TestListItem: FC<TestListItemProps> = ({
 
   const requestsBadge = test.result?.requests && test.result.requests.length > 0 && (
     <IconButton
-      disabled={view === 'report'}
+      disabled
       className={styles.badgeIcon}
       onClick={() => {
-        setPanelIndex(2);
+        setPanelIndex(1);
         setOpen(true);
       }}
     >
@@ -88,7 +89,7 @@ const TestListItem: FC<TestListItemProps> = ({
 
   const testLabel = (
     <>
-      <Typography className={styles.shortId}>{test.short_id}</Typography>
+      {test.short_id && <Typography className={styles.shortId}>{test.short_id}</Typography>}
       {test.optional && <Typography className={styles.optionalLabel}>Optional</Typography>}
       <Typography className={styles.labelText}>{test.title}</Typography>
     </>
@@ -139,21 +140,15 @@ const TestListItem: FC<TestListItemProps> = ({
             }}
             variant="fullWidth"
           >
-            <Tab label="About" />
             <Tab label="Messages" />
             <Tab label="HTTP Requests" />
+            <Tab label="About" />
           </Tabs>
           <Divider />
           <TabPanel currentPanelIndex={panelIndex} index={0}>
-            <Container>
-              <Typography variant="subtitle2">{testDescription}</Typography>
-            </Container>
-            <Divider />
-          </TabPanel>
-          <TabPanel currentPanelIndex={panelIndex} index={1}>
             <MessagesList messages={test.result?.messages || []} />
           </TabPanel>
-          <TabPanel currentPanelIndex={panelIndex} index={2}>
+          <TabPanel currentPanelIndex={panelIndex} index={1}>
             {updateRequest && (
               <RequestsList
                 requests={test.result?.requests || []}
@@ -161,6 +156,12 @@ const TestListItem: FC<TestListItemProps> = ({
                 updateRequest={updateRequest}
               />
             )}
+          </TabPanel>
+          <TabPanel currentPanelIndex={panelIndex} index={2}>
+            <Container>
+              <Typography variant="subtitle2">{testDescription}</Typography>
+            </Container>
+            <Divider />
           </TabPanel>
         </Collapse>
       )}

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
@@ -44,7 +44,7 @@ const TestListItem: FC<TestListItemProps> = ({
 }) => {
   const styles = useStyles();
   const openCondition =
-    test.result?.result === 'fail' || test.result?.result === 'error' || view === 'report';
+    (test.result?.result === 'fail' || test.result?.result === 'error') && view !== 'report';
   const [open, setOpen] = React.useState(openCondition);
   const [panelIndex, setPanelIndex] = React.useState(0);
 
@@ -140,6 +140,7 @@ const TestListItem: FC<TestListItemProps> = ({
       <Accordion
         disableGutters
         className={styles.accordion}
+        sx={view === 'report' ? { 'pointer-events': 'none' } : {}}
         expanded={open}
         TransitionProps={{ unmountOnExit: true }}
         onClick={() => setOpen(!open)}

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
@@ -2,7 +2,6 @@ import React, { FC, useEffect } from 'react';
 import useStyles from './styles';
 import {
   Box,
-  Collapse,
   Container,
   Divider,
   IconButton,
@@ -24,7 +23,6 @@ import RequestsList from './RequestsList';
 import ResultIcon from '../ResultIcon';
 import PublicIcon from '@mui/icons-material/Public';
 import MailIcon from '@mui/icons-material/Mail';
-import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ReactMarkdown from 'react-markdown';
 import TestRunButton from '../../TestRunButton/TestRunButton';
@@ -171,21 +169,14 @@ const TestListItem: FC<TestListItemProps> = ({
             }}
             variant="fullWidth"
           >
-            {/* {test.result?.messages && test.result.messages.length > 0 &&  */}
             <Tab label="Messages" />
-            {/* } */}
-            {/* {test.result?.requests && test.result.requests.length > 0 && ( */}
             <Tab label="HTTP Requests" />
-            {/* )} */}
             <Tab label="About" />
           </Tabs>
           <Divider />
-          {/* {test.result?.messages && test.result.messages.length > 0 && ( */}
           <TabPanel currentPanelIndex={panelIndex} index={0}>
             <MessagesList messages={test.result?.messages || []} />
           </TabPanel>
-          {/* )} */}
-          {/* {test.result?.requests && test.result.requests.length > 0 && ( */}
           <TabPanel currentPanelIndex={panelIndex} index={1}>
             {updateRequest && (
               <RequestsList
@@ -195,7 +186,6 @@ const TestListItem: FC<TestListItemProps> = ({
               />
             )}
           </TabPanel>
-          {/* )} */}
           <TabPanel currentPanelIndex={panelIndex} index={2}>
             <Container>
               <Typography variant="subtitle2">{testDescription}</Typography>

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
@@ -204,69 +204,6 @@ const TestListItem: FC<TestListItemProps> = ({
           </TabPanel>
         </AccordionDetails>
       </Accordion>
-
-      {/* <Box className={styles.listItem}>
-        <ListItem>
-          {test.result && (
-            <div className={styles.testIcon}>
-              <ResultIcon result={test.result} />
-            </div>
-          )}
-          <ListItemText primary={testLabel} />
-          {messagesBadge}
-          {requestsBadge}
-          {view === 'run' && runTests && (
-            <TestRunButton
-              runnable={test}
-              runnableType={RunnableType.Test}
-              runTests={runTests}
-              testRunInProgress={testRunInProgress}
-            />
-          )}
-          {expandButton}
-        </ListItem>
-        {test.result?.result_message && (
-          <ReactMarkdown className={styles.resultMessageMarkdown}>
-            {test.result.result_message}
-          </ReactMarkdown>
-        )}
-      </Box>
-      {view === 'run' && (
-        <Collapse in={open} className={styles.collapsible} unmountOnExit>
-          <Divider />
-          <Tabs
-            value={panelIndex}
-            className={styles.tabs}
-            onChange={(_event, newIndex) => {
-              setPanelIndex(newIndex);
-            }}
-            variant="fullWidth"
-          >
-            <Tab label="Messages" />
-            <Tab label="HTTP Requests" />
-            <Tab label="About" />
-          </Tabs>
-          <Divider />
-          <TabPanel currentPanelIndex={panelIndex} index={0}>
-            <MessagesList messages={test.result?.messages || []} />
-          </TabPanel>
-          <TabPanel currentPanelIndex={panelIndex} index={1}>
-            {updateRequest && (
-              <RequestsList
-                requests={test.result?.requests || []}
-                resultId={test.result?.id || ''}
-                updateRequest={updateRequest}
-              />
-            )}
-          </TabPanel>
-          <TabPanel currentPanelIndex={panelIndex} index={2}>
-            <Container>
-              <Typography variant="subtitle2">{testDescription}</Typography>
-            </Container>
-            <Divider />
-          </TabPanel>
-        </Collapse>
-      )} */}
     </>
   );
 };

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/styles.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/styles.tsx
@@ -40,6 +40,9 @@ export default makeStyles((theme: Theme) => ({
   bolderText: {
     fontWeight: 'bolder',
   },
+  testCardList: {
+    padding: 0,
+  },
   messageMessage: {
     width: '90%',
     padding: '0 !important',
@@ -53,18 +56,22 @@ export default makeStyles((theme: Theme) => ({
     backgroundColor: theme.palette.common.white,
     fontWeight: 'bold',
   },
-  listItem: {
-    borderBottom: '1px solid rgba(0,0,0,.12)',
+  accordion: {
+    '&:before': {
+      display: 'none',
+    },
+    '&:not(last-child)': {
+      borderBottom: `1px solid ${theme.palette.divider}`,
+    },
   },
-  collapsible: {
+  accordionDetailContainer: {
     backgroundColor: 'rgba(0,0,0,0.05)',
+    padding: 0,
   },
   resultMessageMarkdown: {
     '& > *': {
       margin: 0,
     },
-    margin: '0 48px 16px 48px',
-    color: 'rgba(0,0,0,0.6)',
   },
   requestUrl: {
     overflow: 'hidden',


### PR DESCRIPTION
All accordions should now be click to expand.

Any other additional actions (buttons, tab nav, etc.) should not modify the accordion, with the exception of badge icons -- these should only expand the panel on click (but not collapse).

Note that this should not work on the accordion content, i.e. clicking inside an expanded accordion should not collapse the accordion.