### PR TITLE
FI-1520: Include primitive extensions when validating

### DIFF
--- a/lib/inferno/dsl/fhir_validation.rb
+++ b/lib/inferno/dsl/fhir_validation.rb
@@ -1,3 +1,5 @@
+require_relative '../ext/fhir_models'
+
 module Inferno
   module DSL
     # This module contains the methods needed to configure a validator to
@@ -168,7 +170,7 @@ module Inferno
         def validate(resource, profile_url)
           RestClient.post(
             "#{url}/validate",
-            resource.to_json,
+            resource.source_contents,
             params: { profile: profile_url }
           ).body
         end

--- a/lib/inferno/ext/fhir_models.rb
+++ b/lib/inferno/ext/fhir_models.rb
@@ -1,0 +1,59 @@
+require 'json'
+
+# Extension to FHIR::Model. Prepending this into FHIR::Model (done below)
+# allows us to call super() on initialize when we overriding it,
+# while also defining new methods and attributes
+module InfernoFHIRModelExtensions
+  attr_accessor :source_hash, :source_text
+
+  def initialize(hash = {})
+    super(hash)
+    @source_hash = hash
+  end
+
+  def source_contents
+    @source_text || JSON.generate({ resourceType: resourceType }.merge(@source_hash))
+  end
+end
+
+module FHIR
+  class Model
+    prepend ::InfernoFHIRModelExtensions
+  end
+end
+
+# Extension to FHIR::Json. Prepending this into FHIR::Json (done below)
+# allows us to call super() on from_json
+module InfernoJson
+  def from_json(json)
+    resource = super(json)
+    resource.source_text = json
+    resource
+  end
+end
+
+# Extension to FHIR::Xml. Prepending this into FHIR::Xml (done below)
+# allows us to call super() on from_xml
+module InfernoXml
+  def from_xml(xml)
+    resource = super(xml)
+    resource.source_text = xml
+    resource
+  end
+end
+
+module FHIR
+  module Json
+    class << self
+      prepend InfernoJson
+    end
+  end
+end
+
+module FHIR
+  module Xml
+    class << self
+      prepend InfernoXml
+    end
+  end
+end

--- a/lib/inferno/ext/fhir_models.rb
+++ b/lib/inferno/ext/fhir_models.rb
@@ -12,7 +12,7 @@ module InfernoFHIRModelExtensions
   end
 
   def source_contents
-    @source_text || JSON.generate({ resourceType: resourceType }.merge(@source_hash))
+    @source_text || JSON.generate(@source_hash)
   end
 end
 

--- a/spec/inferno/dsl/assertions_spec.rb
+++ b/spec/inferno/dsl/assertions_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Inferno::DSL::Assertions do
         validation_request =
           stub_request(:post, validation_url)
             .with(query: { profile: FHIR::Definitions.resource_definition('Patient').url })
-            .with(body: patient_resource.to_json)
+            .with(body: patient_resource.source_contents)
             .to_return(status: 200, body: success_outcome.to_json)
 
         klass.assert_valid_resource(resource: patient_resource)
@@ -132,7 +132,7 @@ RSpec.describe Inferno::DSL::Assertions do
         validation_request =
           stub_request(:post, validation_url)
             .with(query: { profile: FHIR::Definitions.resource_definition('Patient').url })
-            .with(body: patient_resource.to_json)
+            .with(body: patient_resource.source_contents)
             .to_return(status: 200, body: success_outcome.to_json)
 
         klass.assert_valid_resource
@@ -146,7 +146,7 @@ RSpec.describe Inferno::DSL::Assertions do
         validation_request =
           stub_request(:post, validation_url)
             .with(query: { profile: FHIR::Definitions.resource_definition('Patient').url })
-            .with(body: patient_resource.to_json)
+            .with(body: patient_resource.source_contents)
             .to_return(status: 200, body: success_outcome.to_json)
 
         klass.assert_valid_resource(resource: patient_resource)
@@ -160,7 +160,7 @@ RSpec.describe Inferno::DSL::Assertions do
         validation_request =
           stub_request(:post, validation_url)
             .with(query: { profile: profile_url })
-            .with(body: patient_resource.to_json)
+            .with(body: patient_resource.source_contents)
             .to_return(status: 200, body: success_outcome.to_json)
 
         klass.assert_valid_resource(resource: patient_resource, profile_url: profile_url)
@@ -173,7 +173,7 @@ RSpec.describe Inferno::DSL::Assertions do
       it 'raises an exception' do
         stub_request(:post, validation_url)
           .with(query: { profile: profile_url })
-          .with(body: patient_resource.to_json)
+          .with(body: patient_resource.source_contents)
           .to_return(status: 200, body: error_outcome.to_json)
 
         expect { klass.assert_valid_resource(resource: patient_resource, profile_url: profile_url) }.to(
@@ -184,7 +184,7 @@ RSpec.describe Inferno::DSL::Assertions do
       it 'adds an error message' do
         stub_request(:post, validation_url)
           .with(query: { profile: profile_url })
-          .with(body: patient_resource.to_json)
+          .with(body: patient_resource.source_contents)
           .to_return(status: 200, body: error_outcome.to_json)
 
         expect { klass.assert_valid_resource(resource: patient_resource, profile_url: profile_url) }.to(
@@ -202,7 +202,7 @@ RSpec.describe Inferno::DSL::Assertions do
         validation_request =
           stub_request(:post, validation_url)
             .with(query: { profile: profile_url })
-            .with(body: patient_resource.to_json)
+            .with(body: patient_resource.source_contents)
             .to_return(status: 200, body: outcome_with_messages.to_json)
 
         klass.assert_valid_resource(resource: patient_resource, profile_url: profile_url)
@@ -213,7 +213,7 @@ RSpec.describe Inferno::DSL::Assertions do
       it 'adds warning/info messages' do
         stub_request(:post, validation_url)
           .with(query: { profile: profile_url })
-          .with(body: patient_resource.to_json)
+          .with(body: patient_resource.source_contents)
           .to_return(status: 200, body: outcome_with_messages.to_json)
 
         klass.assert_valid_resource(resource: patient_resource, profile_url: profile_url)
@@ -235,7 +235,7 @@ RSpec.describe Inferno::DSL::Assertions do
 
         stub_request(:post, validation_url)
           .with(query: { profile: profile_url })
-          .with(body: patient_resource.to_json)
+          .with(body: patient_resource.source_contents)
           .to_return(status: 200, body: outcome_with_messages.to_json)
 
         klass.assert_valid_resource(resource: patient_resource, profile_url: profile_url)
@@ -272,11 +272,11 @@ RSpec.describe Inferno::DSL::Assertions do
           [
             stub_request(:post, validation_url)
               .with(query: { profile: FHIR::Definitions.resource_definition('Patient').url })
-              .with(body: patient_resource.to_json)
+              .with(body: patient_resource.source_contents)
               .to_return(status: 200, body: success_outcome.to_json),
             stub_request(:post, validation_url)
               .with(query: { profile: FHIR::Definitions.resource_definition('CarePlan').url })
-              .with(body: care_plan_resource.to_json)
+              .with(body: care_plan_resource.source_contents)
               .to_return(status: 200, body: error_outcome.to_json)
           ]
 
@@ -296,11 +296,11 @@ RSpec.describe Inferno::DSL::Assertions do
           [
             stub_request(:post, validation_url)
               .with(query: { profile: FHIR::Definitions.resource_definition('Patient').url })
-              .with(body: patient_resource.to_json)
+              .with(body: patient_resource.source_contents)
               .to_return(status: 200, body: success_outcome.to_json),
             stub_request(:post, validation_url)
               .with(query: { profile: FHIR::Definitions.resource_definition('CarePlan').url })
-              .with(body: care_plan_resource.to_json)
+              .with(body: care_plan_resource.source_contents)
               .to_return(status: 200, body: success_outcome.to_json)
           ]
 
@@ -316,11 +316,11 @@ RSpec.describe Inferno::DSL::Assertions do
           [
             stub_request(:post, validation_url)
               .with(query: { profile: FHIR::Definitions.resource_definition('Patient').url })
-              .with(body: patient_resource.to_json)
+              .with(body: patient_resource.source_contents)
               .to_return(status: 200, body: success_outcome.to_json),
             stub_request(:post, validation_url)
               .with(query: { profile: FHIR::Definitions.resource_definition('CarePlan').url })
-              .with(body: care_plan_resource.to_json)
+              .with(body: care_plan_resource.source_contents)
               .to_return(status: 200, body: success_outcome.to_json)
           ]
 
@@ -335,7 +335,7 @@ RSpec.describe Inferno::DSL::Assertions do
         validation_request =
           stub_request(:post, validation_url)
             .with(query: { profile: FHIR::Definitions.resource_definition('CarePlan').url })
-            .with(body: care_plan_resource.to_json)
+            .with(body: care_plan_resource.source_contents)
             .to_return(status: 200, body: success_outcome.to_json)
 
         klass.assert_valid_bundle_entries(bundle: bundle, resource_types: 'CarePlan')
@@ -349,7 +349,7 @@ RSpec.describe Inferno::DSL::Assertions do
         validation_request =
           stub_request(:post, validation_url)
             .with(query: { profile: FHIR::Definitions.resource_definition('CarePlan').url })
-            .with(body: care_plan_resource.to_json)
+            .with(body: care_plan_resource.source_contents)
             .to_return(status: 200, body: success_outcome.to_json)
 
         klass.assert_valid_bundle_entries(bundle: bundle, resource_types: ['CarePlan'])
@@ -365,11 +365,11 @@ RSpec.describe Inferno::DSL::Assertions do
           [
             stub_request(:post, validation_url)
               .with(query: { profile: patient_profile })
-              .with(body: patient_resource.to_json)
+              .with(body: patient_resource.source_contents)
               .to_return(status: 200, body: success_outcome.to_json),
             stub_request(:post, validation_url)
               .with(query: { profile: FHIR::Definitions.resource_definition('CarePlan').url })
-              .with(body: care_plan_resource.to_json)
+              .with(body: care_plan_resource.source_contents)
               .to_return(status: 200, body: success_outcome.to_json)
           ]
 


### PR DESCRIPTION
This branch uses our existing workaround for including primitive extensions in FHIR models. This was raised as an issue for certification: https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/67