### PR TITLE
FI-1474: Apply inputs/outputs defined after creation to children

### DIFF
--- a/lib/inferno/dsl/input_output_handling.rb
+++ b/lib/inferno/dsl/input_output_handling.rb
@@ -57,10 +57,20 @@ module Inferno
           [identifier, *other_identifiers].compact.each do |output_identifier|
             outputs << output_identifier
             config.add_output(output_identifier)
+            children
+              .reject { |child| child.outputs.include? output_identifier }
+              .each do |child|
+                child.output(output_identifier)
+              end
           end
         else
           outputs << identifier
           config.add_output(identifier, output_definition)
+          children
+            .reject { |child| child.outputs.include? identifier }
+            .each do |child|
+              child.output(identifier, **output_definition)
+            end
         end
       end
 

--- a/lib/inferno/dsl/input_output_handling.rb
+++ b/lib/inferno/dsl/input_output_handling.rb
@@ -24,10 +24,20 @@ module Inferno
           [identifier, *other_identifiers].compact.each do |input_identifier|
             inputs << input_identifier
             config.add_input(input_identifier)
+            children
+              .reject { |child| child.inputs.include? input_identifier }
+              .each do |child|
+                child.input(input_identifier)
+              end
           end
         else
           inputs << identifier
           config.add_input(identifier, input_params)
+          children
+            .reject { |child| child.inputs.include? identifier }
+            .each do |child|
+              child.input(identifier, **input_params)
+            end
         end
       end
 

--- a/lib/inferno/entities/test.rb
+++ b/lib/inferno/entities/test.rb
@@ -145,10 +145,12 @@ module Inferno
         # Define outputs for this Test
         #
         # @param output_definitions [Symbol]
+        # @param _output_params [Hash] Unused parameter. Just makes method
+        #   signature compatible with `Inferno::DSL::InputOutputHandling.output`
         # @return [void]
         # @example
         #   output :patient_id, :bearer_token
-        def output(*output_definitions)
+        def output(*output_definitions, **_output_params)
           super
 
           output_definitions.each do |output|

--- a/spec/inferno/dsl/input_output_handling_spec.rb
+++ b/spec/inferno/dsl/input_output_handling_spec.rb
@@ -150,4 +150,27 @@ RSpec.describe Inferno::DSL::InputOutputHandling do
       end
     end
   end
+
+  describe '.input' do
+    it 'adds the input to all children' do
+      group = Class.new(Inferno::TestGroup) do
+        input :a
+
+        test do
+          title 'child test'
+        end
+      end
+
+      group.children.each do |child|
+        expect(child.inputs).to include(:a)
+      end
+
+      group.input(:b, description: 'abc')
+
+      group.children.each do |child|
+        expect(child.inputs).to include(:b)
+        expect(child.config.input(:b).description).to eq('abc')
+      end
+    end
+  end
 end

--- a/spec/inferno/dsl/input_output_handling_spec.rb
+++ b/spec/inferno/dsl/input_output_handling_spec.rb
@@ -173,4 +173,27 @@ RSpec.describe Inferno::DSL::InputOutputHandling do
       end
     end
   end
+
+  describe '.output' do
+    it 'adds the output to all children' do
+      group = Class.new(Inferno::TestGroup) do
+        output :a
+
+        test do
+          title 'child test'
+        end
+      end
+
+      group.children.each do |child|
+        expect(child.outputs).to include(:a)
+      end
+
+      group.output(:b, type: :oauth_credentials)
+
+      group.children.each do |child|
+        expect(child.outputs).to include(:b)
+        expect(child.config.outputs[:b][:type]).to eq(:oauth_credentials)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Currently, a group's inputs/outputs are added to their children when the children are added. If an input/output is added after a child has been added, it is not added to that child. This branch fixes that issue. The particular use case is adding an input to an imported group which will be used by one of the tests within that group through a configuration option.

```ruby
group from: :some_group do
  # Prior to the fix in this branch, the input abc would not be
  # available to the tests in this group, so the a_proc option
  # would fail if a test tried to evaluate it
  input :abc
  config(
    options: {
      a_proc: -> {  "I'm a string containing #{abc}" }
    }
  )
end

```