### PR TITLE
Change TestListItem error and warning messages to be more readable

### DIFF
--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/MessageType.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/MessageType.tsx
@@ -1,0 +1,37 @@
+import { Typography } from '@mui/material';
+import React, { FC } from 'react';
+import clsx from 'clsx';
+import useStyles from './styles';
+
+import Dangerous from '@mui/icons-material/Dangerous';
+import Warning from '@mui/icons-material/Warning';
+import Info from '@mui/icons-material/Info';
+
+type MessageTypeProps = {
+  type: 'warning' | 'error' | 'info';
+};
+
+const MessageType: FC<MessageTypeProps> = ({ type }) => {
+  const styles = useStyles();
+  const style = styles[type];
+
+  let icon;
+  if (type === 'error') {
+    icon = <Dangerous className={style} />;
+  } else if (type === 'warning') {
+    icon = <Warning className={style} />;
+  } else if (type === 'info') {
+    icon = <Info className={style} />;
+  }
+
+  return (
+    <span>
+      {icon}
+      <Typography variant="caption" className={clsx([styles.messageTypeText, style])}>
+        {type}
+      </Typography>
+    </span>
+  );
+};
+
+export default MessageType;

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/MessageType.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/MessageType.tsx
@@ -3,7 +3,7 @@ import React, { FC } from 'react';
 import clsx from 'clsx';
 import useStyles from './styles';
 
-import Dangerous from '@mui/icons-material/Dangerous';
+import Cancel from '@mui/icons-material/Cancel';
 import Warning from '@mui/icons-material/Warning';
 import Info from '@mui/icons-material/Info';
 
@@ -17,7 +17,7 @@ const MessageType: FC<MessageTypeProps> = ({ type }) => {
 
   let icon;
   if (type === 'error') {
-    icon = <Dangerous className={style} />;
+    icon = <Cancel className={style} />;
   } else if (type === 'warning') {
     icon = <Warning className={style} />;
   } else if (type === 'info') {

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/MessagesList.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/MessagesList.tsx
@@ -4,6 +4,9 @@ import { Table, TableBody, TableRow, TableCell, Typography, TableHead, Box } fro
 import { Message } from 'models/testSuiteModels';
 import ReactMarkdown from 'react-markdown';
 
+import MessageType from './MessageType';
+import { sortByMessageType } from './helper';
+
 interface MessagesListProps {
   messages: Message[];
 }
@@ -24,12 +27,12 @@ const MessagesList: FC<MessagesListProps> = ({ messages }) => {
     </TableRow>
   );
 
-  const messageListItems = messages.map((message: Message, index: number) => {
+  const messageListItems = sortByMessageType(messages).map((message: Message, index: number) => {
     return (
       <TableRow key={`msgRow-${index}`}>
         <TableCell>
           <Typography variant="subtitle2" component="p" className={styles.bolderText}>
-            {message.type}:
+            <MessageType type={message.type} />
           </Typography>
         </TableCell>
         <TableCell className={styles.messageMessage}>

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/ProblemBadge.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/ProblemBadge.tsx
@@ -1,0 +1,55 @@
+import { Badge, SvgIconTypeMap, Tooltip } from '@mui/material';
+import { OverridableComponent } from '@mui/material/OverridableComponent';
+import React, { FC } from 'react';
+import clsx from 'clsx';
+import useStyles from './styles';
+
+type ProblemBadgeProps = {
+  Icon: OverridableComponent<SvgIconTypeMap<unknown, 'svg'>>;
+  counts: number;
+  color: string;
+  badgeStyle: string;
+  setPanelIndex: React.Dispatch<React.SetStateAction<number>>;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+const ProblemBadge: FC<ProblemBadgeProps> = ({
+  Icon,
+  counts,
+  color,
+  badgeStyle,
+  setPanelIndex,
+  setOpen,
+}) => {
+  const styles = useStyles();
+  return (
+    <Badge
+      badgeContent={counts}
+      overlap="circular"
+      className={clsx([color, badgeStyle, styles.badgeBase])}
+    >
+      <Tooltip describeChild title={`${counts} message(s)`}>
+        <Icon
+          aria-label={`View ${counts} message(s)`}
+          aria-hidden={false}
+          tabIndex={0}
+          className={clsx([styles.badgeIcon, styles.problemBadge, color])}
+          onClick={(e) => {
+            e.stopPropagation();
+            setPanelIndex(0);
+            setOpen(true);
+          }}
+          onKeyDown={(e) => {
+            e.stopPropagation();
+            if (e.key === 'Enter') {
+              setPanelIndex(0);
+              setOpen(true);
+            }
+          }}
+        />
+      </Tooltip>
+    </Badge>
+  );
+};
+
+export default ProblemBadge;

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/__tests__/helper.test.ts
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/__tests__/helper.test.ts
@@ -1,0 +1,29 @@
+import type { Message } from '../../../../../models/testSuiteModels';
+import { sortByMessageType, countMessageTypes } from '../helper';
+
+describe('TestListItem helpers', () => {
+  const messages = [
+    { message: 'Message One', type: 'info' },
+    { message: 'Message Two', type: 'info' },
+    { message: 'Message Three', type: 'warning' },
+    { message: 'Message Four', type: 'error' },
+    { message: 'Message Five', type: 'error' },
+  ] as Message[];
+
+  it('sorts messages by type', () => {
+    const expected = [
+      { message: 'Message Four', type: 'error' },
+      { message: 'Message Five', type: 'error' },
+      { message: 'Message Three', type: 'warning' },
+      { message: 'Message One', type: 'info' },
+      { message: 'Message Two', type: 'info' },
+    ];
+
+    expect(sortByMessageType(messages)).toStrictEqual(expected);
+  });
+
+  it('groups messages into count categories for the icon display', () => {
+    const expected = { errors: 2, warnings: 1, infos: 2 };
+    expect(countMessageTypes(messages)).toEqual(expected);
+  });
+});

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/helper.ts
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/helper.ts
@@ -1,0 +1,32 @@
+import type { Message } from '../../../../models/testSuiteModels';
+
+export type MessageCounts = {
+  errors: number;
+  warnings: number;
+  infos: number;
+};
+
+export const sortByMessageType = (messages: Message[]): Message[] => {
+  const sortOrder = ['error', 'warning', 'info'];
+
+  const sorted = messages.sort((a, b) => {
+    return sortOrder.indexOf(a.type) - sortOrder.indexOf(b.type);
+  });
+  return sorted;
+};
+
+const countType = (messages: Message[], type: string): number => {
+  return messages.filter((message) => message.type === type).length;
+};
+
+export const countMessageTypes = (messages: Message[]): MessageCounts => {
+  const error_count = countType(messages, 'error');
+  const warning_count = countType(messages, 'warning');
+  const info_count = countType(messages, 'info');
+
+  return {
+    errors: error_count,
+    warnings: warning_count,
+    infos: info_count,
+  };
+};

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/styles.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/styles.tsx
@@ -40,7 +40,7 @@ export default makeStyles((theme: Theme) => ({
     fontWeight: 'bolder',
   },
   messageMessage: {
-    width: '90%',
+    width: '82%',
     padding: '0 !important',
   },
   inputOutputsValue: {
@@ -112,5 +112,57 @@ export default makeStyles((theme: Theme) => ({
   },
   requestUrlContainer: {
     width: '100%',
+  },
+  messageTypeText: {
+    paddingLeft: '3px',
+    position: 'relative',
+    top: '-8px',
+    fontSize: '13px',
+  },
+  problemBadge: {
+    fontWeight: 'bold',
+    zIndex: '1',
+  },
+
+  // these colors are here for the badges as well as the messages column
+  error: {
+    color: '#F44336',
+  },
+  warning: {
+    color: '#F88B30',
+  },
+  info: {
+    color: theme.palette.info.dark,
+  },
+
+  // common styling for the badge component inside a ProblemBadge
+  badgeBase: {
+    '& .MuiBadge-badge': {
+      backgroundColor: 'white',
+      top: '22%',
+      right: '14px',
+      zIndex: '10',
+    },
+  },
+
+  // each badge component inside a ProblemBadge has its own color
+  // depending on severity
+  errorBadge: {
+    '& .MuiBadge-badge': {
+      color: theme.palette.error.main,
+      border: `1px solid ${theme.palette.error.main}`,
+    },
+  },
+  warningBadge: {
+    '& .MuiBadge-badge': {
+      color: theme.palette.warning.main,
+      border: `1px solid ${theme.palette.warning.main}`,
+    },
+  },
+  infoBadge: {
+    '& .MuiBadge-badge': {
+      color: theme.palette.info.dark,
+      border: `1px solid ${theme.palette.info.dark}`,
+    },
   },
 }));

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/styles.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/styles.tsx
@@ -122,6 +122,9 @@ export default makeStyles((theme: Theme) => ({
   problemBadge: {
     fontWeight: 'bold',
     zIndex: '1',
+    '&:focus': {
+      outline: 'none',
+    },
   },
 
   // these colors are here for the badges as well as the messages column


### PR DESCRIPTION
* only show errors and warnings, don't count info messages
* add colors and icons
* groups and sort messages by type
* extract out a "ProblemBadge" component to represent a more focused badge

## Before
![before](https://user-images.githubusercontent.com/45436454/169622121-76331e80-ea0c-47dc-b61b-bf829d23912e.jpg)

## After
![after](https://user-images.githubusercontent.com/45436454/169622152-8735481b-e003-430b-8494-3cc07470853e.jpg)

