### PR TITLE
Remove links for now because they point to a misleading place.

### DIFF
--- a/client/src/components/Footer/Footer.tsx
+++ b/client/src/components/Footer/Footer.tsx
@@ -4,16 +4,20 @@ import { Box, Link, Typography, Divider } from '@mui/material';
 import logo from '~/images/inferno_logo.png';
 import { getStaticPath } from '~/api/infernoApiService';
 
+// TODO: update linklist to retrieve this from the API as it should be defined by the suite
+// linkList has the shape:
+// [
+//   { label: 'Open Source', url: 'https://github.com/inferno-framework/inferno-core' },
+//   { label: 'Issues', url: 'https://github.com/inferno-framework/inferno-core/issues' },
+// ];
+
 interface FooterProps {
   version: string;
+  linkList?: any[];
 }
 
-const Footer: FC<FooterProps> = ({ version }) => {
+const Footer: FC<FooterProps> = ({ version, linkList }) => {
   const styles = useStyles();
-  const linkList = [
-    { label: 'Open Source', url: 'https://github.com/inferno-framework/inferno-core' },
-    { label: 'Issues', url: 'https://github.com/inferno-framework/inferno-core/issues' },
-  ];
 
   return (
     <footer className={styles.footer}>
@@ -42,8 +46,9 @@ const Footer: FC<FooterProps> = ({ version }) => {
             </Box>
           )}
         </Box>
+        { linkList && (
         <Box display="flex" alignItems="center" p={2}>
-          {linkList.map((link, i) => {
+          {linkList?.map((link, i) => {
             return (
               <React.Fragment key={link.url}>
                 <Link
@@ -60,6 +65,7 @@ const Footer: FC<FooterProps> = ({ version }) => {
             );
           })}
         </Box>
+        )}
       </Box>
     </footer>
   );


### PR DESCRIPTION
We probably shouldn't have merged the footer links change in (my fault!) because I'm concerned that linking users to report issues within the g10 test suite to inferno-core's issue location will be misleading.  I thought we would have some time to address this prior to release, but that isn't the case.  So for now, I'm just removing the default so no links show up, and we can add in suite-specific links in the next release.

This doesn't look great, but its either this, or back out the whole PR (which might be a pain), or not include a version update to inferno-core in the next g10 release, 
<img width="1162" alt="Screen Shot 2022-06-30 at 3 14 58 PM" src="https://user-images.githubusercontent.com/412901/176759632-2d158fa9-5bcc-465b-9002-7ef528bde047.png">
or include misleading links.

