### PR TITLE
Fix suite-level run button.

### DIFF
--- a/client/src/components/TestSuite/TestRunButton/TestRunButton.tsx
+++ b/client/src/components/TestSuite/TestRunButton/TestRunButton.tsx
@@ -2,13 +2,7 @@ import React, { FC, Fragment } from 'react';
 import { Button, Tooltip, IconButton } from '@mui/material';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import PlayCircleIcon from '@mui/icons-material/PlayCircle';
-import {
-  TestGroup,
-  RunnableType,
-  TestSuite,
-  Test,
-  runnableIsTestSuite,
-} from 'models/testSuiteModels';
+import { TestGroup, RunnableType, TestSuite, Test } from 'models/testSuiteModels';
 
 export interface TestRunButtonProps {
   runnable: TestSuite | TestGroup | Test;
@@ -25,7 +19,7 @@ const TestRunButton: FC<TestRunButtonProps> = ({
   testRunInProgress,
   buttonText,
 }) => {
-  const showRunButton = runnableIsTestSuite(runnable) || (runnable as TestGroup).user_runnable;
+  const showRunButton = (runnable as TestGroup).user_runnable !== false;
   const runButton = showRunButton ? (
     <Tooltip title={testRunInProgress ? 'Disabled - Ongoing Test.' : ''} arrow>
       {buttonText ? (

--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
@@ -37,7 +37,6 @@ const TestGroupCard: FC<TestGroupCardProps> = ({
   );
 
   const runnableType = 'tests' in runnable ? RunnableType.TestGroup : RunnableType.TestSuite;
-
   return (
     <Card className={styles.testGroupCard} variant="outlined">
       <div className={styles.testGroupCardHeader}>

--- a/client/src/models/testSuiteModels.ts
+++ b/client/src/models/testSuiteModels.ts
@@ -153,7 +153,3 @@ export interface PresetSummary {
   id: string;
   title: string;
 }
-
-export function runnableIsTestSuite(runnable: TestSuite | TestGroup | Test): runnable is TestSuite {
-  return (runnable as TestGroup).inputs == undefined;
-}


### PR DESCRIPTION
We had logic in there to force the button to show up if at suite-level, because suites don't have "user_runnable" tagged to them (we probably should somehow allow suites decide if it makes sense to run everything in a suite or not all at once, but not in scope right now).  I updated the logic for that button so that it will show up as long as the runnable explicitly doesn't say "don't show the button", which works because the suite wouldn't say one way or another right now.  That way we don't need that function that checks if a runnable is a suite or not, which got broken in your other updates (it was looking for inputs to determine type, but now suites have inputs).  I deleted the function because it was the only place it was being used somehow...

I tested on the suite, groups that should have that button (both run_as_group and not run_as_gruop)... and also on things that shouldn't have the button (which you can't navigate to any more in g10, but you can get to one by messing with ids, e.g. http://localhost:4567/inferno/test_sessions/fd5002e9-f854-4239-8174-9616cc71174a#g10_certification-g10_smart_standalone_patient_app-g10_smart_standalone_token_refresh )

NOTE: The suite-level run-all modal is broken because a bunch of stuff is locked that shouldn't be.

<img width="1042" alt="Screen Shot 2022-03-03 at 4 58 36 PM" src="https://user-images.githubusercontent.com/412901/156659747-d497f9fb-bd5d-457b-ab32-d56353705d1b.png">


