### PR TITLE
Change usage of zustand store to be more precise

### DIFF
--- a/client/src/components/App/App.tsx
+++ b/client/src/components/App/App.tsx
@@ -12,8 +12,10 @@ import { basePath } from 'api/infernoApiService';
 import { useAppStore } from '../../store/app';
 
 const App: FC<unknown> = () => {
-  const { testSuites, setTestSuites } = useAppStore();
-  const { testSession, setTestSession } = useAppStore();
+  const testSuites = useAppStore((state) => state.testSuites);
+  const setTestSuites = useAppStore((state) => state.setTestSuites);
+  const testSession = useAppStore((state) => state.testSession);
+  const setTestSession = useAppStore((state) => state.setTestSession);
 
   useEffect(() => {
     getTestSuites()


### PR DESCRIPTION
Fetching everything from the store will cause unnecessary rerenders. Doing it this way will be a good example for the future.  Have to be careful about selectors in Redux too.

Additionally, not all this scope is needed but this is the easiest
to read.  `setTestSuites` is used on one location and could be moved into the first useEffect().  Until we get used to a global store,
this might be the most familiar way to do it for now.