### PR TITLE
Change material-ui imports.

### DIFF
--- a/client/src/components/ThemeProvider.tsx
+++ b/client/src/components/ThemeProvider.tsx
@@ -1,6 +1,10 @@
 import React, { FC, ReactNode } from 'react';
 
-import { ThemeProvider as MuiThemeProvider, Theme, StyledEngineProvider } from '@mui/material';
+import {
+  ThemeProvider as MuiThemeProvider,
+  Theme,
+  StyledEngineProvider,
+} from '@mui/material/styles';
 import lightTheme from 'styles/theme';
 
 declare module '@mui/styles/defaultTheme' {

--- a/client/src/styles/theme.tsx
+++ b/client/src/styles/theme.tsx
@@ -1,4 +1,4 @@
-import { createTheme } from '@mui/material';
+import { createTheme } from '@mui/material/styles';
 
 // https://material-ui.com/customization/palette/#adding-new-colors
 declare module '@mui/material/styles/createPalette' {


### PR DESCRIPTION
* The move to v5 includes some temporary aliases it seems.
* The upgrade we did is fine but I believe these are the real and future names according to [theming docs](https://mui.com/customization/theming/)

This was exposed by using a babel direct import plugin in trying to shrink the bundle size.