### PR TITLE
feature/FI-1517-git-links

### DIFF
--- a/client/src/components/Footer/Footer.tsx
+++ b/client/src/components/Footer/Footer.tsx
@@ -10,9 +10,14 @@ interface FooterProps {
 
 const Footer: FC<FooterProps> = ({ version }) => {
   const styles = useStyles();
+  const linkList = [
+    { label: 'Open Source', url: 'https://github.com/inferno-framework/inferno-core' },
+    { label: 'Issues', url: 'https://github.com/inferno-framework/inferno-core/issues' },
+  ];
+
   return (
     <footer className={styles.footer}>
-      <Box display="flex" flexDirection="row" justifyContent="space-between">
+      <Box display="flex" flexDirection="row" justifyContent="space-between" overflow="auto">
         <Box display="flex" alignItems="center" px={2}>
           <Link
             href="https://inferno-framework.github.io/inferno-core"
@@ -38,25 +43,22 @@ const Footer: FC<FooterProps> = ({ version }) => {
           )}
         </Box>
         <Box display="flex" alignItems="center" p={2}>
-          <Link
-            href="https://inferno-framework.github.io/inferno-core"
-            target="_blank"
-            rel="noreferrer"
-            color="secondary"
-            className={styles.linkText}
-          >
-            Open Source
-          </Link>
-          <Divider orientation="vertical" flexItem />
-          <Link
-            href="https://inferno-framework.github.io/inferno-core"
-            target="_blank"
-            rel="noreferrer"
-            color="secondary"
-            className={styles.linkText}
-          >
-            Issues
-          </Link>
+          {linkList.map((link, i) => {
+            return (
+              <>
+                <Link
+                  href={link.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  color="secondary"
+                  className={styles.linkText}
+                >
+                  {link.label}
+                </Link>
+                {i !== linkList.length - 1 && <Divider orientation="vertical" flexItem />}
+              </>
+            );
+          })}
         </Box>
       </Box>
     </footer>

--- a/client/src/components/Footer/Footer.tsx
+++ b/client/src/components/Footer/Footer.tsx
@@ -50,7 +50,7 @@ const Footer: FC<FooterProps> = ({ version }) => {
                   href={link.url}
                   target="_blank"
                   rel="noreferrer"
-                  color="secondary"
+                  underline="hover"
                   className={styles.linkText}
                 >
                   {link.label}

--- a/client/src/components/Footer/Footer.tsx
+++ b/client/src/components/Footer/Footer.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 import useStyles from './styles';
-import { Container, Box, Link, Typography } from '@mui/material';
+import { Box, Link, Typography, Divider } from '@mui/material';
 import logo from 'images/inferno_logo.png';
 import { getStaticPath } from 'api/infernoApiService';
 
@@ -12,11 +12,8 @@ const Footer: FC<FooterProps> = ({ version }) => {
   const styles = useStyles();
   return (
     <footer className={styles.footer}>
-      <Container>
-        <Box className={styles.builtUsingContainer}>
-          <Typography variant="overline" className={styles.footerText}>
-            built using
-          </Typography>
+      <Box display="flex" flexDirection="row" justifyContent="space-between">
+        <Box display="flex" alignItems="center" px={2}>
           <Link
             href="https://inferno-framework.github.io/inferno-core"
             target="_blank"
@@ -30,12 +27,38 @@ const Footer: FC<FooterProps> = ({ version }) => {
             />
           </Link>
           {version && (
-            <Typography variant="overline" className={styles.footerText}>
-              {`version ${version}`}
-            </Typography>
+            <Box display="flex" flexDirection="column">
+              <Typography className={styles.logoText} style={{ fontSize: '0.7rem' }}>
+                Built with
+              </Typography>
+              <Typography className={styles.logoText} style={{ fontSize: '0.9rem' }}>
+                {`v.${version}`}
+              </Typography>
+            </Box>
           )}
         </Box>
-      </Container>
+        <Box display="flex" alignItems="center" p={2}>
+          <Link
+            href="https://inferno-framework.github.io/inferno-core"
+            target="_blank"
+            rel="noreferrer"
+            color="secondary"
+            className={styles.linkText}
+          >
+            Open Source
+          </Link>
+          <Divider orientation="vertical" flexItem />
+          <Link
+            href="https://inferno-framework.github.io/inferno-core"
+            target="_blank"
+            rel="noreferrer"
+            color="secondary"
+            className={styles.linkText}
+          >
+            Issues
+          </Link>
+        </Box>
+      </Box>
     </footer>
   );
 };

--- a/client/src/components/Footer/styles.tsx
+++ b/client/src/components/Footer/styles.tsx
@@ -12,25 +12,26 @@ export default makeStyles((theme: Theme) => ({
     backgroundColor: theme.palette.common.orangeLightest,
     position: 'sticky',
     bottom: 0,
-    '& .MuiContainer-root': {
-      display: 'flex',
-      justifyContent: 'center',
-    },
     '@media print': {
       display: 'none',
     },
   },
-  builtUsingContainer: {
-    display: 'flex',
-    alignItems: 'center',
-    flexDirection: 'row',
-  },
   logo: {
     objectFit: 'contain',
-    height: '2.5em',
+    height: '3em',
+    padding: '4px 8px 4px 0',
   },
-  footerText: {
+  logoText: {
     fontStyle: 'italic',
-    padding: '11px 12px 8px 8px',
+    textTransform: 'uppercase',
+  },
+  linkText: {
+    fontWeight: 'bolder',
+    fontSize: '1.1rem',
+    margin: '0 16px',
+    textDecoration: 'none',
+    '&:hover': {
+      textDecoration: 'underline',
+    },
   },
 }));

--- a/client/src/components/Footer/styles.tsx
+++ b/client/src/components/Footer/styles.tsx
@@ -29,9 +29,6 @@ export default makeStyles((theme: Theme) => ({
     fontWeight: 'bolder',
     fontSize: '1.1rem',
     margin: '0 16px',
-    textDecoration: 'none',
-    '&:hover': {
-      textDecoration: 'underline',
-    },
+    color: theme.palette.common.grayDark,
   },
 }));


### PR DESCRIPTION
Updates the footer styles to accommodate links (currently using repository and issues links).

<img width="726" alt="new-footer" src="https://user-images.githubusercontent.com/11209247/172703263-02834442-5351-47d6-ba2d-2baeb31acb1c.png">

