### PR TITLE
FI-1500: Fix duplicated inputs

### DIFF
--- a/lib/inferno/dsl/input_output_handling.rb
+++ b/lib/inferno/dsl/input_output_handling.rb
@@ -169,7 +169,11 @@ module Inferno
       def available_inputs
         @available_inputs ||=
           begin
-            available_inputs = input_definitions
+            available_inputs =
+              input_definitions
+                .each_with_object({}) do |(_, input), inputs|
+                  inputs[input.name.to_sym] = input
+                end
 
             available_inputs.each do |input, current_definition|
               child_definition = children_available_inputs[input]

--- a/lib/inferno/dsl/input_output_handling.rb
+++ b/lib/inferno/dsl/input_output_handling.rb
@@ -5,13 +5,13 @@ module Inferno
       #
       # @param identifier [Symbol] identifier for the input
       # @param other_identifiers [Symbol] array of symbols if specifying multiple inputs
-      # @param input_definition [Hash] options for input such as type, description, or title
-      # @option input_definition [String] :title Human readable title for input
-      # @option input_definition [String] :description Description for the input
-      # @option input_definition [String] :type text | textarea | radio
-      # @option input_definition [String] :default The default value for the input
-      # @option input_definition [Boolean] :optional Set to true to not require input for test execution
-      # @option input_definition [Hash] :options Possible input option formats based on input type
+      # @param input_params [Hash] options for input such as type, description, or title
+      # @option input_params [String] :title Human readable title for input
+      # @option input_params [String] :description Description for the input
+      # @option input_params [String] :type text | textarea | radio
+      # @option input_params [String] :default The default value for the input
+      # @option input_params [Boolean] :optional Set to true to not require input for test execution
+      # @option input_params [Hash] :options Possible input option formats based on input type
       # @option options [Array] :list_options Array of options for input formats that require a list of possible values
       # @return [void]
       # @example
@@ -19,7 +19,7 @@ module Inferno
       #                     default: 'default_patient_id'
       # @example
       #   input :textarea, title: 'Textarea Input Example', type: 'textarea', optional: true
-      def input(identifier, *other_identifiers, **input_definition)
+      def input(identifier, *other_identifiers, **input_params)
         if other_identifiers.present?
           [identifier, *other_identifiers].compact.each do |input_identifier|
             inputs << input_identifier
@@ -27,7 +27,7 @@ module Inferno
           end
         else
           inputs << identifier
-          config.add_input(identifier, input_definition)
+          config.add_input(identifier, input_params)
         end
       end
 
@@ -65,11 +65,6 @@ module Inferno
       end
 
       # @private
-      def input_definitions
-        config.inputs.slice(*inputs)
-      end
-
-      # @private
       def output_definitions
         config.outputs.slice(*outputs)
       end
@@ -77,8 +72,8 @@ module Inferno
       # @private
       def required_inputs
         available_inputs
-          .reject { |_, input_definition| input_definition.optional }
-          .map { |_, input_definition| input_definition.name }
+          .reject { |_, input| input.optional }
+          .map { |_, input| input.name }
       end
 
       # @private
@@ -170,7 +165,8 @@ module Inferno
         @available_inputs ||=
           begin
             available_inputs =
-              input_definitions
+              config.inputs
+                .slice(*inputs)
                 .each_with_object({}) do |(_, input), inputs|
                   inputs[input.name.to_sym] = input
                 end

--- a/lib/inferno/entities/test.rb
+++ b/lib/inferno/entities/test.rb
@@ -122,16 +122,16 @@ module Inferno
         #
         # @param name [Symbol] name of the input
         # @param other_names [Symbol] array of symbols if specifying multiple inputs
-        # @param input_definition [Hash] options for input such as type, description, or title
-        # @option input_definition [String] :title Human readable title for input
-        # @option input_definition [String] :description Description for the input
-        # @option input_definition [String] :type 'text' | 'textarea'
+        # @param input_params [Hash] options for input such as type, description, or title
+        # @option input_params [String] :title Human readable title for input
+        # @option input_params [String] :description Description for the input
+        # @option input_params [String] :type 'text' | 'textarea'
         # @return [void]
         # @example
         #   input :patientid, title: 'Patient ID', description: 'The ID of the patient being searched for'
         # @example
         #   input :textarea, title: 'Textarea Input Example', type: 'textarea'
-        def input(name, *other_names, **input_definition)
+        def input(name, *other_names, **input_params)
           super
 
           if other_names.present?

--- a/lib/inferno/utils/preset_template_generator.rb
+++ b/lib/inferno/utils/preset_template_generator.rb
@@ -7,17 +7,16 @@ module Inferno
         self.runnable = runnable
       end
 
-      def input_definitions
-        @input_definitions ||= runnable.available_inputs.transform_values(&:to_hash)
+      def available_inputs
+        @available_inputs ||= runnable.available_inputs.transform_values(&:to_hash)
       end
 
       def inputs
         # The rubocop rule is disabled because `each_value` returns the hash,
         # while `values.each` will return the array of values. We want the array
         # of values here.
-        input_definitions.values.each do |input_definition| # rubocop:disable Style/HashEachMethods
-          input_definition[:value] =
-            (input_definition.delete(:default) if input_definition.key? :default)
+        available_inputs.values.each do |input| # rubocop:disable Style/HashEachMethods
+          input[:value] = (input.delete(:default) if input.key? :default)
         end
       end
 

--- a/spec/inferno/dsl/input_output_handling_spec.rb
+++ b/spec/inferno/dsl/input_output_handling_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Inferno::DSL::InputOutputHandling do
           input :a, name: :b
 
           test do
-            run {}
+            run { nil }
           end
         end
       end

--- a/spec/inferno/dsl/input_output_handling_spec.rb
+++ b/spec/inferno/dsl/input_output_handling_spec.rb
@@ -21,6 +21,24 @@ RSpec.describe Inferno::DSL::InputOutputHandling do
       expect(group.available_inputs.length).to eq(2)
       expect(group.available_inputs.values.map(&:name)).to eq(['b', 'c'])
     end
+
+    it 'does not duplicate renamed inputs' do
+      suite = Class.new(Inferno::Entities::TestSuite) do
+        group do
+          input :a, name: :b
+
+          test do
+            run {}
+          end
+        end
+      end
+      group = suite.groups.first
+      test = group.tests.first
+
+      expect(suite.available_inputs.keys).to eq([:b])
+      expect(group.available_inputs.keys).to eq([:b])
+      expect(test.available_inputs.keys).to eq([:b])
+    end
   end
 
   describe '.missing_inputs' do

--- a/spec/inferno/utils/preset_template_generator_spec.rb
+++ b/spec/inferno/utils/preset_template_generator_spec.rb
@@ -39,8 +39,6 @@ RSpec.describe Inferno::Utils::PresetTemplateGenerator do
       generator = described_class.new(suite)
       template = generator.generate
 
-      # binding.pry
-
       expect(template).to eq(expected_template)
     end
   end

--- a/spec/inferno/web/serializers/test_group_spec.rb
+++ b/spec/inferno/web/serializers/test_group_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Inferno::Web::Serializers::TestGroup do
     expect(serialized_group['test_groups']).to be_empty
     expect(serialized_group['tests'].length).to eq(group.tests.length)
 
-    group.input_definitions.each do |_identifier, definition|
+    group.available_inputs.each do |_identifier, definition|
       raw_input = serialized_group['inputs'].find { |serialized_input| serialized_input['name'] == definition.name }
       expect(raw_input).to be_present
       input = Inferno::Entities::Input.new(raw_input.symbolize_keys)

--- a/spec/inferno/web/serializers/test_spec.rb
+++ b/spec/inferno/web/serializers/test_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Inferno::Web::Serializers::Test do
     expect(serialized_test['inputs'].length).to eq(test.inputs.length)
     expect(serialized_test['outputs'].length).to eq(test.outputs.length)
 
-    test.input_definitions.each do |_identifier, definition|
+    test.available_inputs.each do |_identifier, definition|
       raw_input = serialized_test['inputs'].find { |serialized_input| serialized_input['name'] == definition.name }
       expect(raw_input).to be_present
       input = Inferno::Entities::Input.new(raw_input.symbolize_keys)


### PR DESCRIPTION
If a runnable declared an input and renamed it, it would appear twice in `available_inputs` for that runnable.