### PR TITLE
Fix minor spacing issue.

### DIFF
--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupListItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupListItem.tsx
@@ -132,7 +132,7 @@ const TestGroupListItem: FC<TestGroupListItemProps> = ({
                     {testGroup.short_id && (
                       <Typography className={styles.shortId}>{testGroup.short_id}</Typography>
                     )}
-                    {testGroup.title}
+                    <Typography className={styles.labelText}>{testGroup.title}</Typography>
                   </>
                 }
                 secondary={testGroup.result?.result_message}

--- a/client/src/components/TestSuite/TestSuiteDetails/styles.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/styles.tsx
@@ -23,6 +23,9 @@ export default makeStyles((theme: Theme) => ({
     padding: '0 8px 0 0',
     display: 'inline-flex',
   },
+  labelText: {
+    display: 'inline',
+  },
   testGroupCardHeader: {
     padding: '8px 16px',
     fontWeight: 600,
@@ -52,6 +55,7 @@ export default makeStyles((theme: Theme) => ({
     fontWeight: 'bold',
     alignSelf: 'center',
     color: theme.palette.common.grayVeryDark,
+    padding: '0 4px 0 0', // Padding should not be necessary
   },
   testGroupCardHeaderButton: {
     minWidth: 'fit-content',


### PR DESCRIPTION
There is a spacing issue in Firefox in the current version that I was unable to determine an elegant fix for.

Before:
![Screen Shot 2022-05-23 at 4 19 54 PM](https://user-images.githubusercontent.com/412901/169906180-6d199277-d8dd-485f-a9a1-5bb35ae07e9d.png)

After:
![Screen Shot 2022-05-23 at 5 03 45 PM](https://user-images.githubusercontent.com/412901/169906217-5168f2e4-819a-4737-b283-e50843cfac45.png)


It is ugly enough that I think its worth having a bit of a CSS workaround here. I spend an hour or so debugging and couldn't find the answer, and it just doesn't seem worthwhile to spend much more time on it.

Before approving, check in Chrome to make sure that this isn't a Firefox-only thing.