### PR TITLE
FI-1532: Handle results with missing runnables

### DIFF
--- a/config/presets/us_core_v311_reference_server_preset.json
+++ b/config/presets/us_core_v311_reference_server_preset.json
@@ -1,0 +1,36 @@
+{
+  "title": "Preset for US Core v3.1.1",
+  "id": null,
+  "test_suite_id": "us_core_v311",
+  "inputs": [
+    {
+      "name": "url",
+      "title": "FHIR Endpoint",
+      "description": "URL of the FHIR endpoint",
+      "type": "text",
+      "value": "https://inferno.healthit.gov/reference-server/r4"
+    },
+    {
+      "name": "smart_credentials",
+      "title": "OAuth Credentials",
+      "type": "oauth_credentials",
+      "optional": true,
+      "value": "{\"access_token\": \"SAMPLE_TOKEN\"}"
+    },
+    {
+      "name": "patient_ids",
+      "title": "Patient IDs",
+      "description": "Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements",
+      "type": "text",
+      "value": "85,355"
+    },
+    {
+      "name": "implantable_device_codes",
+      "title": "Implantable Device Type Code",
+      "description": "Enter the code for an Implantable Device type, or multiple codes separated by commas. If blank, Inferno will validate all Device resources against the Implantable Device profile",
+      "type": "text",
+      "optional": true,
+      "value": null
+    }
+  ]
+}

--- a/lib/inferno/entities/result.rb
+++ b/lib/inferno/entities/result.rb
@@ -60,7 +60,7 @@ module Inferno
       end
 
       def optional?
-        runnable.optional?
+        runnable.nil? || runnable.optional?
       end
 
       def required?

--- a/spec/inferno/web/serializers/result_spec.rb
+++ b/spec/inferno/web/serializers/result_spec.rb
@@ -23,5 +23,10 @@ RSpec.describe Inferno::Web::Serializers::Result do
     it 'does not raise an error' do
       expect { described_class.render(result) }.to_not raise_error
     end
+
+    it 'sets optional to true' do
+      serialized_result = JSON.parse(described_class.render(result))
+      expect(serialized_result['optional']).to eq(true)
+    end
   end
 end

--- a/spec/inferno/web/serializers/result_spec.rb
+++ b/spec/inferno/web/serializers/result_spec.rb
@@ -16,4 +16,12 @@ RSpec.describe Inferno::Web::Serializers::Result do
 
     expect(serialized_result['outputs'].first['type']).to eq('some_other_type')
   end
+
+  context 'when the runnable can not be found' do
+    before { allow(result).to receive(:runnable).and_return(nil) }
+
+    it 'does not raise an error' do
+      expect { described_class.render(result) }.to_not raise_error
+    end
+  end
 end


### PR DESCRIPTION
Fix an issue which causes an error when a result refers to a missing runnable. The runnable can be missing if it was removed or if its id changed. If the runnable is missing, `optional` is set to `true` on a result, since it can't be required if we don't even know what it's for.

How to test manually:
- `git checkout main`
- add `gem 'us_core_test_kit', '0.2.0'` to `Gemfile`
- `bundle`
- add `require 'us_core_test_kit'` to the top of `dev_suites/dev_demo_ig_stu1/demo_suite.rb`
- `npm run dev`
- run the Patient group
- stop inferno
- update the us core version to `0.2.1` in the `Gemfile`
- `bundle update us_core_test_kit`
- `npm run dev`
- reload your test session in the browser, and it should fail
- stop inferno
- `git stash`
- `git checkout handle-results-with-missing-runnables`
- `git stash pop`
- `npm run dev`
- reload your test session in the browser and it should succeed