### PR TITLE
Use Zustand for React state management

### DIFF
--- a/client/src/components/App/App.tsx
+++ b/client/src/components/App/App.tsx
@@ -9,9 +9,11 @@ import ThemeProvider from 'components/ThemeProvider';
 import { TestSession, TestSuite } from 'models/testSuiteModels';
 import { basePath } from 'api/infernoApiService';
 
+import { useAppStore } from '../../store/app';
+
 const App: FC<unknown> = () => {
-  const [testSuites, setTestSuites] = React.useState<TestSuite[]>();
-  const [testSession, setTestSession] = React.useState<TestSession>();
+  const { testSuites, setTestSuites } = useAppStore();
+  const { testSession, setTestSession } = useAppStore();
 
   useEffect(() => {
     getTestSuites()

--- a/client/src/components/App/__mocked_data__/mockData.ts
+++ b/client/src/components/App/__mocked_data__/mockData.ts
@@ -1,0 +1,34 @@
+import { TestSuite, TestSession } from 'models/testSuiteModels';
+
+export const testSuites: TestSuite[] = [
+  {
+    id: 'one',
+    title: 'Suite One',
+    description: '',
+    optional: false,
+    inputs: [],
+  },
+  {
+    id: 'two',
+    title: 'Suite Two',
+    description: '',
+    optional: false,
+    inputs: [],
+  },
+];
+
+export const singleTestSuite: TestSuite[] = [
+  {
+    id: 'one',
+    title: 'Suite One',
+    description: '',
+    optional: false,
+    inputs: [],
+  },
+];
+
+export const testSession: TestSession = {
+  id: '42',
+  test_suite: singleTestSuite[0],
+  test_suite_id: 'test-suite-id',
+};

--- a/client/src/components/App/__tests__/App.test.tsx
+++ b/client/src/components/App/__tests__/App.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import App from '../App';
+import * as testSuitesApi from 'api/TestSuitesApi';
+import * as testSessionApi from 'api/TestSessionApi';
+import { testSuites, singleTestSuite, testSession } from '../__mocked_data__/mockData';
+
+// mock out a complex child component, react-testing-library advises
+// against this but we are in the App component, so maybe make an exception?
+jest.mock('../../TestSuite/TestSessionWrapper', () => () => <div>Mock TestSessionWrapper</div>);
+
+describe('The App Root Component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('sets Test Suite state on mount', async () => {
+    const mock = jest.spyOn(testSuitesApi, 'getTestSuites');
+    mock.mockResolvedValue(testSuites);
+
+    render(<App />);
+
+    // We have to wait for something to load so we don't get act()
+    // warnings.  The only thing rendered by App is children components.
+    // So await for those to be done with side effects (hooks).
+    await screen.findByText('Suite One');
+
+    expect(mock).toBeCalledTimes(1);
+  });
+
+  it('sets the Test Session if there is a single Test Suite', async () => {
+    const getTestSuites = jest.spyOn(testSuitesApi, 'getTestSuites');
+    getTestSuites.mockResolvedValue(singleTestSuite);
+
+    const postTestSessions = jest.spyOn(testSessionApi, 'postTestSessions');
+    postTestSessions.mockResolvedValue(testSession);
+
+    render(<App />);
+
+    // We have to wait for something to load so we don't get act()
+    // warnings.  The only thing rendered by App is children components.
+    // So await for those to be done with side effects (hooks).
+    await screen.findByText('Suite One');
+
+    expect(postTestSessions).toBeCalledTimes(1);
+  });
+});

--- a/client/src/store/app.ts
+++ b/client/src/store/app.ts
@@ -1,0 +1,22 @@
+import create from 'zustand';
+import { devtoolsInDev } from './devtools';
+
+import { TestSuite, TestSession } from '../models/testSuiteModels';
+
+type AppStore = {
+  testSuites: TestSuite[];
+  testSession: TestSession | undefined;
+  setTestSuites: (testSuites: TestSuite[]) => void;
+  setTestSession: (testSession: TestSession | undefined) => void;
+};
+
+// this store is for global state, things at the top level
+// other stores can be attached to child components
+export const useAppStore = create<AppStore>(
+  devtoolsInDev((set, _get) => ({
+    testSuites: [] as TestSuite[],
+    testSession: undefined,
+    setTestSuites: (testSuites: TestSuite[]) => set({ testSuites: testSuites }),
+    setTestSession: (testSession: TestSession | undefined) => set({ testSession: testSession }),
+  }))
+);

--- a/client/src/store/devtools.ts
+++ b/client/src/store/devtools.ts
@@ -1,0 +1,11 @@
+import { devtools } from 'zustand/middleware';
+
+// typing is tricky with devtools
+// modified from https://github.com/pmndrs/zustand/discussions/842
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export const devtoolsInDev = (process.env.NODE_ENV === 'development'
+  ? devtools
+  : (fn: any) => fn) as unknown as typeof devtools;
+/* eslint-enable @typescript-eslint/no-unsafe-return */
+/* eslint-enable @typescript-eslint/no-explicit-any */

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,8 @@
         "react-router-dom": "^5.2.0",
         "react-scripts": "5.0.0",
         "web-vitals": "^0.2.4",
-        "yaml": "^1.10.2"
+        "yaml": "^1.10.2",
+        "zustand": "^3.7.2"
       },
       "devDependencies": {
         "@babel/core": "^7.13.10",
@@ -23951,6 +23952,22 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zustand": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.2.tgz",
+      "integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==",
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
     }
   },
   "dependencies": {
@@ -41398,6 +41415,12 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+    },
+    "zustand": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.2.tgz",
+      "integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==",
+      "requires": {}
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "5.0.0",
     "web-vitals": "^0.2.4",
-    "yaml": "^1.10.2"
+    "yaml": "^1.10.2",
+    "zustand": "^3.7.2"
   },
   "scripts": {
     "start": "webpack serve --config ./webpack.config.js --mode=development",


### PR DESCRIPTION
* introduce the library
* create a store (for App only for the moment)
* move the App component to use Zustand instead of local hooks

The value of reducing prop drilling isn't realized with this small
change but it will avoid merge conflicts.