### PR TITLE
FI-1410: Input order

### DIFF
--- a/dev_suites/dev_demo_ig_stu1/demo_suite.rb
+++ b/dev_suites/dev_demo_ig_stu1/demo_suite.rb
@@ -146,6 +146,9 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
     # separate groups (so their results don't collide)
     group do
       id :repetitive_group
+
+      input_order :bearer_token, :patient_id, :url
+
       title 'Group 2'
       group from: 'DemoIG_STU1::DemoGroup', id: 'DEF', title: 'Demo Group Instance 2'
       group from: 'DemoIG_STU1::DemoGroup' do

--- a/lib/inferno/dsl/input_output_handling.rb
+++ b/lib/inferno/dsl/input_output_handling.rb
@@ -95,7 +95,7 @@ module Inferno
       #     input_order :input3, :input2, :input1
       #   end
       # @param new_input_order [Array<String,Symbol>]
-      # @return [Array<String, Symbol]
+      # @return [Array<String, Symbol>]
       def input_order(*new_input_order)
         return @input_order = new_input_order if new_input_order.present?
 

--- a/spec/inferno/dsl/input_output_handling_spec.rb
+++ b/spec/inferno/dsl/input_output_handling_spec.rb
@@ -92,4 +92,44 @@ RSpec.describe Inferno::DSL::InputOutputHandling do
       expect(missing_inputs).to eq([])
     end
   end
+
+  describe '.input_order' do
+    let(:group) do
+      Class.new(Inferno::Entities::TestGroup) do
+        input :a, name: :aa
+        input :b, name: :bb
+        input :c, name: :cc
+      end
+    end
+
+    context 'when blank' do
+      it 'does no ordering on the inputs' do
+        group.input_order
+
+        ordered_inputs = group.available_inputs.values.map(&:name)
+
+        expect(ordered_inputs).to eq(['aa', 'bb', 'cc'])
+      end
+    end
+
+    context 'when all inputs are present' do
+      it 'orders the inputs' do
+        group.input_order(:bb, :cc, :aa)
+
+        ordered_inputs = group.available_inputs.values.map(&:name)
+
+        expect(ordered_inputs).to eq(['bb', 'cc', 'aa'])
+      end
+    end
+
+    context 'when some inputs are present' do
+      it 'orders those inputs first' do
+        group.input_order(:bb)
+
+        ordered_inputs = group.available_inputs.values.map(&:name)
+
+        expect(ordered_inputs).to eq(['bb', 'aa', 'cc'])
+      end
+    end
+  end
 end


### PR DESCRIPTION
This branch allows you to use `input_order` to specify the order of inputs in a runnable.

The order of inputs in `Group 3` in the demo suite was changed. So you can compare it to `Group 2` in the UI.