### PR TITLE
FI-1638: Fix option filtering in serializers

### DIFF
--- a/dev_suites/dev_options_suite/options_suite.rb
+++ b/dev_suites/dev_options_suite/options_suite.rb
@@ -51,12 +51,16 @@ module OptionsSuite
       title 'All Versions Test 2'
       id :all_versions_test2
 
+      required_suite_options ig_version: '1'
+
       run { pass }
     end
 
     test do
       title 'All Versions Test 3'
       id :all_versions_test3
+
+      required_suite_options ig_version: '2'
 
       run { pass }
     end

--- a/lib/inferno/apps/web/serializers/test_group.rb
+++ b/lib/inferno/apps/web/serializers/test_group.rb
@@ -16,10 +16,12 @@ module Inferno
         field :optional?, name: :optional
 
         field :test_groups do |group, options|
-          TestGroup.render_as_hash(group.groups(options[:suite_options]))
+          suite_options = options[:suite_options]
+          TestGroup.render_as_hash(group.groups(suite_options), suite_options: suite_options)
         end
         field :tests do |group, options|
-          Test.render_as_hash(group.tests(options[:suite_options]))
+          suite_options = options[:suite_options]
+          Test.render_as_hash(group.tests(suite_options), suite_options: suite_options)
         end
         field :available_inputs, name: :inputs, extractor: HashValueExtractor, blueprint: Input
         field :output_definitions, name: :outputs, extractor: HashValueExtractor

--- a/lib/inferno/apps/web/serializers/test_suite.rb
+++ b/lib/inferno/apps/web/serializers/test_suite.rb
@@ -19,7 +19,8 @@ module Inferno
         view :full do
           include_view :summary
           field :test_groups do |suite, options|
-            TestGroup.render_as_hash(suite.groups(options[:suite_options]))
+            suite_options = options[:suite_options]
+            TestGroup.render_as_hash(suite.groups(suite_options), suite_options: suite_options)
           end
           field :configuration_messages
           field :available_inputs, name: :inputs, extractor: HashValueExtractor, blueprint: Input

--- a/spec/inferno/dsl/runnable_spec.rb
+++ b/spec/inferno/dsl/runnable_spec.rb
@@ -112,8 +112,8 @@ RSpec.describe Inferno::DSL::Runnable do
 
       it 'only counts the included runnables' do
         total_count = suite.test_count
-        v1_count = v1_group.test_count
-        v2_count = v2_group.test_count
+        v1_count = v1_group.test_count + 1
+        v2_count = v2_group.test_count + 1
         v1_option = Inferno::DSL::SuiteOption.new(id: :ig_version, value: '1')
         v2_option = Inferno::DSL::SuiteOption.new(id: :ig_version, value: '2')
 

--- a/spec/inferno/test_runner_spec.rb
+++ b/spec/inferno/test_runner_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe Inferno::TestRunner do
 
       results = results_repo.current_results_for_test_session(test_session.id)
 
-      expect(results.length).to eq(7)
+      expect(results.length).to eq(6)
 
       runnable_ids = results.map(&:runnable).map(&:id)
 

--- a/spec/inferno/web/serializers/test_session_spec.rb
+++ b/spec/inferno/web/serializers/test_session_spec.rb
@@ -28,5 +28,12 @@ RSpec.describe Inferno::Web::Serializers::TestSession do
 
     expect(serialized_session['test_suite']).to eq(serialized_suite)
     expect(serialized_session['test_suite']['test_groups'].length).to eq(2)
+
+    all_versions_group = serialized_session['test_suite']['test_groups'].first
+    all_versions_test_titles = all_versions_group['tests'].map { |test| test['title'] }
+
+    expect(all_versions_test_titles).to include('All Versions Test 1')
+    expect(all_versions_test_titles).to include('All Versions Test 2')
+    expect(all_versions_test_titles).to_not include('All Versions Test 3')
   end
 end


### PR DESCRIPTION
The `TestGroup` serializer was not correctly filtering its children based on suite options, so top level groups would be filtered correctly in the suite, but groups/tests further down were not being filtered.