### PR TITLE
FI-1471 Resume Location

### DIFF
--- a/lib/inferno/dsl/resume_test_route.rb
+++ b/lib/inferno/dsl/resume_test_route.rb
@@ -55,7 +55,7 @@ module Inferno
 
       # @private
       def redirect_route
-        "#{Application['base_url']}/test_sessions/#{test_run.test_session_id}##{waiting_group_id}"
+        "#{Application['base_url']}/test_sessions/#{test_run.test_session_id}##{resume_ui_at_id}"
       end
 
       # @private
@@ -64,8 +64,8 @@ module Inferno
       end
 
       # @private
-      def waiting_group_id
-        test.parent.id
+      def resume_ui_at_id
+        test_run.test_suite_id || test_run.test_group_id || test.parent.id
       end
 
       # @private


### PR DESCRIPTION
In our g10 tests, the user will almost never run the test from the group in which the wait/resume happens (exception is the 'other' launches), because it is embedded under a 'run_as_group' group.  In the current behavior, this causes the user to get stranded at a level in the UI that shouldn't ever be accessed for this particular set of tests.

See https://github.com/inferno-framework/inferno-core/issues/115

This update makes it so the user is redirected to the level in which they ran the test (could be suite, or group).  To try it out, run the 'Standalone Patient App' group in the g10 tests (see the `Gemfile` for how to get those tests showing up in `inferno-core`).  You should be redirected back to the `Standalone Patient App` group.  If you run all tests at the suite level, you should get redirected back to the suite level. 

This may not be quite perfect in every case, but it is substantially better in the g10 case, and still better in most cases.