### PR TITLE
Fix TestSession height (masking as footer bug)

### DIFF
--- a/client/src/components/TestSuite/TestSession.tsx
+++ b/client/src/components/TestSuite/TestSession.tsx
@@ -273,10 +273,7 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
   const bannerHeight = document.getElementsByClassName('banner')[0]?.clientHeight;
 
   return (
-    <Box
-      className={styles.testSuiteMain}
-      maxHeight={`calc(100vh - 64px - 51px - ${bannerHeight}px)`}
-    >
+    <Box className={styles.testSuiteMain} height={`calc(100vh - 64px - 51px - ${bannerHeight}px)`}>
       {renderTestRunProgressBar()}
       <Drawer
         variant="permanent"


### PR DESCRIPTION
* use height instead of maxHeight to force the main section to push down
* tricky because dev server seems to hide this between git branches
* tested manually even with custom banner as described in README