### PR TITLE
Force sending Content-Type on landing pages for GitHub Codespaces.

### DIFF
--- a/lib/inferno/apps/web/router.rb
+++ b/lib/inferno/apps/web/router.rb
@@ -36,8 +36,10 @@ module Inferno
           get '/version', to: ->(_env) { [200, {}, [{ 'version' => Inferno::VERSION.to_s }.to_json]] }, as: :api_version
         end
 
-        get '/', to: ->(_env) { [200, {}, [client_page]] }
-        get '/test_sessions/:id', to: ->(_env) { [200, {}, [client_page]] }
+        # Should not need Content-Type header but GitHub Codespaces will not work without them.
+        # This could be investigated and likely removed if addressed properly elsewhere.
+        get '/', to: ->(_env) { [200, { 'Content-Type' => 'text/html' }, [client_page]] }
+        get '/test_sessions/:id', to: ->(_env) { [200, { 'Content-Type' => 'text/html' }, [client_page]] }
 
         Inferno.routes.each do |route|
           cleaned_id = route[:suite].id.gsub(/[^a-zA-Z\d\-._~]/, '_')


### PR DESCRIPTION
This is not an ideal fix but I am not sure if we should spend the effort right now figuring out exactly why CodeSpaces is acting weird here.  I'd like this as an option for DevDays in a few weeks and we have a lot of high priority things to work on.