### PR TITLE
FI-1426 Bust bundle.js cache.

### DIFF
--- a/lib/inferno/apps/web/index.html.erb
+++ b/lib/inferno/apps/web/index.html.erb
@@ -40,6 +40,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-    <script src='<%= Inferno::Application['js_host'] %>/bundle.js'></script>
+    <script src='<%= Inferno::Application['js_host'] %>/bundle.js?<%= Inferno::Application['cache_bust_token']%>'></script>
   </body>
 </html>

--- a/lib/inferno/config/application.rb
+++ b/lib/inferno/config/application.rb
@@ -21,6 +21,7 @@ module Inferno
     Application.register('async_jobs', ENV['ASYNC_JOBS'] != 'false')
     Application.register('inferno_host', ENV.fetch('INFERNO_HOST', 'http://localhost:4567'))
     Application.register('base_url', URI.join(Application['inferno_host'], base_path).to_s)
+    Application.register('cache_bust_token', SecureRandom.uuid)
 
     configure do |config|
       config.root = File.expand_path('../../..', __dir__)


### PR DESCRIPTION
This will generate a new cache-busting token on bundle.js each time the service is restarted. This is a minimal solution that can probably be more comprehensive, to include webpack configuration updates so that all assets are purged and not just bundle.js. But in practice we hardly ever change the other assets so this should fix 95% of the problem right now.