### PR TITLE
Gem updates and factory_bot breaking change fix

### DIFF
--- a/lib/inferno/config/boot.rb
+++ b/lib/inferno/config/boot.rb
@@ -4,4 +4,4 @@ ENV['APP_ENV'] ||= 'development'
 
 root_path = Dir.pwd
 
-Dotenv.load(File.join(root_path, '.env'), File.join(root_path, ".env.#{ENV['APP_ENV']}"))
+Dotenv.load(File.join(root_path, '.env'), File.join(root_path, ".env.#{ENV.fetch('APP_ENV', nil)}"))

--- a/lib/inferno/config/boot/db.rb
+++ b/lib/inferno/config/boot/db.rb
@@ -11,7 +11,7 @@ Inferno::Application.boot(:db) do
 
     config_path = File.expand_path('database.yml', File.join(Dir.pwd, 'config'))
     config_contents = ERB.new(File.read(config_path)).result
-    config = YAML.safe_load(config_contents)[ENV['APP_ENV']]
+    config = YAML.safe_load(config_contents)[ENV.fetch('APP_ENV', nil)]
       .merge(logger: Inferno::Application['logger'])
     connection_attempts_remaining = ENV.fetch('MAX_DB_CONNECTION_ATTEMPTS', '10').to_i
     connection_retry_delay = ENV.fetch('DB_CONNECTION_RETRY_DELAY', '5').to_i

--- a/spec/inferno/web/serializers/result_spec.rb
+++ b/spec/inferno/web/serializers/result_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Inferno::Web::Serializers::Result do
 
     it 'sets optional to true' do
       serialized_result = JSON.parse(described_class.render(result))
-      expect(serialized_result['optional']).to eq(true)
+      expect(serialized_result['optional']).to be(true)
     end
   end
 end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -16,6 +16,12 @@ class CreateStrategy
 
     result
   end
+
+  # breaking change in factory_bot 6.2.1
+  # https://github.com/thoughtbot/factory_bot/issues/1536
+  def to_sym
+    :repo_create
+  end
 end
 
 FactoryBot.register_strategy(:repo_create, CreateStrategy)


### PR DESCRIPTION
This is the result of `bundle update` which I normally do not like to do but I wanted to see what would happen since internally someone had a stdlib/ruby compat issue.

There's a breaking change on a patch level semver bump on factory_bot ❔that is surprising but is fixed in this PR.  In case we need to move up a version for other reasons, this might be a useful PR and did not want to just throw this away.

Here is the summary from bundle update, skipping things that did not change:
```
Using public_suffix 4.0.7 (was 4.0.6)
Using simplecov_json_formatter 0.1.4 (was 0.1.3)
Fetching parallel 1.22.1 (was 1.21.0)
Fetching regexp_parser 2.3.1 (was 2.2.0)
Using i18n 1.10.0 (was 1.9.1)
Using sidekiq 6.4.2 (was 6.4.1)
Fetching nokogiri 1.13.5 (x86_64-darwin) (was 1.13.4)
Fetching parser 3.1.2.0 (was 3.1.0.0)
Using pry 0.14.1 (was 0.13.1)
Using pry-byebug 3.8.0 (was 3.9.0)
Fetching activesupport 6.1.5.1 (was 6.1.4.4)
Fetching database_cleaner-sequel 2.0.2 (was 2.0.0)
Fetching rspec-mocks 3.11.1 (was 3.11.0)
Installing parallel 1.22.1 (was 1.21.0)
Installing database_cleaner-sequel 2.0.2 (was 2.0.0)
Installing regexp_parser 2.3.1 (was 2.2.0)
Installing rspec-mocks 3.11.1 (was 3.11.0)
Installing activesupport 6.1.5.1 (was 6.1.4.4)
Fetching factory_bot 6.2.1 (was 6.2.0)
Installing parser 3.1.2.0 (was 3.1.0.0)
Installing factory_bot 6.2.1 (was 6.2.0)
Fetching rubocop-ast 1.17.0 (was 1.15.1)
Installing rubocop-ast 1.17.0 (was 1.15.1)
Fetching rubocop 1.29.0 (was 1.25.1)
Installing nokogiri 1.13.5 (x86_64-darwin) (was 1.13.4)
Installing rubocop 1.29.0 (was 1.25.1)
Fetching rubocop-rspec 2.10.0 (was 2.8.0)
Installing rubocop-rspec 2.10.0 (was 2.8.0)
```

Tests pass.