### PR TITLE
feature/FI-1610-options-display

### DIFF
--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -5,11 +5,12 @@ import { AppBar, Box, Button, IconButton, Toolbar, Typography } from '@mui/mater
 import { useHistory } from 'react-router-dom';
 import NoteAddIcon from '@mui/icons-material/NoteAdd';
 import { getStaticPath } from '~/api/infernoApiService';
+import { SuiteOptionChoice } from '~/models/testSuiteModels';
 
 export interface HeaderProps {
   suiteTitle?: string;
   suiteVersion?: string;
-  suiteOptions?: string;
+  suiteOptions?: SuiteOptionChoice[];
   drawerOpen: boolean;
   windowIsSmall: boolean;
   toggleDrawer: (drawerOpen: boolean) => void;
@@ -30,6 +31,11 @@ const Header: FC<HeaderProps> = ({
     history.push('/');
   };
 
+  const suiteOptionsString =
+    suiteOptions && suiteOptions.length > 0
+      ? ` - ${suiteOptions.map((option) => option.label).join(', ')}`
+      : '';
+
   return suiteTitle ? (
     <AppBar color="default" className={styles.appbar}>
       <Toolbar className={styles.toolbar}>
@@ -46,8 +52,8 @@ const Header: FC<HeaderProps> = ({
           <Box className={styles.titleContainer}>
             <Typography variant="h5" component="h1" className={styles.title}>
               {suiteTitle}
+              {suiteOptionsString}
             </Typography>
-            {suiteOptions && <Typography>{suiteOptions}</Typography>}
             {suiteVersion && (
               <Typography variant="overline" className={styles.version}>
                 {`v.${suiteVersion}`}

--- a/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
+++ b/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
@@ -63,6 +63,8 @@ const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuites }) => {
       });
   }
 
+  console.log(testSuite?.suite_options);
+
   return (
     <Container maxWidth="lg" className={styles.main} role="main">
       <Grid container spacing={6}>

--- a/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
+++ b/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
@@ -63,8 +63,6 @@ const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuites }) => {
       });
   }
 
-  console.log(testSuite?.suite_options);
-
   return (
     <Container maxWidth="lg" className={styles.main} role="main">
       <Grid container spacing={6}>

--- a/client/src/components/TestSuite/TestSessionWrapper.tsx
+++ b/client/src/components/TestSuite/TestSessionWrapper.tsx
@@ -134,10 +134,11 @@ const TestSessionWrapper: FC<unknown> = () => {
       );
     const parsedOptions = suiteOptionChoices
       ? testSession.suite_options
-          ?.map((option: SuiteOption) => {
-            const optionId = suiteOptionChoices[option.id];
-            return optionId.filter((choice: SuiteOptionChoice) => choice.value === option.value);
-          })
+          ?.map((option: SuiteOption) =>
+            suiteOptionChoices[option.id].filter(
+              (choice: SuiteOptionChoice) => choice.value === option.value
+            )
+          )
           .flat()
           .filter((v) => v) // Remove empty values
       : [];

--- a/client/src/components/TestSuite/TestSuiteTree/TestSuiteTree.tsx
+++ b/client/src/components/TestSuite/TestSuiteTree/TestSuiteTree.tsx
@@ -91,14 +91,14 @@ const TestSuiteTreeComponent: FC<TestSuiteTreeProps> = ({
         configMessages?.filter((message) => message.type === 'error').length > 0
       ) {
         configMessagesSeverityIcon = (
-          <ErrorOutlineIcon sx={{ color: lightTheme.palette.common.red }} />
+          <ErrorOutlineIcon sx={{ color: lightTheme.palette.error.main }} />
         );
       } else if (
         configMessages &&
         configMessages?.filter((message) => message.type === 'warning').length > 0
       ) {
         configMessagesSeverityIcon = (
-          <WarningAmberIcon sx={{ color: lightTheme.palette.common.orange }} />
+          <WarningAmberIcon sx={{ color: lightTheme.palette.warning.main }} />
         );
       }
 


### PR DESCRIPTION
Adds selected options to the header.

<img width="424" alt="Screen Shot 2022-07-13 at 12 48 06 PM" src="https://user-images.githubusercontent.com/11209247/178787815-f5e3d908-8ac5-4ce4-8cb2-0856855fb5c8.png">

***Note:*** Full option choice data isn't attached to the `testSession.suite_options` object so there's a bit of parsing to pull that info (specifically labels) directly from the `testSuite.suite_options` object. We might want to look into making that data more widely accessible.