### PR TITLE
Require file to ensure it is loaded prior to test run.

### DIFF
--- a/dev_suites/dev_infrastructure_test/infrastructure_test.rb
+++ b/dev_suites/dev_infrastructure_test/infrastructure_test.rb
@@ -1,6 +1,7 @@
 require_relative 'external_outer_group'
 require_relative 'passing_optional_group'
 require_relative 'mixed_optional_group'
+require_relative 'failing_optional_group'
 
 module InfrastructureTest
   class Suite < Inferno::TestSuite


### PR DESCRIPTION
GitHub Actions is intermittently failing one Ruby spec unrelated to PRs that are being opened, I believe because sometimes test files are loaded in different orders.  I noticed that we weren't explicitly calling `require_relative` for one group which was causing the issue.

![Screen Shot 2022-03-11 at 1 43 40 PM](https://user-images.githubusercontent.com/412901/157932183-f7f6dda9-e766-4632-8b6a-3c59cfa78aac.png)

```
An error occurred while loading spec_helper.
Failure/Error: raise Exceptions::ParentNotLoadedException.new(child_metadata[:class], superclass_id) unless superclass

Inferno::Exceptions::ParentNotLoadedException:
  No TestGroup found with id 'failing_optional_group'
# ./lib/inferno/dsl/runnable.rb:129:in `create_child_class'
# ./lib/inferno/dsl/runnable.rb:84:in `define_child'
# ./lib/inferno/entities/test_suite.rb:41:in `group'
```
