### PR TITLE
Refactor typescript model types

### DIFF
--- a/client/src/components/LandingPage/__mocked_data__/mockData.ts
+++ b/client/src/components/LandingPage/__mocked_data__/mockData.ts
@@ -1,8 +1,8 @@
 import { TestSuite } from 'models/testSuiteModels';
 
 export const mockedTestSuitesReturnValue: TestSuite[] = [
-  { id: 'demo', title: 'Demonstration Suite', description: '', optional: false },
-  { id: 'infra_test', title: 'Infrastructure Test', description: '', optional: false },
+  { id: 'demo', title: 'Demonstration Suite', description: '', optional: false, inputs: [] },
+  { id: 'infra_test', title: 'Infrastructure Test', description: '', optional: false, inputs: [] },
 ];
 
 export const mockedPostTestSuiteResponse = {

--- a/client/src/components/TestSuite/TestRunButton/TestRunButton.tsx
+++ b/client/src/components/TestSuite/TestRunButton/TestRunButton.tsx
@@ -2,10 +2,10 @@ import React, { FC } from 'react';
 import { Button, IconButton } from '@mui/material';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import PlayCircleIcon from '@mui/icons-material/PlayCircle';
-import { TestGroup, RunnableType, TestSuite, Test } from 'models/testSuiteModels';
+import { TestGroup, Runnable, RunnableType } from 'models/testSuiteModels';
 
 export interface TestRunButtonProps {
-  runnable: TestSuite | TestGroup | Test;
+  runnable: Runnable;
   runnableType: RunnableType;
   runTests: (runnableType: RunnableType, runnableId: string) => void;
   testRunInProgress: boolean;

--- a/client/src/components/TestSuite/TestSession.tsx
+++ b/client/src/components/TestSuite/TestSession.tsx
@@ -2,6 +2,7 @@ import React, { FC, useEffect } from 'react';
 import {
   TestInput,
   RunnableType,
+  Runnable,
   TestRun,
   Result,
   TestSession,
@@ -22,10 +23,7 @@ import { useLocation } from 'react-router-dom';
 import { deleteTestRun, getTestRunWithResults, postTestRun } from 'api/TestRunsApi';
 import { Drawer, Toolbar, Box } from '@mui/material';
 
-function mapRunnableRecursive(
-  testGroup: TestGroup,
-  map: Map<string, TestSuite | TestGroup | Test>
-) {
+function mapRunnableRecursive(testGroup: TestGroup, map: Map<string, Runnable>) {
   map.set(testGroup.id, testGroup);
   testGroup.test_groups.forEach((subGroup: TestGroup) => {
     mapRunnableRecursive(subGroup, map);
@@ -35,8 +33,8 @@ function mapRunnableRecursive(
   });
 }
 
-function mapRunnableToId(testSuite: TestSuite): Map<string, TestSuite | TestGroup | Test> {
-  const map = new Map<string, TestSuite | TestGroup | Test>();
+function mapRunnableToId(testSuite: TestSuite): Map<string, Runnable> {
+  const map = new Map<string, Runnable>();
   map.set(testSuite.id, testSuite);
   testSuite?.test_groups?.forEach((testGroup: TestGroup) => {
     mapRunnableRecursive(testGroup, map);
@@ -285,10 +283,8 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
           modalVisible={inputModalVisible}
           runnableType={runnableType}
           runnableId={runnableId}
-          title={(runnableMap.get(selectedRunnable) as TestSuite | TestGroup | Test).title}
-          inputInstructions={
-            (runnableMap.get(selectedRunnable) as TestSuite | TestGroup | Test).input_instructions
-          }
+          title={(runnableMap.get(selectedRunnable) as Runnable).title}
+          inputInstructions={(runnableMap.get(selectedRunnable) as Runnable).input_instructions}
           inputs={inputs}
           sessionData={sessionData}
         />

--- a/client/src/components/TestSuite/TestSuiteTree/__tests__/TestSuiteTree.test.tsx
+++ b/client/src/components/TestSuite/TestSuiteTree/__tests__/TestSuiteTree.test.tsx
@@ -103,6 +103,7 @@ const demoTestSuite: TestSuite = {
   id: 'example suite',
   test_groups: [sequence1, sequence2, parentGroup],
   optional: false,
+  inputs: [],
 };
 
 const testSuiteTreeProps: TestSuiteTreeProps = {

--- a/client/src/components/TestSuite/TestSuiteUtilities.tsx
+++ b/client/src/components/TestSuite/TestSuiteUtilities.tsx
@@ -1,7 +1,7 @@
-import { Test, TestGroup, TestSuite } from 'models/testSuiteModels';
+import { Runnable } from 'models/testSuiteModels';
 
 export const shouldShowDescription = (
-  runnable: Test | TestGroup | TestSuite,
+  runnable: Runnable,
   description: JSX.Element | undefined
 ): boolean => {
   if (description && runnable.description && runnable.description.length > 0) {

--- a/client/src/components/TestSuite/__mocked_data__/mockData.ts
+++ b/client/src/components/TestSuite/__mocked_data__/mockData.ts
@@ -31,6 +31,7 @@ export const mockedTestSession: TestSession = {
         user_runnable: true,
       },
     ],
+    inputs: [],
     title: 'Demonstration Suite',
   },
   test_suite_id: 'demo',

--- a/client/src/components/_common/__mocked_data__/mockData.ts
+++ b/client/src/components/_common/__mocked_data__/mockData.ts
@@ -4,4 +4,5 @@ export const mockedTestSuite: TestSuite = {
   id: 'demo',
   title: 'Demonstration Suite',
   description: '',
+  inputs: [],
 };

--- a/client/src/models/testSuiteModels.ts
+++ b/client/src/models/testSuiteModels.ts
@@ -63,59 +63,44 @@ export interface TestOutput {
   value: string | undefined;
 }
 
-export interface Test {
+export type Runnable = {
   id: string;
-  short_id: string;
   title: string;
   short_title?: string;
+  description?: string | null;
+  short_description?: string;
   result?: Result;
   inputs: TestInput[];
-  outputs: TestOutput[];
-  input_instructions?: string;
-  description?: string;
-  short_description?: string;
-  user_runnable?: boolean;
   optional?: boolean;
-}
+  input_instructions?: string;
+};
 
-export interface TestGroup {
-  id: string;
+export type Test = Runnable & {
   short_id: string;
-  title: string;
-  short_title?: string;
+  outputs: TestOutput[];
+  user_runnable?: boolean;
+};
+
+export type TestGroup = Runnable & {
+  short_id: string;
   parent_group?: TestGroup | null;
   test_groups: TestGroup[];
-  inputs: TestInput[];
   outputs: TestOutput[];
-  input_instructions?: string;
   tests: Test[];
-  result?: Result;
-  description?: string | null;
-  short_description?: string;
   run_as_group?: boolean;
   user_runnable?: boolean;
   test_count?: number;
-  optional?: boolean;
   expanded?: boolean;
-}
+};
 
-export interface TestSuite {
-  title: string;
-  short_title?: string;
-  id: string;
-  description?: string | null;
-  short_description?: string;
+export type TestSuite = Runnable & {
   run_as_group?: boolean;
-  result?: Result;
-  inputs?: TestInput[];
   test_count?: number;
   test_groups?: TestGroup[];
-  optional?: boolean;
-  input_instructions?: string;
   configuration_messages?: Message[];
   version?: string;
   presets?: PresetSummary[];
-}
+};
 
 export interface TestSession {
   id: string;


### PR DESCRIPTION
* change Runnable interfaces to types
* create a base type called Runnable (RunnableType is still needed)
* move all common properties to Runnable
* change outside code to use Runnable instead of `Test | TestGroup | TestSuite`