### PR TITLE
Make `selected_suite_options` argument of `children` optional

### DIFF
--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -398,7 +398,7 @@ module Inferno
         @suite_option_requirements = suite_option_requirements
       end
 
-      def children(selected_suite_options)
+      def children(selected_suite_options = nil)
         return all_children if selected_suite_options.blank?
 
         all_children.select do |child|


### PR DESCRIPTION
# Summary
Makes the `selected_suite_options` argument of `children` optional.

Previously, `children` was a private attribute that took no arguments. This will allow code that used `children` in this way to continue to function properly.

e.g. This specialized g10 test filtering code:
https://github.com/onc-healthit/onc-certification-g10-test-kit/blob/63eac95deedf9d9ee6a9d5f9df8e32dde70f684f/lib/onc_certification_g10_test_kit/single_patient_api_group.rb#L86

# Testing

1. Uncomment the g10 test kit from the Gemfile
2. Uncomment `require_relative` of the g10 test kit in `demo_suite.rb`
3. run bundle install and then `npm run dev`

The following error will be thrown without the change included in this PR:

```shell
/inferno-core/lib/inferno/dsl/runnable.rb:401:in `children': wrong number of arguments (given 0, expected 1) (ArgumentError)
    from .../gems/onc_certification_g10_test_kit-2.2.1/lib/onc_certification_g10_test_kit/single_patient_api_group.rb:86
```