### PR TITLE
FI-1478: Only serialize available inputs

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,6 @@
 # URL for FHIR validator service
 VALIDATOR_URL=https://inferno.healthit.gov/validatorapi
+G10_VALIDATOR_URL=https://inferno.healthit.gov/validatorapi
 
 # The base path where inferno will be hosted. Leave blank to host inferno at the
 # root of its host.

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,9 @@ gemspec
 # To test with the g10 test kit (this also adds the US Core, SMART, and TLS test
 # kits):
 # - Uncomment this line:
-# gem 'onc_certification_g10_test_kit'
+gem 'onc_certification_g10_test_kit',
+    git: 'https://github.com/inferno-framework/g10-certification-test-kit.git',
+    branch: 'fi-1478-fix-patient-id-inputs'
 # - Run `bundle update`
 # - Uncomment the require at the top of
 # `dev_suites/dev_demo_ig_stu1/demo_suite.rb`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,20 @@
+GIT
+  remote: https://github.com/inferno-framework/g10-certification-test-kit.git
+  revision: f7c58d5db09d57a7a50df4836325009c1f0f37d1
+  branch: fi-1478-fix-patient-id-inputs
+  specs:
+    onc_certification_g10_test_kit (2.0.0.rc1)
+      bloomer (~> 1.0.0)
+      colorize (~> 0.8.1)
+      inferno_core (> 0.1.3)
+      json-jwt (~> 1.13.0)
+      mime-types (~> 3.4.0)
+      ndjson (~> 1.0.0)
+      rubyzip (~> 2.3.2)
+      smart_app_launch_test_kit (= 0.1.0)
+      tls_test_kit (= 0.1.1)
+      us_core_test_kit (= 0.1.1)
+
 PATH
   remote: .
   specs:
@@ -25,7 +42,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.4.4)
+    activesupport (6.1.4.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -33,15 +50,22 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    aes_key_wrap (1.1.0)
     ast (2.4.2)
     backports (3.23.0)
     bcp47 (0.3.3)
       i18n
+    bindata (2.4.10)
+    bitarray (1.2.0)
+    bloomer (1.0.0)
+      bitarray
+      msgpack
     blueprinter (0.25.2)
     byebug (11.1.3)
     codecov (0.6.0)
       simplecov (>= 0.15, < 0.22)
     coderay (1.1.3)
+    colorize (0.8.1)
     concurrent-ruby (1.1.9)
     connection_pool (2.2.5)
     crack (0.4.5)
@@ -158,18 +182,24 @@ GEM
     http_router (0.11.2)
       rack (>= 1.0.0)
       url_mount (~> 0.2.1)
-    i18n (1.9.1)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
+    json-jwt (1.13.0)
+      activesupport (>= 4.2)
+      aes_key_wrap
+      bindata
     jwt (2.3.0)
     method_source (1.0.0)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
     minitest (5.15.0)
+    msgpack (1.4.5)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
+    ndjson (1.0.0)
     netrc (0.11.0)
     nio4r (2.5.8)
     nokogiri (1.13.3-x86_64-darwin)
@@ -184,14 +214,14 @@ GEM
       rack (>= 1.2, < 3)
     oj (3.11.0)
     parallel (1.21.0)
-    parser (3.1.0.0)
+    parser (3.1.1.0)
       ast (~> 2.4.1)
-    pry (0.13.1)
+    pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.9.0)
+    pry-byebug (3.8.0)
       byebug (~> 11.0)
-      pry (~> 0.13.0)
+      pry (~> 0.10)
     public_suffix (4.0.6)
     puma (5.6.2)
       nio4r (~> 2.0)
@@ -202,7 +232,7 @@ GEM
     rainbow (3.1.1)
     rake (13.0.6)
     redis (4.6.0)
-    regexp_parser (2.2.0)
+    regexp_parser (2.2.1)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -231,16 +261,17 @@ GEM
       rubocop-ast (>= 1.15.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.15.1)
-      parser (>= 3.0.1.1)
+    rubocop-ast (1.16.0)
+      parser (>= 3.1.1.0)
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
-    rubocop-rspec (2.8.0)
+    rubocop-rspec (2.9.0)
       rubocop (~> 1.19)
     rubocop-sequel (0.3.3)
       rubocop (~> 1.0)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
+    rubyzip (2.3.2)
     sequel (5.42.0)
     sidekiq (6.4.1)
       connection_pool (>= 2.2.2)
@@ -251,10 +282,16 @@ GEM
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
-    simplecov_json_formatter (0.1.3)
+    simplecov_json_formatter (0.1.4)
+    smart_app_launch_test_kit (0.1.0)
+      inferno_core (> 0.1.3)
+      jwt (~> 2.2)
+      tls_test_kit (~> 0.1.0)
     sqlite3 (1.4.2)
     thor (1.1.0)
     tilt (2.0.10)
+    tls_test_kit (0.1.1)
+      inferno_core (> 0.1.3)
     transproc (1.1.1)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -264,6 +301,9 @@ GEM
     unicode-display_width (2.1.0)
     url_mount (0.2.1)
       rack
+    us_core_test_kit (0.1.1)
+      inferno_core (> 0.1.3)
+      tls_test_kit (~> 0.1.0)
     webmock (3.14.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -286,6 +326,7 @@ DEPENDENCIES
   database_cleaner-sequel
   factory_bot
   inferno_core!
+  onc_certification_g10_test_kit!
   pry
   pry-byebug
   rack-test

--- a/client/src/components/TestSuite/TestRunButton/TestRunButton.tsx
+++ b/client/src/components/TestSuite/TestRunButton/TestRunButton.tsx
@@ -2,13 +2,7 @@ import React, { FC, Fragment } from 'react';
 import { Button, Tooltip, IconButton } from '@mui/material';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import PlayCircleIcon from '@mui/icons-material/PlayCircle';
-import {
-  TestGroup,
-  RunnableType,
-  TestSuite,
-  Test,
-  runnableIsTestSuite,
-} from 'models/testSuiteModels';
+import { TestGroup, RunnableType, TestSuite, Test } from 'models/testSuiteModels';
 
 export interface TestRunButtonProps {
   runnable: TestSuite | TestGroup | Test;
@@ -25,7 +19,7 @@ const TestRunButton: FC<TestRunButtonProps> = ({
   testRunInProgress,
   buttonText,
 }) => {
-  const showRunButton = runnableIsTestSuite(runnable) || (runnable as TestGroup).user_runnable;
+  const showRunButton = (runnable as TestGroup).user_runnable !== false;
   const runButton = showRunButton ? (
     <Tooltip title={testRunInProgress ? 'Disabled - Ongoing Test.' : ''} arrow>
       {buttonText ? (

--- a/client/src/components/TestSuite/TestSession.tsx
+++ b/client/src/components/TestSuite/TestSession.tsx
@@ -196,10 +196,10 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
 
   function runTests(runnableType: RunnableType, runnableId: string) {
     const runnable = runnableMap.get(runnableId);
-    runnable.inputs?.forEach((input: TestInput) => {
+    runnable?.inputs?.forEach((input: TestInput) => {
       input.value = sessionData.get(input.name);
     });
-    if (runnable.inputs && runnable.inputs.length > 0) {
+    if (runnable?.inputs && runnable.inputs.length > 0) {
       showInputsModal(runnableType, runnableId, runnable.inputs);
     } else {
       createTestRun(runnableType, runnableId, []);

--- a/client/src/components/TestSuite/TestSession.tsx
+++ b/client/src/components/TestSuite/TestSession.tsx
@@ -18,7 +18,6 @@ import TestRunProgressBar from './TestRunProgressBar/TestRunProgressBar';
 import TestSuiteTreeComponent from './TestSuiteTree/TestSuiteTree';
 import TestSuiteDetailsPanel from './TestSuiteDetails/TestSuiteDetailsPanel';
 import TestSuiteReport from './TestSuiteDetails/TestSuiteReport';
-import { getAllContainedInputs } from './TestSuiteUtilities';
 import { useLocation } from 'react-router-dom';
 import { deleteTestRun, getTestRunWithResults, postTestRun } from 'api/TestRunsApi';
 import { Drawer, Toolbar, Box } from '@mui/material';
@@ -93,8 +92,7 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
   const [showProgressBar, setShowProgressBar] = React.useState<boolean>(false);
 
   useEffect(() => {
-    const allInputs = getAllContainedInputs(test_suite.test_groups as TestGroup[]);
-    allInputs.forEach((input: TestInput) => {
+    test_suite.inputs?.forEach((input: TestInput) => {
       const defaultValue = input.default || '';
       sessionData.set(input.name, sessionData.get(input.name) || defaultValue);
     });
@@ -197,30 +195,14 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
   });
 
   function runTests(runnableType: RunnableType, runnableId: string) {
-    let allInputs: TestInput[] = [];
-    if (runnableType == RunnableType.TestSuite) {
-      const testSuite = runnableMap.get(runnableId) as TestSuite;
-      if (testSuite && testSuite.test_groups) {
-        allInputs = getAllContainedInputs(testSuite.test_groups);
-      }
-    } else if (runnableType == RunnableType.TestGroup) {
-      const testGroup = runnableMap.get(runnableId) as TestGroup;
-      if (testGroup) {
-        allInputs = getAllContainedInputs([testGroup]);
-      }
-    } else {
-      const test = runnableMap.get(runnableId) as Test;
-      if (test) {
-        allInputs = test.inputs;
-      }
-    }
-    allInputs.forEach((input: TestInput) => {
+    const runnable = runnableMap.get(runnableId);
+    runnable.inputs?.forEach((input: TestInput) => {
       input.value = sessionData.get(input.name);
     });
-    if (allInputs.length > 0) {
-      showInputsModal(runnableType, runnableId, allInputs);
+    if (runnable.inputs && runnable.inputs.length > 0) {
+      showInputsModal(runnableType, runnableId, runnable.inputs);
     } else {
-      createTestRun(runnableType, runnableId, allInputs);
+      createTestRun(runnableType, runnableId, []);
     }
   }
 

--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
@@ -37,7 +37,6 @@ const TestGroupCard: FC<TestGroupCardProps> = ({
   );
 
   const runnableType = 'tests' in runnable ? RunnableType.TestGroup : RunnableType.TestSuite;
-
   return (
     <Card className={styles.testGroupCard} variant="outlined">
       <div className={styles.testGroupCardHeader}>

--- a/client/src/components/TestSuite/TestSuiteUtilities.tsx
+++ b/client/src/components/TestSuite/TestSuiteUtilities.tsx
@@ -1,46 +1,46 @@
 import { Test, TestGroup, TestInput, TestSuite } from 'models/testSuiteModels';
 
-function inputAlreadyExists(existing_inputs: TestInput[], new_input: TestInput): boolean {
-  return existing_inputs.some((existing_input: TestInput) => {
-    return existing_input.name == new_input.name;
-  });
-}
+/* function inputAlreadyExists(existing_inputs: TestInput[], new_input: TestInput): boolean {
+ *   return existing_inputs.some((existing_input: TestInput) => {
+ *     return existing_input.name == new_input.name;
+ *   });
+ * }
+ * 
+ * export function getAllContainedInputs(testGroups: TestGroup[]): TestInput[] {
+ *   const all_inputs: TestInput[] = [];
+ *   const all_outputs: Set<string> = new Set();
+ * 
+ *   testGroups.forEach((subGroup) => {
+ *     const subgroup_inputs: TestInput[] = getInputsRecursive(subGroup, all_outputs);
+ *     subgroup_inputs.forEach((test_input: TestInput) => {
+ *       if (!inputAlreadyExists(all_inputs, test_input)) {
+ *         all_inputs.push(test_input);
+ *       }
+ *     });
+ *   });
+ *   return all_inputs;
+ * }
+ * 
+ * function getInputsRecursive(testGroup: TestGroup, testOutputs: Set<string>): TestInput[] {
+ *   let inputs = testGroup.inputs.filter((input) => !testOutputs.has(input.name));
+ *   testGroup.test_groups.forEach((subGroup) => {
+ *     inputs = inputs.concat(getInputsRecursive(subGroup, testOutputs));
+ *   });
+ *   testGroup.tests.forEach((test) => {
+ *     inputs = inputs.concat(test.inputs.filter((input) => !testOutputs.has(input.name)));
+ *     test.outputs.forEach((output) => testOutputs.add(output.name));
+ *   });
+ *   testGroup.outputs.forEach((output) => testOutputs.add(output.name));
+ *   return inputs;
+ * } */
 
-export function getAllContainedInputs(testGroups: TestGroup[]): TestInput[] {
-  const all_inputs: TestInput[] = [];
-  const all_outputs: Set<string> = new Set();
-
-  testGroups.forEach((subGroup) => {
-    const subgroup_inputs: TestInput[] = getInputsRecursive(subGroup, all_outputs);
-    subgroup_inputs.forEach((test_input: TestInput) => {
-      if (!inputAlreadyExists(all_inputs, test_input)) {
-        all_inputs.push(test_input);
-      }
-    });
-  });
-  return all_inputs;
-}
-
-function getInputsRecursive(testGroup: TestGroup, testOutputs: Set<string>): TestInput[] {
-  let inputs = testGroup.inputs.filter((input) => !testOutputs.has(input.name));
-  testGroup.test_groups.forEach((subGroup) => {
-    inputs = inputs.concat(getInputsRecursive(subGroup, testOutputs));
-  });
-  testGroup.tests.forEach((test) => {
-    inputs = inputs.concat(test.inputs.filter((input) => !testOutputs.has(input.name)));
-    test.outputs.forEach((output) => testOutputs.add(output.name));
-  });
-  testGroup.outputs.forEach((output) => testOutputs.add(output.name));
-  return inputs;
-}
-
-export const shouldShowDescription = (
-  runnable: Test | TestGroup | TestSuite,
-  description: JSX.Element | undefined
-): boolean => {
-  if (description && runnable.description && runnable.description.length > 0) {
-    return true;
-  } else {
-    return false;
-  }
-};
+  export const shouldShowDescription = (
+    runnable: Test | TestGroup | TestSuite,
+    description: JSX.Element | undefined
+  ): boolean => {
+    if (description && runnable.description && runnable.description.length > 0) {
+      return true;
+    } else {
+      return false;
+    }
+  };

--- a/client/src/components/TestSuite/TestSuiteUtilities.tsx
+++ b/client/src/components/TestSuite/TestSuiteUtilities.tsx
@@ -1,46 +1,12 @@
-import { Test, TestGroup, TestInput, TestSuite } from 'models/testSuiteModels';
+import { Test, TestGroup, TestSuite } from 'models/testSuiteModels';
 
-/* function inputAlreadyExists(existing_inputs: TestInput[], new_input: TestInput): boolean {
- *   return existing_inputs.some((existing_input: TestInput) => {
- *     return existing_input.name == new_input.name;
- *   });
- * }
- * 
- * export function getAllContainedInputs(testGroups: TestGroup[]): TestInput[] {
- *   const all_inputs: TestInput[] = [];
- *   const all_outputs: Set<string> = new Set();
- * 
- *   testGroups.forEach((subGroup) => {
- *     const subgroup_inputs: TestInput[] = getInputsRecursive(subGroup, all_outputs);
- *     subgroup_inputs.forEach((test_input: TestInput) => {
- *       if (!inputAlreadyExists(all_inputs, test_input)) {
- *         all_inputs.push(test_input);
- *       }
- *     });
- *   });
- *   return all_inputs;
- * }
- * 
- * function getInputsRecursive(testGroup: TestGroup, testOutputs: Set<string>): TestInput[] {
- *   let inputs = testGroup.inputs.filter((input) => !testOutputs.has(input.name));
- *   testGroup.test_groups.forEach((subGroup) => {
- *     inputs = inputs.concat(getInputsRecursive(subGroup, testOutputs));
- *   });
- *   testGroup.tests.forEach((test) => {
- *     inputs = inputs.concat(test.inputs.filter((input) => !testOutputs.has(input.name)));
- *     test.outputs.forEach((output) => testOutputs.add(output.name));
- *   });
- *   testGroup.outputs.forEach((output) => testOutputs.add(output.name));
- *   return inputs;
- * } */
-
-  export const shouldShowDescription = (
-    runnable: Test | TestGroup | TestSuite,
-    description: JSX.Element | undefined
-  ): boolean => {
-    if (description && runnable.description && runnable.description.length > 0) {
-      return true;
-    } else {
-      return false;
-    }
-  };
+export const shouldShowDescription = (
+  runnable: Test | TestGroup | TestSuite,
+  description: JSX.Element | undefined
+): boolean => {
+  if (description && runnable.description && runnable.description.length > 0) {
+    return true;
+  } else {
+    return false;
+  }
+};

--- a/client/src/models/testSuiteModels.ts
+++ b/client/src/models/testSuiteModels.ts
@@ -107,7 +107,7 @@ export interface TestSuite {
   short_description?: string;
   run_as_group?: boolean;
   result?: Result;
-  inputs: TestInput[];
+  inputs?: TestInput[];
   test_count?: number;
   test_groups?: TestGroup[];
   optional?: boolean;

--- a/client/src/models/testSuiteModels.ts
+++ b/client/src/models/testSuiteModels.ts
@@ -153,7 +153,3 @@ export interface PresetSummary {
   id: string;
   title: string;
 }
-
-export function runnableIsTestSuite(runnable: TestSuite | TestGroup | Test): runnable is TestSuite {
-  return (runnable as TestGroup).inputs == undefined;
-}

--- a/client/src/models/testSuiteModels.ts
+++ b/client/src/models/testSuiteModels.ts
@@ -107,6 +107,7 @@ export interface TestSuite {
   short_description?: string;
   run_as_group?: boolean;
   result?: Result;
+  inputs: TestInput[];
   test_count?: number;
   test_groups?: TestGroup[];
   optional?: boolean;

--- a/dev_suites/dev_demo_ig_stu1/demo_suite.rb
+++ b/dev_suites/dev_demo_ig_stu1/demo_suite.rb
@@ -1,4 +1,4 @@
-# require 'onc_certification_g10_test_kit'
+require 'onc_certification_g10_test_kit'
 require_relative 'groups/demo_group'
 
 module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase

--- a/lib/inferno/apps/web/serializers/test_group.rb
+++ b/lib/inferno/apps/web/serializers/test_group.rb
@@ -17,7 +17,7 @@ module Inferno
 
         association :groups, name: :test_groups, blueprint: TestGroup
         association :tests, blueprint: Test
-        field :input_definitions, name: :inputs, extractor: HashValueExtractor, blueprint: Input
+        field :available_input_definitions, name: :inputs, extractor: HashValueExtractor, blueprint: Input
         field :output_definitions, name: :outputs, extractor: HashValueExtractor
       end
     end

--- a/lib/inferno/apps/web/serializers/test_suite.rb
+++ b/lib/inferno/apps/web/serializers/test_suite.rb
@@ -18,6 +18,7 @@ module Inferno
           include_view :summary
           association :groups, name: :test_groups, blueprint: TestGroup
           field :configuration_messages
+          field :available_input_definitions, name: :inputs, extractor: HashValueExtractor, blueprint: Input
         end
       end
     end

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -486,7 +486,7 @@ module Inferno
       # Goes through this runnable and all of its children, gathering the inputs
       # they need, and excluding any which are provided by outputs of an earlier
       # runnable.
-      def available_input_definitions(prior_outputs = [])
+      def available_input_definitions(prior_outputs = []) # rubocop:disable Metrics/CyclomaticComplexity
         @available_input_definitions ||=
           begin
             available_input_definitions =

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -51,16 +51,13 @@ module Inferno
 
         subclass.config(config)
 
-        child_types.each do |child_type|
-          new_children = send(child_type).map do |child|
-            Class.new(child).tap do |subclass_child|
-              subclass_child.parent = subclass
-            end
+        new_children = children.map do |child|
+          Class.new(child).tap do |subclass_child|
+            subclass_child.parent = subclass
           end
-
-          subclass.instance_variable_set(:"@#{child_type}", new_children)
-          subclass.children.concat(new_children)
         end
+
+        subclass.instance_variable_set(:@children, new_children)
       end
 
       # @private

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -461,15 +461,10 @@ module Inferno
       end
 
       # @private
-      def required_inputs(prior_outputs = [])
-        required_inputs =
-          inputs
-            .reject { |input| input_definitions[input][:optional] }
-            .map { |input| config.input_name(input) }
-            .reject { |input| prior_outputs.include?(input) }
-        children_required_inputs = children.flat_map { |child| child.required_inputs(prior_outputs) }
-        prior_outputs.concat(outputs.map { |output| config.output_name(output) })
-        (required_inputs + children_required_inputs).flatten.uniq
+      def required_inputs
+        available_input_definitions
+          .reject { |_, input_definition| input_definition[:optional] }
+          .map { |_, input_definition| input_definition[:name] }
       end
 
       # @private

--- a/spec/inferno/dsl/fhir_validation_spec.rb
+++ b/spec/inferno/dsl/fhir_validation_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Inferno::DSL::FHIRValidation do
         validator.perform_additional_validation { 1 }
         validator.perform_additional_validation { nil }
 
-        expect(validator.resource_is_valid?(resource, profile_url, runnable)).to eq(true)
+        expect(validator.resource_is_valid?(resource, profile_url, runnable)).to be(true)
         expect(runnable.messages).to eq([])
       end
     end
@@ -35,7 +35,7 @@ RSpec.describe Inferno::DSL::FHIRValidation do
       it 'adds the messages to the runnable' do
         validator.perform_additional_validation { extra_message }
 
-        expect(validator.resource_is_valid?(resource, profile_url, runnable)).to eq(true)
+        expect(validator.resource_is_valid?(resource, profile_url, runnable)).to be(true)
         expect(runnable.messages).to eq([extra_message])
       end
     end
@@ -51,7 +51,7 @@ RSpec.describe Inferno::DSL::FHIRValidation do
       it 'adds the messages to the runnable' do
         validator.perform_additional_validation { extra_messages }
 
-        expect(validator.resource_is_valid?(resource, profile_url, runnable)).to eq(true)
+        expect(validator.resource_is_valid?(resource, profile_url, runnable)).to be(true)
         expect(runnable.messages).to eq(extra_messages)
       end
     end
@@ -67,7 +67,7 @@ RSpec.describe Inferno::DSL::FHIRValidation do
       it 'fails validation' do
         validator.perform_additional_validation { extra_messages }
 
-        expect(validator.resource_is_valid?(resource, profile_url, runnable)).to eq(false)
+        expect(validator.resource_is_valid?(resource, profile_url, runnable)).to be(false)
         expect(runnable.messages).to eq(extra_messages)
       end
     end

--- a/spec/inferno/dsl/runnable_spec.rb
+++ b/spec/inferno/dsl/runnable_spec.rb
@@ -184,8 +184,8 @@ RSpec.describe Inferno::DSL::Runnable do
       example_test_group.test 'test' do
         input :a
       end
-      expect(example_test_group.user_runnable?).to eq(true)
-      expect(example_test_group.tests.first.user_runnable?).to eq(true)
+      expect(example_test_group.user_runnable?).to be(true)
+      expect(example_test_group.tests.first.user_runnable?).to be(true)
     end
 
     it 'sets user_runnable on groups to true if not under groups set to run_as_group' do

--- a/spec/inferno/entities/request_spec.rb
+++ b/spec/inferno/entities/request_spec.rb
@@ -23,10 +23,10 @@ RSpec.describe Inferno::Entities::Request do
       expect(entity.response_body).to eq(response_body)
       expect(
         entity.request_headers.one? { |header| header.name == 'accept' && header.value == 'application/json' }
-      ).to eq(true)
+      ).to be(true)
       expect(
         entity.response_headers.one? { |header| header.name == 'content-type' && header.value == 'application/json' }
-      ).to eq(true)
+      ).to be(true)
     end
   end
 
@@ -53,12 +53,12 @@ RSpec.describe Inferno::Entities::Request do
       expect(entity.response_body).to eq(response_body.to_json)
       expect(
         entity.request_headers.one? { |header| header.name == 'accept' && header.value == 'application/fhir+json' }
-      ).to eq(true)
+      ).to be(true)
       expect(
         entity.response_headers.one? do |header|
           header.name == 'content-type' && header.value == 'application/fhir+json'
         end
-      ).to eq(true)
+      ).to be(true)
     end
 
     it 'correctly handles form encoded bodies' do

--- a/spec/inferno/web/serializers/test_group_spec.rb
+++ b/spec/inferno/web/serializers/test_group_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Inferno::Web::Serializers::TestGroup do
     expect(serialized_group['description']).to eq(group.description)
     expect(serialized_group['short_description']).to eq(group.short_description)
     expect(serialized_group['input_instructions']).to eq(group.input_instructions)
-    expect(serialized_group['inputs'].length).to eq(group.inputs.length)
+    expect(serialized_group['inputs'].length).to eq(group.available_input_definitions.length)
     expect(serialized_group['outputs'].length).to eq(group.outputs.length)
     expect(serialized_group['test_count']).to eq(group.tests.length)
     expect(serialized_group['test_groups']).to be_empty

--- a/spec/inferno/web/serializers/test_suite_spec.rb
+++ b/spec/inferno/web/serializers/test_suite_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Inferno::Web::Serializers::TestSuite do
     ]
   end
   let(:full_keys) do
-    summary_keys + ['configuration_messages', 'test_groups']
+    summary_keys + ['configuration_messages', 'test_groups', 'inputs']
   end
 
   it 'serializes a suite summary view' do


### PR DESCRIPTION
This branch updates the JSON api so that for each runnable entity, it only gives the inputs which that runnable needs. So for a suite/group, it goes through all of their children, gathers their inputs, and removes any that are provided by a previous output. This allows us to remove that logic from the front end.