### PR TITLE
FI-1590: Suite options JSON API

### DIFF
--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -589,18 +589,16 @@ definitions:
       description:
         type: "string"
       value:
-        type: "string
+        type: "string"
       list_options:
         type: "array"
         items:
           type: "object"
           properties:
-            type: "object"
-            properties:
-              label:
-                type: "string"
-              value:
-                type: "string"
+            label:
+              type: "string"
+            value:
+              type: "string"
   TestGroup:
     type: "object"
     required:

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -572,6 +572,33 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/PresetSummary"
+      suite_options:
+        tye: "array"
+        items:
+          $ref: "#/definitions/SuiteOption"
+  SuiteOption:
+    type: "object"
+    required:
+    - "id"
+    - "list_options"
+    properties:
+      id:
+        type: "string"
+      title:
+        type: "string"
+      description:
+        type: "string"
+      list_options:
+        type: "array"
+        items:
+          type: "object"
+          properties:
+            type: "object"
+            properties:
+              label:
+                type: "string"
+              value:
+                type: "string"
   TestGroup:
     type: "object"
     required:

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -342,8 +342,8 @@ paths:
         "404":
           description: "HTTP request not found"
   /version:
-    get: 
-      tags: 
+    get:
+      tags:
       - "Version"
       summary: "Get the version of Inferno currently being queried."
       produces:
@@ -351,9 +351,9 @@ paths:
       responses:
         "200":
           description: "success"
-          schema: 
-            $ref: "#/definitions/Version" 
-            
+          schema:
+            $ref: "#/definitions/Version"
+
 definitions:
   TestSession:
     type: "object"
@@ -372,6 +372,10 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/Result"
+      suite_options:
+        type: "array"
+        items:
+          $ref: "#/definitions/SuiteOption"
   TestRun:
     type: "object"
     required:
@@ -573,25 +577,26 @@ definitions:
         items:
           $ref: "#/definitions/PresetSummary"
       suite_options:
-        tye: "array"
+        type: "array"
         items:
           $ref: "#/definitions/SuiteOption"
   SuiteOption:
     type: "object"
-    required:
-    - "id"
-    - "list_options"
     properties:
       id:
         type: "string"
+        readOnly: true
       title:
         type: "string"
+        readOnly: true
       description:
         type: "string"
+        readOnly: true
       value:
         type: "string"
       list_options:
         type: "array"
+        readOnly: true
         items:
           type: "object"
           properties:

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -588,6 +588,8 @@ definitions:
         type: "string"
       description:
         type: "string"
+      value:
+        type: "string
       list_options:
         type: "array"
         items:

--- a/lib/inferno/apps/web/controllers/test_sessions/create.rb
+++ b/lib/inferno/apps/web/controllers/test_sessions/create.rb
@@ -3,7 +3,7 @@ module Inferno
     module Controllers
       module TestSessions
         class Create < Controller
-          PARAMS = [:test_suite_id].freeze
+          PARAMS = [:test_suite_id, :suite_options].freeze
 
           def call(params)
             session = repo.create(create_params(params))

--- a/lib/inferno/apps/web/serializers/suite_option.rb
+++ b/lib/inferno/apps/web/serializers/suite_option.rb
@@ -1,0 +1,13 @@
+module Inferno
+  module Web
+    module Serializers
+      class SuiteOption < Serializer
+        identifier :id
+        field :title, if: :field_present?
+        field :description, if: :field_present?
+        field :list_options, if: :field_present?
+        field :value, if: :field_present?
+      end
+    end
+  end
+end

--- a/lib/inferno/apps/web/serializers/test_group.rb
+++ b/lib/inferno/apps/web/serializers/test_group.rb
@@ -15,8 +15,12 @@ module Inferno
         field :user_runnable?, name: :user_runnable
         field :optional?, name: :optional
 
-        association :groups, name: :test_groups, blueprint: TestGroup
-        association :tests, blueprint: Test
+        field :test_groups do |group, options|
+          TestGroup.render_as_hash(group.groups(options[:suite_options]))
+        end
+        field :tests do |group, options|
+          Test.render_as_hash(group.tests(options[:suite_options]))
+        end
         field :available_inputs, name: :inputs, extractor: HashValueExtractor, blueprint: Input
         field :output_definitions, name: :outputs, extractor: HashValueExtractor
       end

--- a/lib/inferno/apps/web/serializers/test_session.rb
+++ b/lib/inferno/apps/web/serializers/test_session.rb
@@ -7,6 +7,7 @@ module Inferno
         identifier :id
 
         field :test_suite_id
+        field :suite_options, extractor: HashValueExtractor
 
         association :test_suite, blueprint: TestSuite, view: :full
         # association :test_runs, blueprint: TestRun

--- a/lib/inferno/apps/web/serializers/test_session.rb
+++ b/lib/inferno/apps/web/serializers/test_session.rb
@@ -7,11 +7,18 @@ module Inferno
         identifier :id
 
         field :test_suite_id
-        field :suite_options, extractor: HashValueExtractor
+        field :suite_options do |session, _options|
+          (session.suite_options.presence || {}).each_with_object([]) do |(key, value), formatted_options|
+            formatted_options << {
+              id: key,
+              value: value
+            }
+          end
+        end
 
-        association :test_suite, blueprint: TestSuite, view: :full
-        # association :test_runs, blueprint: TestRun
-        # association :results, blueprint: Result
+        field :test_suite do |session, _options|
+          TestSuite.render_as_hash(session.test_suite, view: :full, suite_options: session.suite_options)
+        end
       end
     end
   end

--- a/lib/inferno/apps/web/serializers/test_session.rb
+++ b/lib/inferno/apps/web/serializers/test_session.rb
@@ -1,3 +1,4 @@
+require_relative 'suite_option'
 require_relative 'test_suite'
 
 module Inferno
@@ -7,14 +8,7 @@ module Inferno
         identifier :id
 
         field :test_suite_id
-        field :suite_options do |session, _options|
-          (session.suite_options.presence || {}).each_with_object([]) do |(key, value), formatted_options|
-            formatted_options << {
-              id: key,
-              value: value
-            }
-          end
-        end
+        association :suite_options, blueprint: SuiteOption
 
         field :test_suite do |session, _options|
           TestSuite.render_as_hash(session.test_suite, view: :full, suite_options: session.suite_options)

--- a/lib/inferno/apps/web/serializers/test_suite.rb
+++ b/lib/inferno/apps/web/serializers/test_suite.rb
@@ -11,7 +11,7 @@ module Inferno
           field :input_instructions
           field :test_count
           field :version
-          field :suite_options, extractor: HashValueExtractor
+          association :suite_options, blueprint: SuiteOption
           association :presets, view: :summary, blueprint: Preset
         end
 

--- a/lib/inferno/apps/web/serializers/test_suite.rb
+++ b/lib/inferno/apps/web/serializers/test_suite.rb
@@ -17,7 +17,9 @@ module Inferno
 
         view :full do
           include_view :summary
-          association :groups, name: :test_groups, blueprint: TestGroup
+          field :test_groups do |suite, options|
+            TestGroup.render_as_hash(suite.groups(options[:suite_options]))
+          end
           field :configuration_messages
           field :available_inputs, name: :inputs, extractor: HashValueExtractor, blueprint: Input
         end

--- a/lib/inferno/apps/web/serializers/test_suite.rb
+++ b/lib/inferno/apps/web/serializers/test_suite.rb
@@ -11,6 +11,7 @@ module Inferno
           field :input_instructions
           field :test_count
           field :version
+          field :suite_options, extractor: HashValueExtractor
           association :presets, view: :summary, blueprint: Preset
         end
 

--- a/lib/inferno/db/migrations/007_add_suite_options.rb
+++ b/lib/inferno/db/migrations/007_add_suite_options.rb
@@ -1,0 +1,5 @@
+Sequel.migration do
+  change do
+    add_column :test_sessions, :suite_options, String, text: true, size: 255
+  end
+end

--- a/lib/inferno/db/schema.rb
+++ b/lib/inferno/db/schema.rb
@@ -9,6 +9,7 @@ Sequel.migration do
       String :test_suite_id, :size=>255, :null=>false
       DateTime :created_at, :null=>false
       DateTime :updated_at, :null=>false
+      String :suite_options, :text=>true
       
       primary_key [:id]
     end

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -379,7 +379,7 @@ module Inferno
       end
 
       # @private
-      def test_count(selected_suite_options = {})
+      def test_count(selected_suite_options = [])
         @test_counts ||= {}
 
         @test_counts[selected_suite_options] ||=
@@ -395,17 +395,23 @@ module Inferno
       end
 
       def required_suite_options(suite_option_requirements)
-        @suite_option_requirements = suite_option_requirements
+        @suite_option_requirements =
+          suite_option_requirements.map do |key, value|
+            DSL::SuiteOption.new(id: key, value: value)
+          end
       end
 
-      def children(selected_suite_options = nil)
+      def children(selected_suite_options = [])
         return all_children if selected_suite_options.blank?
 
         all_children.select do |child|
-          requirements = child.suite_option_requirements || {}
+          requirements = child.suite_option_requirements
 
-          # requirements are a subset of selected options or equal to selected options
-          selected_suite_options >= requirements
+          if requirements.blank?
+            true
+          else
+            requirements.all? { |requirement| selected_suite_options.include? requirement }
+          end
         end
       end
     end

--- a/lib/inferno/dsl/suite_option.rb
+++ b/lib/inferno/dsl/suite_option.rb
@@ -1,0 +1,40 @@
+require_relative '../entities/attributes'
+
+module Inferno
+  module DSL
+    class SuiteOption
+      ATTRIBUTES = [
+        :id,
+        :title,
+        :description,
+        :list_options,
+        :value
+      ].freeze
+
+      include Entities::Attributes
+
+      def initialize(raw_params)
+        params = raw_params.deep_symbolize_keys
+        bad_params = params.keys - ATTRIBUTES
+
+        raise Exceptions::UnknownAttributeException.new(bad_params, self.class) if bad_params.present?
+
+        params
+          .compact
+          .each { |key, value| send("#{key}=", value) }
+
+        self.id = id.to_sym if id.is_a? String
+      end
+
+      def ==(other)
+        id == other.id && value == other.value
+      end
+
+      def to_hash
+        self.class::ATTRIBUTES.each_with_object({}) do |attribute, hash|
+          hash[attribute] = send(attribute)
+        end.compact
+      end
+    end
+  end
+end

--- a/lib/inferno/entities/test_group.rb
+++ b/lib/inferno/entities/test_group.rb
@@ -31,12 +31,12 @@ module Inferno
           Inferno::Repositories::TestGroups.new
         end
 
-        def groups
-          all_children.select { |child| child < Inferno::Entities::TestGroup }
+        def groups(options = nil)
+          children(options).select { |child| child < Inferno::Entities::TestGroup }
         end
 
-        def tests
-          all_children.select { |child| child < Inferno::Entities::Test }
+        def tests(options = nil)
+          children(options).select { |child| child < Inferno::Entities::Test }
         end
 
         # Methods to configure Inferno::DSL::Runnable

--- a/lib/inferno/entities/test_session.rb
+++ b/lib/inferno/entities/test_session.rb
@@ -37,10 +37,6 @@ module Inferno
 
       def initialize(params)
         super(params, ATTRIBUTES)
-
-        self.suite_options = JSON.parse(suite_options)&.deep_symbolize_keys if suite_options.is_a? String
-
-        self.suite_options ||= {}
       end
 
       def to_hash
@@ -48,9 +44,15 @@ module Inferno
           hash[attribute] = send(attribute)
         end
 
-        session_hash[:suite_options] = JSON.generate(suite_options)
+        session_hash[:suite_options] = JSON.generate(suite_options&.map(&:to_hash) || [])
 
         session_hash.compact
+      end
+
+      def suite_options_hash
+        (suite_options || []).each_with_object({}) do |option, hash|
+          hash[option.id] = option.value
+        end
       end
     end
   end

--- a/lib/inferno/entities/test_session.rb
+++ b/lib/inferno/entities/test_session.rb
@@ -44,7 +44,7 @@ module Inferno
           hash[attribute] = send(attribute)
         end
 
-        session_hash[:suite_options] = JSON.generate(suite_options&.map(&:to_hash) || [])
+        session_hash[:suite_options] = suite_options&.map(&:to_hash) || []
 
         session_hash.compact
       end

--- a/lib/inferno/entities/test_session.rb
+++ b/lib/inferno/entities/test_session.rb
@@ -38,9 +38,9 @@ module Inferno
       def initialize(params)
         super(params, ATTRIBUTES)
 
-        if suite_options.is_a? String # rubocop:disable Style/GuardClause
-          self.suite_options = JSON.parse(suite_options)&.deep_symbolize_keys
-        end
+        self.suite_options = JSON.parse(suite_options)&.deep_symbolize_keys if suite_options.is_a? String
+
+        self.suite_options ||= {}
       end
 
       def to_hash

--- a/lib/inferno/entities/test_session.rb
+++ b/lib/inferno/entities/test_session.rb
@@ -37,6 +37,20 @@ module Inferno
 
       def initialize(params)
         super(params, ATTRIBUTES)
+
+        if suite_options.is_a? String # rubocop:disable Style/GuardClause
+          self.suite_options = JSON.parse(suite_options)&.deep_symbolize_keys
+        end
+      end
+
+      def to_hash
+        session_hash = (self.class::ATTRIBUTES - [:suite_options]).each_with_object({}) do |attribute, hash|
+          hash[attribute] = send(attribute)
+        end
+
+        session_hash[:suite_options] = JSON.generate(suite_options)
+
+        session_hash.compact
       end
     end
   end

--- a/lib/inferno/entities/test_suite.rb
+++ b/lib/inferno/entities/test_suite.rb
@@ -86,7 +86,7 @@ module Inferno
         end
 
         def suite_option(identifier, **input_params)
-          suite_options[identifier] = input_params
+          suite_options[identifier] = input_params.merge(id: identifier)
         end
 
         def suite_options

--- a/lib/inferno/entities/test_suite.rb
+++ b/lib/inferno/entities/test_suite.rb
@@ -30,8 +30,8 @@ module Inferno
           Inferno::Repositories::TestSuites.new
         end
 
-        def groups
-          all_children.select { |child| child < Inferno::Entities::TestGroup }
+        def groups(options = nil)
+          children(options).select { |child| child < Inferno::Entities::TestGroup }
         end
 
         # Methods to configure Inferno::DSL::Runnable

--- a/lib/inferno/entities/test_suite.rb
+++ b/lib/inferno/entities/test_suite.rb
@@ -1,5 +1,6 @@
 require_relative 'test_group'
 require_relative '../dsl/runnable'
+require_relative '../dsl/suite_option'
 require_relative '../repositories/test_groups'
 require_relative '../repositories/test_suites'
 
@@ -86,11 +87,11 @@ module Inferno
         end
 
         def suite_option(identifier, **input_params)
-          suite_options[identifier] = input_params.merge(id: identifier)
+          suite_options << DSL::SuiteOption.new(input_params.merge(id: identifier))
         end
 
         def suite_options
-          @suite_options ||= {}
+          @suite_options ||= []
         end
       end
     end

--- a/lib/inferno/repositories/test_sessions.rb
+++ b/lib/inferno/repositories/test_sessions.rb
@@ -37,6 +37,18 @@ module Inferno
         end
       end
 
+      def build_entity(params)
+        suite_options = JSON.parse(params[:suite_options] || '[]').map do |suite_option_hash|
+          suite_option_hash.deep_symbolize_keys!
+          suite_option_hash[:id] = suite_option_hash[:id].to_sym
+          DSL::SuiteOption.new(suite_option_hash)
+        end
+
+        final_params = params.merge(suite_options: suite_options)
+        add_non_db_entities(final_params)
+        entity_class.new(final_params)
+      end
+
       class Model < Sequel::Model(db)
         include Import[test_suites_repo: 'repositories.test_suites']
 

--- a/lib/inferno/repositories/test_sessions.rb
+++ b/lib/inferno/repositories/test_sessions.rb
@@ -19,6 +19,18 @@ module Inferno
         }
       end
 
+      def create(params)
+        raw_suite_options = params[:suite_options]
+        suite_options =
+          if raw_suite_options.blank?
+            '[]'
+          else
+            JSON.generate(raw_suite_options.map(&:to_hash))
+          end
+
+        super(params.merge(suite_options: suite_options))
+      end
+
       def results_for_test_session(test_session_id)
         test_session_hash =
           self.class::Model

--- a/lib/inferno/test_runner.rb
+++ b/lib/inferno/test_runner.rb
@@ -67,7 +67,7 @@ module Inferno
           inputs: inputs,
           test_session_id: test_session.id,
           scratch: scratch,
-          suite_options: test_session.suite_options
+          suite_options: test_session.suite_options_hash
         )
 
       result = begin

--- a/spec/inferno/dsl/runnable_spec.rb
+++ b/spec/inferno/dsl/runnable_spec.rb
@@ -114,9 +114,11 @@ RSpec.describe Inferno::DSL::Runnable do
         total_count = suite.test_count
         v1_count = v1_group.test_count
         v2_count = v2_group.test_count
+        v1_option = Inferno::DSL::SuiteOption.new(id: :ig_version, value: '1')
+        v2_option = Inferno::DSL::SuiteOption.new(id: :ig_version, value: '2')
 
-        expect(suite.test_count(ig_version: '1')).to eq(total_count - v2_count)
-        expect(suite.test_count(ig_version: '2')).to eq(total_count - v1_count)
+        expect(suite.test_count([v1_option])).to eq(total_count - v2_count)
+        expect(suite.test_count([v2_option])).to eq(total_count - v1_count)
       end
     end
   end

--- a/spec/inferno/test_runner_spec.rb
+++ b/spec/inferno/test_runner_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe Inferno::TestRunner do
     let(:suite) { OptionsSuite::Suite }
 
     it 'only runs groups which should be included based on options' do
-      test_session.suite_options = { ig_version: '1' }
+      test_session.suite_options = [Inferno::DSL::SuiteOption.new(id: :ig_version, value: '1')]
 
       runner.run(suite)
 
@@ -156,7 +156,7 @@ RSpec.describe Inferno::TestRunner do
     end
 
     it 'makes suite options available to tests' do
-      test_session.suite_options = { ig_version: '1' }
+      test_session.suite_options = [Inferno::DSL::SuiteOption.new(id: :ig_version, value: '1')]
 
       runner.run(suite)
 

--- a/spec/inferno/web/serializers/test_session_spec.rb
+++ b/spec/inferno/web/serializers/test_session_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Inferno::Web::Serializers::TestSession do
   let(:test_session) { repo_create(:test_session, test_suite_id: 'options', suite_options: suite_options) }
-  let(:suite_options) { { ig_version: '1' } }
+  let(:suite_options) { [Inferno::DSL::SuiteOption.new(id: :ig_version, value: '1')] }
 
   it 'serializes a test session' do
     serialized_session = JSON.parse(described_class.render(test_session))
@@ -12,7 +12,11 @@ RSpec.describe Inferno::Web::Serializers::TestSession do
       expect(serialized_session[key]).to eq(test_session.send(key))
     end
 
-    expect(serialized_session['suite_options']).to eq([{ 'id' => 'ig_version', 'value' => '1' }])
+    serialized_options = serialized_session['suite_options'].map do |option_hash|
+      Inferno::DSL::SuiteOption.new(option_hash.deep_symbolize_keys)
+    end
+
+    expect(serialized_options).to eq(suite_options)
 
     serialized_suite = JSON.parse(
       Inferno::Web::Serializers::TestSuite.render(

--- a/spec/inferno/web/serializers/test_session_spec.rb
+++ b/spec/inferno/web/serializers/test_session_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe Inferno::Web::Serializers::TestSession do
+  let(:test_session) { repo_create(:test_session, test_suite_id: 'options', suite_options: suite_options) }
+  let(:suite_options) { { ig_version: { value: '1' } } }
+
+  it 'serializes a test session' do
+    serialized_session = JSON.parse(described_class.render(test_session))
+
+    expected_keys = ['id', 'suite_options', 'test_suite', 'test_suite_id']
+
+    expect(serialized_session.keys).to match_array(expected_keys)
+    (expected_keys - ['suite_options', 'test_suite']).each do |key|
+      expect(serialized_session[key]).to eq(test_session.send(key))
+    end
+
+    expect(serialized_session['suite_options']).to eq(suite_options.values.map(&:deep_stringify_keys))
+
+    serialized_suite = JSON.parse(Inferno::Web::Serializers::TestSuite.render(test_session.test_suite, view: :full))
+    expect(serialized_session['test_suite']).to eq(serialized_suite)
+  end
+end

--- a/spec/inferno/web/serializers/test_session_spec.rb
+++ b/spec/inferno/web/serializers/test_session_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Inferno::Web::Serializers::TestSession do
   let(:test_session) { repo_create(:test_session, test_suite_id: 'options', suite_options: suite_options) }
-  let(:suite_options) { { ig_version: { value: '1' } } }
+  let(:suite_options) { { ig_version: '1' } }
 
   it 'serializes a test session' do
     serialized_session = JSON.parse(described_class.render(test_session))
@@ -12,9 +12,17 @@ RSpec.describe Inferno::Web::Serializers::TestSession do
       expect(serialized_session[key]).to eq(test_session.send(key))
     end
 
-    expect(serialized_session['suite_options']).to eq(suite_options.values.map(&:deep_stringify_keys))
+    expect(serialized_session['suite_options']).to eq([{ 'id' => 'ig_version', 'value' => '1' }])
 
-    serialized_suite = JSON.parse(Inferno::Web::Serializers::TestSuite.render(test_session.test_suite, view: :full))
+    serialized_suite = JSON.parse(
+      Inferno::Web::Serializers::TestSuite.render(
+        test_session.test_suite,
+        view: :full,
+        suite_options: test_session.suite_options
+      )
+    )
+
     expect(serialized_session['test_suite']).to eq(serialized_suite)
+    expect(serialized_session['test_suite']['test_groups'].length).to eq(2)
   end
 end

--- a/spec/inferno/web/serializers/test_suite_spec.rb
+++ b/spec/inferno/web/serializers/test_suite_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe Inferno::Web::Serializers::TestSuite do
       'input_instructions',
       'test_count',
       'version',
-      'presets'
+      'presets',
+      'suite_options'
     ]
   end
   let(:full_keys) do


### PR DESCRIPTION
This branch adds support for suite options to the JSON API. Options defined in suites are serialized to the front end, and options can be chosen for a particular test session. When retrieving a test session, the included test suite will be filtered according to the selected suite options.