### PR TITLE
FI-1538: Skip on missing request

### DIFF
--- a/lib/inferno/dsl/request_storage.rb
+++ b/lib/inferno/dsl/request_storage.rb
@@ -67,7 +67,9 @@ module Inferno
         self.class.named_requests_used.map do |request_name|
           request_alias = self.class.config.request_name(request_name)
           request = requests_repo.find_named_request(test_session_id, request_alias)
-          raise StandardError, "Unable to find '#{request_alias}' request" if request.nil?
+          if request.nil?
+            raise Exceptions::SkipException, "Request `#{request_alias}` was not made in a previous test as expected."
+          end
 
           requests << request
         end

--- a/spec/inferno/test_runner_spec.rb
+++ b/spec/inferno/test_runner_spec.rb
@@ -1,5 +1,3 @@
-# NOTE: These are basic placeholder specs to make sure we don't break this as we
-#   refactor.
 RSpec.describe Inferno::TestRunner do
   let(:runner) { described_class.new(test_session: test_session, test_run: test_run) }
   let(:test_session) { repo_create(:test_session, test_suite_id: 'demo') }
@@ -112,6 +110,21 @@ RSpec.describe Inferno::TestRunner do
       results = results_repo.current_results_for_test_session(test_session.id)
 
       expect(results.length).to eq(3)
+    end
+  end
+
+  describe 'when a request can not be loaded' do
+    let(:group) { DemoIG_STU1::DemoGroup }
+
+    it 'generates a skip result' do
+      test = DemoIG_STU1::DemoGroup.tests.find { |group_test| group_test.title == 'use named fhir request' }
+
+      runner.run(test)
+
+      results = results_repo.current_results_for_test_session(test_session.id)
+
+      expect(results.length).to eq(1)
+      expect(results.first.result).to eq('skip')
     end
   end
 end


### PR DESCRIPTION
This branch makes it so that if a named request can not be loaded, the test is skipped rather than generating a purple error.