### PR TITLE
Always show required label on form elements.

### DIFF
--- a/client/src/components/InputsModal/InputOAuthCredentials.tsx
+++ b/client/src/components/InputsModal/InputOAuthCredentials.tsx
@@ -43,7 +43,7 @@ const InputOAuthCredentials: FC<InputOAuthCredentialsProps> = ({
   const showRefreshDetails = !!oAuthCredentials.refresh_token;
 
   const fieldLabelText = `${requirement.title || requirement.name}`;
-  const requiredLabel = !requirement.optional && !requirement.locked ? ' (required)' : '';
+  const requiredLabel = !requirement.optional ? ' (required)' : '';
   const lockedIcon = requirement.locked ? (
     <LockIcon fontSize="small" className={styles.lockedIcon} />
   ) : null;

--- a/client/src/components/InputsModal/InputTextArea.tsx
+++ b/client/src/components/InputsModal/InputTextArea.tsx
@@ -17,7 +17,7 @@ const InputTextArea: FC<InputTextAreaProps> = ({ requirement, index, inputsMap, 
   const lockedIcon = requirement.locked ? (
     <LockIcon fontSize="small" className={styles.lockedIcon} />
   ) : null;
-  const requiredLabel = !requirement.optional && !requirement.locked ? ' (required)' : '';
+  const requiredLabel = !requirement.optional ? ' (required)' : '';
   const fieldLabel = (
     <Fragment>
       {fieldLabelText}

--- a/client/src/components/InputsModal/InputTextField.tsx
+++ b/client/src/components/InputsModal/InputTextField.tsx
@@ -22,7 +22,7 @@ const InputTextField: FC<InputTextFieldProps> = ({
   const lockedIcon = requirement.locked && (
     <LockIcon fontSize="small" className={styles.lockedIcon} />
   );
-  const requiredLabel = !requirement.optional && !requirement.locked ? ' (required)' : '';
+  const requiredLabel = !requirement.optional ? ' (required)' : '';
   const fieldLabel = (
     <Fragment>
       {fieldLabelText}


### PR DESCRIPTION
If an input is locked, we do not tell the user whether or not it is required.  While it is strange to have a locked field that you cannot do anything about tell you it is required, I think it is worse to not inform the user in any way why the 'Submit' button is disabled.  At least by enabling this, they can see that there is a field that they do not have access to change that is required (and hopefully there is information in the input instructions as to how to get that field filled out).

This is based on a question from a user that didn't know why they didn't have access to submitting the Single Patient API form in their configuration.

See Demo Suite 3.1.21 for an example.  Before:

![Screen Shot 2022-04-08 at 12 34 02 AM](https://user-images.githubusercontent.com/412901/162364281-d3706d0a-2cca-4f25-b1f7-ead0225e98aa.png)


After:



![Screen Shot 2022-04-08 at 12 32 29 AM](https://user-images.githubusercontent.com/412901/162364329-a1602802-4440-4eca-94d5-610e7ded41bf.png)

Note that this doesn't show what is really bad about not having required displayed, which is if those were empty by default the submit button would be greyed out and the user wouldn't be told why.
