### PR TITLE
FI 1529: Center Suites Display

### DIFF
--- a/client/src/components/LandingPage/styles.tsx
+++ b/client/src/components/LandingPage/styles.tsx
@@ -7,7 +7,8 @@ export default makeStyles((theme: Theme) => ({
     backgroundColor: theme.palette.common.white,
   },
   main: {
-    marginTop: '280px',
+    height: '100%',
+    display: 'flex',
     padding: '0 60px',
   },
   selectedItem: {


### PR DESCRIPTION
On the landing page (`/suites` page for production), adjusted the suites display to center within the available space leftover from adding in a banner. 