### PR TITLE
FI-1478: UI updates

### DIFF
--- a/client/src/components/InputsModal/InputsModal.tsx
+++ b/client/src/components/InputsModal/InputsModal.tsx
@@ -25,6 +25,7 @@ export interface InputsModalProps {
   modalVisible: boolean;
   hideModal: () => void;
   createTestRun: (runnableType: RunnableType, runnableId: string, inputs: TestInput[]) => void;
+  sessionData: Map<string, unknown>;
 }
 
 function runnableTypeReadable(runnableType: RunnableType) {
@@ -47,6 +48,7 @@ const InputsModal: FC<InputsModalProps> = ({
   modalVisible,
   hideModal,
   createTestRun,
+  sessionData
 }) => {
   const styles = useStyles();
   const [inputsMap, setInputsMap] = React.useState<Map<string, unknown>>(new Map());
@@ -79,10 +81,10 @@ const InputsModal: FC<InputsModalProps> = ({
   useEffect(() => {
     inputsMap.clear();
     inputs.forEach((requirement: TestInput) => {
-      inputsMap.set(requirement.name, requirement.value || (requirement.default as string) || '');
+      inputsMap.set(requirement.name, sessionData.get(requirement.name) || (requirement.default as string) || '');
     });
     setInputsMap(new Map(inputsMap));
-  }, [inputs]);
+  }, [inputs, sessionData]);
 
   const instructions =
     inputInstructions ||

--- a/client/src/components/InputsModal/InputsModal.tsx
+++ b/client/src/components/InputsModal/InputsModal.tsx
@@ -48,7 +48,7 @@ const InputsModal: FC<InputsModalProps> = ({
   modalVisible,
   hideModal,
   createTestRun,
-  sessionData
+  sessionData,
 }) => {
   const styles = useStyles();
   const [inputsMap, setInputsMap] = React.useState<Map<string, unknown>>(new Map());
@@ -81,7 +81,10 @@ const InputsModal: FC<InputsModalProps> = ({
   useEffect(() => {
     inputsMap.clear();
     inputs.forEach((requirement: TestInput) => {
-      inputsMap.set(requirement.name, sessionData.get(requirement.name) || (requirement.default as string) || '');
+      inputsMap.set(
+        requirement.name,
+        sessionData.get(requirement.name) || (requirement.default as string) || ''
+      );
     });
     setInputsMap(new Map(inputsMap));
   }, [inputs, sessionData]);

--- a/client/src/components/InputsModal/__tests__/InputModal.test.tsx
+++ b/client/src/components/InputsModal/__tests__/InputModal.test.tsx
@@ -32,6 +32,7 @@ test('Input modal not visible if visibility set to false', () => {
         runnableType={RunnableType.TestGroup}
         runnableId={'test group id'}
         inputs={testInputs}
+        sessionData={new Map()}
       />
     </ThemeProvider>
   );
@@ -50,6 +51,7 @@ test('Modal visible and inputs are shown', () => {
         runnableType={RunnableType.TestGroup}
         runnableId={'test group id'}
         inputs={testInputs}
+        sessionData={new Map()}
       />
     </ThemeProvider>
   );
@@ -79,6 +81,7 @@ test('Pressing cancel hides the modal', () => {
         runnableType={RunnableType.TestGroup}
         runnableId={'test group id'}
         inputs={testInputs}
+        sessionData={new Map()}
       />
     </ThemeProvider>
   );

--- a/client/src/components/TestSuite/TestRunButton/TestRunButton.tsx
+++ b/client/src/components/TestSuite/TestRunButton/TestRunButton.tsx
@@ -2,13 +2,7 @@ import React, { FC } from 'react';
 import { Button, Tooltip, IconButton } from '@mui/material';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import PlayCircleIcon from '@mui/icons-material/PlayCircle';
-import {
-  TestGroup,
-  RunnableType,
-  TestSuite,
-  Test,
-  runnableIsTestSuite,
-} from 'models/testSuiteModels';
+import { TestGroup, RunnableType, TestSuite, Test } from 'models/testSuiteModels';
 
 export interface TestRunButtonProps {
   runnable: TestSuite | TestGroup | Test;
@@ -25,7 +19,7 @@ const TestRunButton: FC<TestRunButtonProps> = ({
   testRunInProgress,
   buttonText,
 }) => {
-  const showRunButton = runnableIsTestSuite(runnable) || (runnable as TestGroup).user_runnable;
+  const showRunButton = (runnable as TestGroup).user_runnable !== false;
 
   return (
     <>

--- a/client/src/components/TestSuite/TestRunButton/TestRunButton.tsx
+++ b/client/src/components/TestSuite/TestRunButton/TestRunButton.tsx
@@ -19,6 +19,8 @@ const TestRunButton: FC<TestRunButtonProps> = ({
   testRunInProgress,
   buttonText,
 }) => {
+  /* Need to explicitly check against false because undefined needs to be treated
+   * as true. */
   const showRunButton = (runnable as TestGroup).user_runnable !== false;
 
   return (

--- a/client/src/components/TestSuite/TestSuiteUtilities.tsx
+++ b/client/src/components/TestSuite/TestSuiteUtilities.tsx
@@ -1,38 +1,4 @@
-import { Test, TestGroup, TestInput, TestSuite } from 'models/testSuiteModels';
-
-function inputAlreadyExists(existing_inputs: TestInput[], new_input: TestInput): boolean {
-  return existing_inputs.some((existing_input: TestInput) => {
-    return existing_input.name == new_input.name;
-  });
-}
-
-export function getAllContainedInputs(testGroups: TestGroup[]): TestInput[] {
-  const all_inputs: TestInput[] = [];
-  const all_outputs: Set<string> = new Set();
-
-  testGroups.forEach((subGroup) => {
-    const subgroup_inputs: TestInput[] = getInputsRecursive(subGroup, all_outputs);
-    subgroup_inputs.forEach((test_input: TestInput) => {
-      if (!inputAlreadyExists(all_inputs, test_input)) {
-        all_inputs.push(test_input);
-      }
-    });
-  });
-  return all_inputs;
-}
-
-function getInputsRecursive(testGroup: TestGroup, testOutputs: Set<string>): TestInput[] {
-  let inputs = testGroup.inputs.filter((input) => !testOutputs.has(input.name));
-  testGroup.test_groups.forEach((subGroup) => {
-    inputs = inputs.concat(getInputsRecursive(subGroup, testOutputs));
-  });
-  testGroup.tests.forEach((test) => {
-    inputs = inputs.concat(test.inputs.filter((input) => !testOutputs.has(input.name)));
-    test.outputs.forEach((output) => testOutputs.add(output.name));
-  });
-  testGroup.outputs.forEach((output) => testOutputs.add(output.name));
-  return inputs;
-}
+import { Test, TestGroup, TestSuite } from 'models/testSuiteModels';
 
 export const shouldShowDescription = (
   runnable: Test | TestGroup | TestSuite,

--- a/client/src/models/testSuiteModels.ts
+++ b/client/src/models/testSuiteModels.ts
@@ -107,6 +107,7 @@ export interface TestSuite {
   short_description?: string;
   run_as_group?: boolean;
   result?: Result;
+  inputs?: TestInput[];
   test_count?: number;
   test_groups?: TestGroup[];
   optional?: boolean;
@@ -151,8 +152,4 @@ export interface OAuthCredentials {
 export interface PresetSummary {
   id: string;
   title: string;
-}
-
-export function runnableIsTestSuite(runnable: TestSuite | TestGroup | Test): runnable is TestSuite {
-  return (runnable as TestGroup).inputs == undefined;
 }

--- a/lib/inferno/apps/web/serializers/test.rb
+++ b/lib/inferno/apps/web/serializers/test.rb
@@ -7,7 +7,7 @@ module Inferno
         field :short_id
         field :title
         field :short_title
-        field :input_definitions, name: :inputs, extractor: HashValueExtractor, blueprint: Input
+        field :available_inputs, name: :inputs, extractor: HashValueExtractor, blueprint: Input
         field :output_definitions, name: :outputs, extractor: HashValueExtractor
         field :description
         field :short_description

--- a/lib/inferno/apps/web/serializers/test_group.rb
+++ b/lib/inferno/apps/web/serializers/test_group.rb
@@ -17,7 +17,7 @@ module Inferno
 
         association :groups, name: :test_groups, blueprint: TestGroup
         association :tests, blueprint: Test
-        field :input_definitions, name: :inputs, extractor: HashValueExtractor, blueprint: Input
+        field :available_inputs, name: :inputs, extractor: HashValueExtractor, blueprint: Input
         field :output_definitions, name: :outputs, extractor: HashValueExtractor
       end
     end

--- a/lib/inferno/apps/web/serializers/test_suite.rb
+++ b/lib/inferno/apps/web/serializers/test_suite.rb
@@ -18,6 +18,7 @@ module Inferno
           include_view :summary
           association :groups, name: :test_groups, blueprint: TestGroup
           field :configuration_messages
+          field :available_inputs, name: :inputs, extractor: HashValueExtractor, blueprint: Input
         end
       end
     end

--- a/spec/inferno/web/serializers/test_group_spec.rb
+++ b/spec/inferno/web/serializers/test_group_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Inferno::Web::Serializers::TestGroup do
     expect(serialized_group['description']).to eq(group.description)
     expect(serialized_group['short_description']).to eq(group.short_description)
     expect(serialized_group['input_instructions']).to eq(group.input_instructions)
-    expect(serialized_group['inputs'].length).to eq(group.inputs.length)
+    expect(serialized_group['inputs'].length).to eq(group.available_inputs.length)
     expect(serialized_group['outputs'].length).to eq(group.outputs.length)
     expect(serialized_group['test_count']).to eq(group.tests.length)
     expect(serialized_group['test_groups']).to be_empty

--- a/spec/inferno/web/serializers/test_suite_spec.rb
+++ b/spec/inferno/web/serializers/test_suite_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Inferno::Web::Serializers::TestSuite do
     ]
   end
   let(:full_keys) do
-    summary_keys + ['configuration_messages', 'test_groups']
+    summary_keys + ['configuration_messages', 'test_groups', 'inputs']
   end
 
   it 'serializes a suite summary view' do


### PR DESCRIPTION
This branch updates the ui to use the inputs as defined on the backend rather than doing its own calculations to determine which inputs to show far a runnable. Check with branch `fi-1478-update-for-input-handling-changes` on the g10 tertification tests.