### PR TITLE
FI-1608-options-ui Initial functional options UI

### DIFF
--- a/client/src/api/TestSessionApi.ts
+++ b/client/src/api/TestSessionApi.ts
@@ -1,4 +1,4 @@
-import { Result, TestGroup, TestOutput, TestRun, TestSession } from 'models/testSuiteModels';
+import { Result, TestGroup, TestOutput, TestRun, TestSession, SuiteOption } from 'models/testSuiteModels';
 import { getApiEndpoint } from './infernoApiService';
 
 export function getLastTestRun(test_session_id: string): Promise<TestRun | null> {
@@ -29,10 +29,15 @@ export function getTestSession(test_session_id: string): Promise<TestSession | n
     });
 }
 
-export function postTestSessions(testSuiteID: string): Promise<TestSession | null> {
+export function postTestSessions(testSuiteID: string, presetId: string | null, suiteOptions: SuiteOption[] | null): Promise<TestSession | null> {
   const testSuiteIDParameter = { name: 'test_suite_id', value: testSuiteID };
   const postEndpoint = getApiEndpoint('/test_sessions', [testSuiteIDParameter]);
-  return fetch(postEndpoint, { method: 'POST' })
+  const suiteOptionsPost = suiteOptions?.map((option) => {return {"id": option.id, "value": option.value}})
+  const postBody = {
+    preset_id: presetId,
+    suite_options: suiteOptionsPost
+  };
+  return fetch(postEndpoint, { method: 'POST', body: JSON.stringify(postBody) })
     .then((response) => response.json())
     .then((result) => {
       return result as TestSession;

--- a/client/src/api/TestSessionApi.ts
+++ b/client/src/api/TestSessionApi.ts
@@ -1,4 +1,11 @@
-import { Result, TestGroup, TestOutput, TestRun, TestSession, SuiteOption } from 'models/testSuiteModels';
+import {
+  Result,
+  TestGroup,
+  TestOutput,
+  TestRun,
+  TestSession,
+  SuiteOption,
+} from 'models/testSuiteModels';
 import { getApiEndpoint } from './infernoApiService';
 
 export function getLastTestRun(test_session_id: string): Promise<TestRun | null> {
@@ -29,13 +36,19 @@ export function getTestSession(test_session_id: string): Promise<TestSession | n
     });
 }
 
-export function postTestSessions(testSuiteID: string, presetId: string | null, suiteOptions: SuiteOption[] | null): Promise<TestSession | null> {
+export function postTestSessions(
+  testSuiteID: string,
+  presetId: string | null,
+  suiteOptions: SuiteOption[] | null
+): Promise<TestSession | null> {
   const testSuiteIDParameter = { name: 'test_suite_id', value: testSuiteID };
   const postEndpoint = getApiEndpoint('/test_sessions', [testSuiteIDParameter]);
-  const suiteOptionsPost = suiteOptions?.map((option) => {return {"id": option.id, "value": option.value}})
+  const suiteOptionsPost = suiteOptions?.map((option) => {
+    return { id: option.id, value: option.value };
+  });
   const postBody = {
     preset_id: presetId,
-    suite_options: suiteOptionsPost
+    suite_options: suiteOptionsPost,
   };
   return fetch(postEndpoint, { method: 'POST', body: JSON.stringify(postBody) })
     .then((response) => response.json())

--- a/client/src/components/App/App.tsx
+++ b/client/src/components/App/App.tsx
@@ -4,6 +4,7 @@ import { StyledEngineProvider } from '@mui/material/styles';
 import { postTestSessions } from '~/api/TestSessionApi';
 import { getTestSuites } from '~/api/TestSuitesApi';
 import LandingPage from '~/components/LandingPage';
+import SuiteOptionsPage from '~/components/SuiteOptionsPage'
 import TestSessionWrapper from '~/components/TestSuite/TestSessionWrapper';
 import ThemeProvider from '~/components/ThemeProvider';
 import { TestSession, TestSuite } from '~/models/testSuiteModels';
@@ -29,7 +30,7 @@ const App: FC<unknown> = () => {
 
   useEffect(() => {
     if (testSuites && testSuites.length == 1) {
-      postTestSessions(testSuites[0].id)
+      postTestSessions(testSuites[0].id, null, null)
         .then((testSession: TestSession | null) => {
           if (testSession && testSession.test_suite) {
             setTestSession(testSession);
@@ -59,6 +60,9 @@ const App: FC<unknown> = () => {
             </Route>
             <Route path="/test_sessions/:test_session_id">
               <TestSessionWrapper />
+            </Route>
+            <Route path="/:test_suite_id">
+              {testSuites.length > 1 && <SuiteOptionsPage testSuites={testSuites} />}
             </Route>
           </Switch>
         </ThemeProvider>

--- a/client/src/components/App/App.tsx
+++ b/client/src/components/App/App.tsx
@@ -4,7 +4,7 @@ import { StyledEngineProvider } from '@mui/material/styles';
 import { postTestSessions } from '~/api/TestSessionApi';
 import { getTestSuites } from '~/api/TestSuitesApi';
 import LandingPage from '~/components/LandingPage';
-import SuiteOptionsPage from '~/components/SuiteOptionsPage'
+import SuiteOptionsPage from '~/components/SuiteOptionsPage';
 import TestSessionWrapper from '~/components/TestSuite/TestSessionWrapper';
 import ThemeProvider from '~/components/ThemeProvider';
 import { TestSession, TestSuite } from '~/models/testSuiteModels';

--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -47,11 +47,7 @@ const Header: FC<HeaderProps> = ({
             <Typography variant="h5" component="h1" className={styles.title}>
               {suiteTitle}
             </Typography>
-            {suiteOptions && 
-              <Typography>
-                {suiteOptions}
-              </Typography>
-            }
+            {suiteOptions && <Typography>{suiteOptions}</Typography>}
             {suiteVersion && (
               <Typography variant="overline" className={styles.version}>
                 {`v.${suiteVersion}`}

--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -9,6 +9,7 @@ import { getStaticPath } from '~/api/infernoApiService';
 export interface HeaderProps {
   suiteTitle?: string;
   suiteVersion?: string;
+  suiteOptions?: string;
   drawerOpen: boolean;
   windowIsSmall: boolean;
   toggleDrawer: (drawerOpen: boolean) => void;
@@ -17,6 +18,7 @@ export interface HeaderProps {
 const Header: FC<HeaderProps> = ({
   suiteTitle,
   suiteVersion,
+  suiteOptions,
   windowIsSmall,
   drawerOpen,
   toggleDrawer,
@@ -45,6 +47,11 @@ const Header: FC<HeaderProps> = ({
             <Typography variant="h5" component="h1" className={styles.title}>
               {suiteTitle}
             </Typography>
+            {suiteOptions && 
+              <Typography>
+                {suiteOptions}
+              </Typography>
+            }
             {suiteVersion && (
               <Typography variant="overline" className={styles.version}>
                 {`v.${suiteVersion}`}

--- a/client/src/components/LandingPage/LandingPage.tsx
+++ b/client/src/components/LandingPage/LandingPage.tsx
@@ -23,16 +23,21 @@ const LandingPage: FC<LandingPageProps> = ({ testSuites }) => {
   const styles = useStyles();
   const history = useHistory();
 
-  function createTestSession(): void {
-    postTestSessions(testSuiteChosen)
-      .then((testSession: TestSession | null) => {
-        if (testSession && testSession.test_suite) {
-          history.push('test_sessions/' + testSession.id);
-        }
-      })
-      .catch((e) => {
-        console.log(e);
-      });
+  function startTestingClick(): void {
+    const testSuite = testSuites?.find((suite: TestSuite) => suite.id == testSuiteChosen);
+    if(testSuite && testSuite.suite_options && testSuite.suite_options.length > 0){
+        history.push(`${testSuiteChosen}`);
+    } else {
+      postTestSessions(testSuiteChosen, null, null)
+        .then((testSession: TestSession | null) => {
+          if (testSession && testSession.test_suite) {
+            history.push('test_sessions/' + testSession.id);
+          }
+        })
+        .catch((e) => {
+          console.log(e);
+        });
+    }
   }
 
   return (
@@ -81,7 +86,7 @@ const LandingPage: FC<LandingPageProps> = ({ testSuites }) => {
                   disabled={!testSuiteChosen}
                   data-testid="go-button"
                   className={styles.startTestingButton}
-                  onClick={() => createTestSession()}
+                  onClick={() => startTestingClick()}
                 >
                   Start Testing
                 </Button>

--- a/client/src/components/LandingPage/LandingPage.tsx
+++ b/client/src/components/LandingPage/LandingPage.tsx
@@ -25,8 +25,8 @@ const LandingPage: FC<LandingPageProps> = ({ testSuites }) => {
 
   function startTestingClick(): void {
     const testSuite = testSuites?.find((suite: TestSuite) => suite.id == testSuiteChosen);
-    if(testSuite && testSuite.suite_options && testSuite.suite_options.length > 0){
-        history.push(`${testSuiteChosen}`);
+    if (testSuite && testSuite.suite_options && testSuite.suite_options.length > 0) {
+      history.push(`${testSuiteChosen}`);
     } else {
       postTestSessions(testSuiteChosen, null, null)
         .then((testSession: TestSession | null) => {

--- a/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
+++ b/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
@@ -1,0 +1,123 @@
+import React, { FC } from 'react';
+import {
+  FormControl,
+  FormControlLabel,
+  FormLabel,
+  Typography,
+  Container,
+  Button,
+  Paper,
+  List,
+  Grid,
+  Radio,
+  RadioGroup
+} from '@mui/material';
+import useStyles from './styles';
+import { useHistory, useParams } from 'react-router-dom';
+import { postTestSessions } from '~/api/TestSessionApi';
+import { TestSuite, TestSession, SuiteOption } from '~/models/testSuiteModels';
+import ReactMarkdown from 'react-markdown';
+
+export interface SuiteOptionsPageProps {
+  testSuites: TestSuite[] | undefined;
+}
+
+const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuites }) => {
+  const styles = useStyles();
+  const history = useHistory();
+
+  const { test_suite_id } = useParams<{ test_suite_id: string }>();
+
+  const testSuite = testSuites?.find((suite: TestSuite) => suite.id == test_suite_id);
+  const initialSelectedSuiteOptions = (testSuite?.suite_options || []).map( (option) => {
+    return {...option, value: option && option.list_options && option.list_options[0].value}
+  });
+
+  const [selectedSuiteOptions, setSelectedSuiteOptions] = React.useState<SuiteOption[]>(initialSelectedSuiteOptions);
+
+  function changeSuiteOption(option_id: string, value: string): void {
+    const newOptions: SuiteOption[] = selectedSuiteOptions.map( (option) => {
+      if(option.id == option_id){
+        return {...option, value: value}
+      }
+      return {...option}
+    });
+    setSelectedSuiteOptions(newOptions);
+  }
+
+  function createTestSession(): void {
+    postTestSessions(test_suite_id, null, selectedSuiteOptions)
+      .then((testSession: TestSession | null) => {
+        if (testSession && testSession.test_suite) {
+          history.push('test_sessions/' + testSession.id);
+        }
+      })
+      .catch((e) => {
+        console.log(e);
+      });
+  }
+
+  return (
+    <Container maxWidth="lg" className={styles.main} role="main">
+      <Grid container spacing={6}>
+        <Grid container item xs={6}>
+          <Grid item>
+            <Typography variant="h2" component="h1">
+              { testSuite?.title }
+            </Typography>
+            <Typography variant="h5" component="h2">
+              <ReactMarkdown>{testSuite?.description || ''}</ReactMarkdown>
+            </Typography>
+          </Grid>
+        </Grid>
+        <Grid container item xs={6}>
+          <Grid item>
+            <Paper elevation={4} className={styles.startTesting}>
+              <Typography variant="h4" component="h2" align="center">
+                Select Options
+              </Typography>
+                {testSuite?.suite_options?.map((suiteOption: SuiteOption, i) => (
+                <FormControl
+                  fullWidth
+                  id={`suite-option-input-${i}`}
+                  key={`suite-form-control${i}`}>
+                  <FormLabel>{suiteOption.title}</FormLabel>
+                  <RadioGroup
+                    row
+                    aria-label={`suite-option-group-${suiteOption.id}`}
+                    defaultValue={suiteOption.list_options && suiteOption.list_options.length && suiteOption.list_options[0].value}
+                    name={`suite-option-group-${suiteOption.id}`}>
+                    {suiteOption && suiteOption.list_options && suiteOption.list_options.map((choice, k) => (
+                    <FormControlLabel 
+                      value={choice.value}
+                      control={<Radio size="small" />}
+                      label={choice.label} 
+                      key={`radio-button-${k}`}
+                      onClick = {()=> {changeSuiteOption(suiteOption.id, choice.value)}} />
+                    ))}
+                  </RadioGroup>
+                </FormControl>
+                ))}
+
+              <List>
+              </List>
+              <Button
+                variant="contained"
+                size="large"
+                color="primary"
+                fullWidth
+                data-testid="go-button"
+                className={styles.startTestingButton}
+                onClick={() => createTestSession()}
+              >
+                Start Testing
+              </Button>
+            </Paper>
+          </Grid>
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default SuiteOptionsPage;

--- a/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
+++ b/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
@@ -10,7 +10,7 @@ import {
   List,
   Grid,
   Radio,
-  RadioGroup
+  RadioGroup,
 } from '@mui/material';
 import useStyles from './styles';
 import { useHistory, useParams } from 'react-router-dom';
@@ -29,18 +29,24 @@ const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuites }) => {
   const { test_suite_id } = useParams<{ test_suite_id: string }>();
 
   const testSuite = testSuites?.find((suite: TestSuite) => suite.id == test_suite_id);
-  const initialSelectedSuiteOptions = (testSuite?.suite_options || []).map( (option) => {
-    return {...option, value: option && option.list_options && option.list_options[0].value}
+
+  // just grab the first to start
+  // perhaps choices should be persisted in the URL to make it easy to share specific
+  // options
+  const initialSelectedSuiteOptions = (testSuite?.suite_options || []).map((option) => {
+    return { id: option.id, value: option && option.list_options && option.list_options[0].value };
   });
 
-  const [selectedSuiteOptions, setSelectedSuiteOptions] = React.useState<SuiteOption[]>(initialSelectedSuiteOptions);
+  const [selectedSuiteOptions, setSelectedSuiteOptions] = React.useState<SuiteOption[]>(
+    initialSelectedSuiteOptions
+  );
 
   function changeSuiteOption(option_id: string, value: string): void {
-    const newOptions: SuiteOption[] = selectedSuiteOptions.map( (option) => {
-      if(option.id == option_id){
-        return {...option, value: value}
+    const newOptions: SuiteOption[] = selectedSuiteOptions.map((option) => {
+      if (option.id == option_id) {
+        return { id: option.id, value: value };
       }
-      return {...option}
+      return { ...option };
     });
     setSelectedSuiteOptions(newOptions);
   }
@@ -63,7 +69,7 @@ const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuites }) => {
         <Grid container item xs={6}>
           <Grid item>
             <Typography variant="h2" component="h1">
-              { testSuite?.title }
+              {testSuite?.title}
             </Typography>
             <Typography variant="h5" component="h2">
               <ReactMarkdown>{testSuite?.description || ''}</ReactMarkdown>
@@ -76,31 +82,41 @@ const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuites }) => {
               <Typography variant="h4" component="h2" align="center">
                 Select Options
               </Typography>
-                {testSuite?.suite_options?.map((suiteOption: SuiteOption, i) => (
+              {testSuite?.suite_options?.map((suiteOption: SuiteOption, i) => (
                 <FormControl
                   fullWidth
                   id={`suite-option-input-${i}`}
-                  key={`suite-form-control${i}`}>
+                  key={`suite-form-control${i}`}
+                >
                   <FormLabel>{suiteOption.title}</FormLabel>
                   <RadioGroup
                     row
                     aria-label={`suite-option-group-${suiteOption.id}`}
-                    defaultValue={suiteOption.list_options && suiteOption.list_options.length && suiteOption.list_options[0].value}
-                    name={`suite-option-group-${suiteOption.id}`}>
-                    {suiteOption && suiteOption.list_options && suiteOption.list_options.map((choice, k) => (
-                    <FormControlLabel 
-                      value={choice.value}
-                      control={<Radio size="small" />}
-                      label={choice.label} 
-                      key={`radio-button-${k}`}
-                      onClick = {()=> {changeSuiteOption(suiteOption.id, choice.value)}} />
-                    ))}
+                    defaultValue={
+                      suiteOption.list_options &&
+                      suiteOption.list_options.length &&
+                      suiteOption.list_options[0].value
+                    }
+                    name={`suite-option-group-${suiteOption.id}`}
+                  >
+                    {suiteOption &&
+                      suiteOption.list_options &&
+                      suiteOption.list_options.map((choice, k) => (
+                        <FormControlLabel
+                          value={choice.value}
+                          control={<Radio size="small" />}
+                          label={choice.label}
+                          key={`radio-button-${k}`}
+                          onClick={() => {
+                            changeSuiteOption(suiteOption.id, choice.value);
+                          }}
+                        />
+                      ))}
                   </RadioGroup>
                 </FormControl>
-                ))}
+              ))}
 
-              <List>
-              </List>
+              <List></List>
               <Button
                 variant="contained"
                 size="large"

--- a/client/src/components/SuiteOptionsPage/index.ts
+++ b/client/src/components/SuiteOptionsPage/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SuiteOptionsPage';

--- a/client/src/components/SuiteOptionsPage/styles.tsx
+++ b/client/src/components/SuiteOptionsPage/styles.tsx
@@ -1,0 +1,26 @@
+import { Theme } from '@mui/material/styles';
+
+import makeStyles from '@mui/styles/makeStyles';
+
+export default makeStyles((theme: Theme) => ({
+  container: {
+    backgroundColor: theme.palette.common.white,
+  },
+  main: {
+    height: '100%',
+    display: 'flex',
+    padding: '0 60px',
+  },
+  selectedItem: {
+    backgroundColor: 'rgba(248, 139, 48, 0.2) !important',
+  },
+  startTesting: {
+    marginTop: '20px',
+    padding: '20px',
+    borderRadius: '16px',
+    width: '400px',
+  },
+  startTestingButton: {
+    fontWeight: 600,
+  },
+}));

--- a/client/src/components/TestSuite/TestSessionWrapper.tsx
+++ b/client/src/components/TestSuite/TestSessionWrapper.tsx
@@ -111,8 +111,12 @@ const TestSessionWrapper: FC<unknown> = () => {
 
   if (testSession && testResults && sessionData) {
     let suiteOptionChoices = '';
-    if(testSession.suite_options){
-      suiteOptionChoices = testSession.suite_options.map((option) => {option.value}).join(' | ')
+    if (testSession.suite_options) {
+      suiteOptionChoices = testSession.suite_options
+        .map((option) => {
+          option.value;
+        })
+        .join(' | ');
     }
     return (
       <Box className={styles.testSessionContainer}>

--- a/client/src/components/TestSuite/TestSessionWrapper.tsx
+++ b/client/src/components/TestSuite/TestSessionWrapper.tsx
@@ -110,11 +110,16 @@ const TestSessionWrapper: FC<unknown> = () => {
   }
 
   if (testSession && testResults && sessionData) {
+    let suiteOptionChoices = '';
+    if(testSession.suite_options){
+      suiteOptionChoices = testSession.suite_options.map((option) => {option.value}).join(' | ')
+    }
     return (
       <Box className={styles.testSessionContainer}>
         <Header
           suiteTitle={testSession.test_suite.title}
           suiteVersion={testSession.test_suite.version}
+          suiteOptions={suiteOptionChoices}
           drawerOpen={drawerOpen}
           windowIsSmall={windowIsSmall}
           toggleDrawer={toggleDrawer}

--- a/client/src/models/testSuiteModels.ts
+++ b/client/src/models/testSuiteModels.ts
@@ -110,7 +110,7 @@ export interface TestSession {
   id: string;
   test_suite: TestSuite;
   test_suite_id: string;
-  suite_options: SuiteOption[];
+  suite_options?: SuiteOption[];
 }
 
 export enum RunnableType {

--- a/client/src/models/testSuiteModels.ts
+++ b/client/src/models/testSuiteModels.ts
@@ -103,12 +103,14 @@ export type TestSuite = Runnable & {
   configuration_messages?: Message[];
   version?: string;
   presets?: PresetSummary[];
+  suite_options?: SuiteOption[];
 };
 
 export interface TestSession {
   id: string;
   test_suite: TestSuite;
   test_suite_id: string;
+  suite_options: SuiteOption[];
 }
 
 export enum RunnableType {
@@ -140,4 +142,18 @@ export interface OAuthCredentials {
 export interface PresetSummary {
   id: string;
   title: string;
+}
+
+export interface SuiteOption {
+  id: string;
+  title?: string;
+  description?: string;
+  list_options?: SuiteOptionChoice[];
+  value?: string;
+}
+
+export interface SuiteOptionChoice {
+  label: string;
+  id: string;
+  value: string;
 }

--- a/dev_suites/dev_options_suite/options_suite.rb
+++ b/dev_suites/dev_options_suite/options_suite.rb
@@ -65,6 +65,21 @@ module OptionsSuite
   class Suite < Inferno::TestSuite
     title 'Options Suite'
     id :options
+    description %{
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua.
+      
+      Feugiat in ante metus dictum. Dignissim cras tincidunt lobortis feugiat.
+      Consequat mauris nunc congue nisi vitae suscipit tellus mauris. Venenatis
+      a condimentum vitae sapien pellentesque habitant morbi tristique senectus.
+
+      Faucibus scelerisque eleifend donec pretium vulputate sapien nec sagittis
+      aliquam. Nulla facilisi nullam vehicula ipsum a. Donec enim diam vulputate
+      ut. Ornare arcu dui vivamus arcu felis bibendum ut tristique et. Malesuada
+      fames ac turpis egestas maecenas pharetra convallis posuere morbi.
+
+
+    }
 
     validator required_suite_options: { ig_version: '1' } do
       url 'v1_validator'
@@ -85,6 +100,24 @@ module OptionsSuite
                    {
                      label: 'v2',
                      value: '2'
+                   }
+                 ]
+
+    suite_option :other_option,
+                 title: 'Another option',
+                 description: 'Another potential thing that could be used',
+                 list_options: [
+                   {
+                     label: 'option 1',
+                     value: '1'
+                   },
+                   {
+                     label: 'option 2',
+                     value: '2'
+                   },
+                   {
+                     label: 'option 3',
+                     value: '3'
                    }
                  ]
 

--- a/dev_suites/dev_options_suite/options_suite.rb
+++ b/dev_suites/dev_options_suite/options_suite.rb
@@ -65,10 +65,10 @@ module OptionsSuite
   class Suite < Inferno::TestSuite
     title 'Options Suite'
     id :options
-    description %{
+    description %(
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
       tempor incididunt ut labore et dolore magna aliqua.
-      
+
       Feugiat in ante metus dictum. Dignissim cras tincidunt lobortis feugiat.
       Consequat mauris nunc congue nisi vitae suscipit tellus mauris. Venenatis
       a condimentum vitae sapien pellentesque habitant morbi tristique senectus.
@@ -79,7 +79,7 @@ module OptionsSuite
       fames ac turpis egestas maecenas pharetra convallis posuere morbi.
 
 
-    }
+    )
 
     validator required_suite_options: { ig_version: '1' } do
       url 'v1_validator'

--- a/lib/inferno/apps/web/controllers/test_sessions/create.rb
+++ b/lib/inferno/apps/web/controllers/test_sessions/create.rb
@@ -5,7 +5,11 @@ module Inferno
         class Create < Controller
           PARAMS = [:test_suite_id, :suite_options].freeze
 
-          def call(params)
+          def call(raw_params)
+            query_params = raw_params.to_h
+            body_params = JSON.parse(request.body.string).symbolize_keys
+            params = query_params.merge(body_params)
+
             session = repo.create(create_params(params))
 
             repo.apply_preset(session.id, params[:preset_id]) if params[:preset_id].present?
@@ -21,7 +25,7 @@ module Inferno
           end
 
           def create_params(params)
-            params.to_h.slice(*PARAMS)
+            params.slice(*PARAMS)
           end
         end
       end

--- a/lib/inferno/apps/web/router.rb
+++ b/lib/inferno/apps/web/router.rb
@@ -51,6 +51,11 @@ module Inferno
             send(route[:method], path, to: route[:handler])
           end
         end
+
+        Inferno::Repositories::TestSuites.all.map{ |suite| "/#{suite.id}" }.each do |suite_path|
+          Application['logger'].info("Registering suite route: #{suite_path}")
+          get suite_path, to: ->(_env) { [200, {}, [client_page]] }
+        end
       end
     end
   end

--- a/lib/inferno/apps/web/router.rb
+++ b/lib/inferno/apps/web/router.rb
@@ -52,7 +52,7 @@ module Inferno
           end
         end
 
-        Inferno::Repositories::TestSuites.all.map{ |suite| "/#{suite.id}" }.each do |suite_path|
+        Inferno::Repositories::TestSuites.all.map { |suite| "/#{suite.id}" }.each do |suite_path|
           Application['logger'].info("Registering suite route: #{suite_path}")
           get suite_path, to: ->(_env) { [200, {}, [client_page]] }
         end


### PR DESCRIPTION
This is primary intended to be functional (and not pretty), to enable the functionality within the interface to choose options to aid continued development on test suites that need this.  It will also help us understand if this workflow is good enough to start or if we need to alter our strategy here substantially.

We have an explicit ticket to 'make this better looking', and to clean up the code. So as long as this meets the goal of enabling further development on the options feature 🔥 **_without affecting suites that do not use options_** :fire:, then it should be good enough.

The Landing Page will look the same:
<img width="1300" alt="Screen Shot 2022-07-01 at 3 10 04 PM" src="https://user-images.githubusercontent.com/412901/176956048-9d702259-92e3-459e-a48f-63c095a62c5a.png">

If (and only if) you choose a suite that has options, (such as the 'Options Suite'), you'll be presented with this additional screen (the lorem ipsum is in the description of the suite, not hardcoded):

<img width="1367" alt="Screen Shot 2022-07-01 at 3 11 51 PM" src="https://user-images.githubusercontent.com/412901/176956145-56bd5c27-e4a8-4888-becc-da4b3e84c745.png">

You should see a `suite_options` field being POSTED now.

~~Leaving as DRAFT because it looks like this is being posted correctly, but I'm not seeing data reflected back.  Will work with @Jammjammjamm to figure out what is wrong before during off 'DRAFT'.~~

@AlyssaWang feel free to take a look at the front-end code to make sure I'm not doing anything horribly wrong / backwards.  But we should get this quick and push off cleaning anything up until later.




