### PR TITLE
feature/FI-1614-options-clean

### DIFF
--- a/client/src/components/LandingPage/LandingPage.tsx
+++ b/client/src/components/LandingPage/LandingPage.tsx
@@ -13,7 +13,7 @@ import { TestSuite, TestSession } from 'models/testSuiteModels';
 import useStyles from './styles';
 import { useHistory } from 'react-router-dom';
 import { postTestSessions } from 'api/TestSessionApi';
-import { useAppStore } from '../../store/app';
+import { useAppStore } from '~/store/app';
 
 export interface LandingPageProps {
   testSuites: TestSuite[] | undefined;
@@ -43,59 +43,57 @@ const LandingPage: FC<LandingPageProps> = ({ testSuites }) => {
   }
 
   return (
-    <>
-      <Container maxWidth="lg" className={styles.main} role="main">
-        <Box display="flex" flexDirection="column" m={2} maxWidth="440px">
-          <Typography variant="h2" component="h1">
-            FHIR Testing with Inferno
+    <Container maxWidth="lg" className={styles.main} role="main">
+      <Box display="flex" flexDirection="column" m={2} maxWidth="440px">
+        <Typography variant="h2" component="h1">
+          FHIR Testing with Inferno
+        </Typography>
+        <Typography variant="h5" component="h2">
+          Test your server's conformance to authentication, authorization, and FHIR content
+          standards.
+        </Typography>
+      </Box>
+      <Box display="flex" justifyContent="center" height="fit-content">
+        <Paper
+          elevation={4}
+          className={styles.getStarted}
+          sx={{ width: windowIsSmall ? 'auto' : '400px' }}
+        >
+          <Typography variant="h4" component="h2" align="center">
+            Select a Test Suite
           </Typography>
-          <Typography variant="h5" component="h2">
-            Test your server's conformance to authentication, authorization, and FHIR content
-            standards.
-          </Typography>
-        </Box>
-        <Box display="flex" justifyContent="center" height="fit-content">
-          <Paper
-            elevation={4}
-            className={styles.getStarted}
-            sx={{ width: windowIsSmall ? 'auto' : '400px' }}
+          <List>
+            {testSuites?.map((testSuite: TestSuite) => {
+              return (
+                // Use li to resolve a11y error
+                <li key={testSuite.id}>
+                  <ListItemButton
+                    data-testid="testing-suite-option"
+                    selected={testSuiteChosen === testSuite.id}
+                    onClick={() => setTestSuiteChosen(testSuite.id)}
+                    classes={{ selected: styles.selectedItem }}
+                  >
+                    <ListItemText primary={testSuite.title} />
+                  </ListItemButton>
+                </li>
+              );
+            })}
+          </List>
+          <Button
+            variant="contained"
+            size="large"
+            color="primary"
+            fullWidth
+            disabled={!testSuiteChosen}
+            data-testid="go-button"
+            className={styles.startTestingButton}
+            onClick={() => startTestingClick()}
           >
-            <Typography variant="h4" component="h2" align="center">
-              Select a Test Suite
-            </Typography>
-            <List>
-              {testSuites?.map((testSuite: TestSuite) => {
-                return (
-                  // Use li to resolve a11y error
-                  <li key={testSuite.id}>
-                    <ListItemButton
-                      data-testid="testing-suite-option"
-                      selected={testSuiteChosen === testSuite.id}
-                      onClick={() => setTestSuiteChosen(testSuite.id)}
-                      classes={{ selected: styles.selectedItem }}
-                    >
-                      <ListItemText primary={testSuite.title} />
-                    </ListItemButton>
-                  </li>
-                );
-              })}
-            </List>
-            <Button
-              variant="contained"
-              size="large"
-              color="primary"
-              fullWidth
-              disabled={!testSuiteChosen}
-              data-testid="go-button"
-              className={styles.startTestingButton}
-              onClick={() => startTestingClick()}
-            >
-              Start Testing
-            </Button>
-          </Paper>
-        </Box>
-      </Container>
-    </>
+            Start Testing
+          </Button>
+        </Paper>
+      </Box>
+    </Container>
   );
 };
 

--- a/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
+++ b/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
@@ -96,19 +96,17 @@ const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuites }) => {
                 }
                 name={`suite-option-group-${suiteOption.id}`}
               >
-                {suiteOption &&
-                  suiteOption.list_options &&
-                  suiteOption.list_options.map((choice, k) => (
-                    <FormControlLabel
-                      value={choice.value}
-                      control={<Radio size="small" />}
-                      label={choice.label}
-                      key={`radio-button-${k}`}
-                      onClick={() => {
-                        changeSuiteOption(suiteOption.id, choice.value);
-                      }}
-                    />
-                  ))}
+                {suiteOption?.list_options?.map((choice, k) => (
+                  <FormControlLabel
+                    value={choice.value}
+                    control={<Radio size="small" />}
+                    label={choice.label}
+                    key={`radio-button-${k}`}
+                    onClick={() => {
+                      changeSuiteOption(suiteOption.id, choice.value);
+                    }}
+                  />
+                ))}
               </RadioGroup>
             </FormControl>
           ))}

--- a/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
+++ b/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
@@ -11,18 +11,21 @@ import {
   Grid,
   Radio,
   RadioGroup,
+  Box,
 } from '@mui/material';
 import useStyles from './styles';
 import { useHistory, useParams } from 'react-router-dom';
 import { postTestSessions } from '~/api/TestSessionApi';
 import { TestSuite, TestSession, SuiteOption } from '~/models/testSuiteModels';
 import ReactMarkdown from 'react-markdown';
+import { useAppStore } from '~/store/app';
 
 export interface SuiteOptionsPageProps {
   testSuites: TestSuite[] | undefined;
 }
 
 const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuites }) => {
+  const windowIsSmall = useAppStore((state) => state.windowIsSmall);
   const styles = useStyles();
   const history = useHistory();
 
@@ -65,17 +68,83 @@ const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuites }) => {
 
   return (
     <Container maxWidth="lg" className={styles.main} role="main">
-      <Grid container spacing={6}>
-        <Grid container item xs={6}>
-          <Grid item>
-            <Typography variant="h2" component="h1">
-              {testSuite?.title}
-            </Typography>
-            <Typography variant="h5" component="h2">
-              <ReactMarkdown>{testSuite?.description || ''}</ReactMarkdown>
-            </Typography>
-          </Grid>
-        </Grid>
+      <Box display="flex" flexDirection="column" m={2} maxWidth="440px">
+        <Typography variant="h2" component="h1">
+          {testSuite?.title}
+        </Typography>
+        <Typography variant="h5" component="h2">
+          <ReactMarkdown>{testSuite?.description || ''}</ReactMarkdown>
+        </Typography>
+      </Box>
+      <Box display="flex" justifyContent="center" height="fit-content">
+        <Paper
+          elevation={4}
+          className={styles.startTesting}
+          sx={{ width: windowIsSmall ? 'auto' : '400px' }}
+        >
+          <Typography variant="h4" component="h2" align="center">
+            Select Options
+          </Typography>
+          {testSuite?.suite_options?.map((suiteOption: SuiteOption, i) => (
+            <FormControl fullWidth id={`suite-option-input-${i}`} key={`suite-form-control${i}`}>
+              <FormLabel>{suiteOption.title}</FormLabel>
+              <RadioGroup
+                row
+                aria-label={`suite-option-group-${suiteOption.id}`}
+                defaultValue={
+                  suiteOption.list_options &&
+                  suiteOption.list_options.length &&
+                  suiteOption.list_options[0].value
+                }
+                name={`suite-option-group-${suiteOption.id}`}
+              >
+                {suiteOption &&
+                  suiteOption.list_options &&
+                  suiteOption.list_options.map((choice, k) => (
+                    <FormControlLabel
+                      value={choice.value}
+                      control={<Radio size="small" />}
+                      label={choice.label}
+                      key={`radio-button-${k}`}
+                      onClick={() => {
+                        changeSuiteOption(suiteOption.id, choice.value);
+                      }}
+                    />
+                  ))}
+              </RadioGroup>
+            </FormControl>
+          ))}
+          {/* <List>
+            {testSuites?.map((testSuite: TestSuite) => {
+              return (
+                // Use li to resolve a11y error
+                <li key={testSuite.id}>
+                  <ListItemButton
+                    data-testid="testing-suite-option"
+                    selected={testSuiteChosen === testSuite.id}
+                    onClick={() => setTestSuiteChosen(testSuite.id)}
+                    classes={{ selected: styles.selectedItem }}
+                  >
+                    <ListItemText primary={testSuite.title} />
+                  </ListItemButton>
+                </li>
+              );
+            })}
+          </List> */}
+          <Button
+            variant="contained"
+            size="large"
+            color="primary"
+            fullWidth
+            data-testid="go-button"
+            className={styles.startTestingButton}
+            onClick={() => createTestSession()}
+          >
+            Start Testing
+          </Button>
+        </Paper>
+      </Box>
+      {/* <Grid container spacing={6}>
         <Grid container item xs={6}>
           <Grid item>
             <Paper elevation={4} className={styles.startTesting}>
@@ -117,21 +186,10 @@ const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuites }) => {
               ))}
 
               <List></List>
-              <Button
-                variant="contained"
-                size="large"
-                color="primary"
-                fullWidth
-                data-testid="go-button"
-                className={styles.startTestingButton}
-                onClick={() => createTestSession()}
-              >
-                Start Testing
-              </Button>
             </Paper>
           </Grid>
         </Grid>
-      </Grid>
+      </Grid> */}
     </Container>
   );
 };

--- a/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
+++ b/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
@@ -7,8 +7,6 @@ import {
   Container,
   Button,
   Paper,
-  List,
-  Grid,
   Radio,
   RadioGroup,
   Box,
@@ -114,23 +112,6 @@ const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuites }) => {
               </RadioGroup>
             </FormControl>
           ))}
-          {/* <List>
-            {testSuites?.map((testSuite: TestSuite) => {
-              return (
-                // Use li to resolve a11y error
-                <li key={testSuite.id}>
-                  <ListItemButton
-                    data-testid="testing-suite-option"
-                    selected={testSuiteChosen === testSuite.id}
-                    onClick={() => setTestSuiteChosen(testSuite.id)}
-                    classes={{ selected: styles.selectedItem }}
-                  >
-                    <ListItemText primary={testSuite.title} />
-                  </ListItemButton>
-                </li>
-              );
-            })}
-          </List> */}
           <Button
             variant="contained"
             size="large"
@@ -144,52 +125,6 @@ const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuites }) => {
           </Button>
         </Paper>
       </Box>
-      {/* <Grid container spacing={6}>
-        <Grid container item xs={6}>
-          <Grid item>
-            <Paper elevation={4} className={styles.startTesting}>
-              <Typography variant="h4" component="h2" align="center">
-                Select Options
-              </Typography>
-              {testSuite?.suite_options?.map((suiteOption: SuiteOption, i) => (
-                <FormControl
-                  fullWidth
-                  id={`suite-option-input-${i}`}
-                  key={`suite-form-control${i}`}
-                >
-                  <FormLabel>{suiteOption.title}</FormLabel>
-                  <RadioGroup
-                    row
-                    aria-label={`suite-option-group-${suiteOption.id}`}
-                    defaultValue={
-                      suiteOption.list_options &&
-                      suiteOption.list_options.length &&
-                      suiteOption.list_options[0].value
-                    }
-                    name={`suite-option-group-${suiteOption.id}`}
-                  >
-                    {suiteOption &&
-                      suiteOption.list_options &&
-                      suiteOption.list_options.map((choice, k) => (
-                        <FormControlLabel
-                          value={choice.value}
-                          control={<Radio size="small" />}
-                          label={choice.label}
-                          key={`radio-button-${k}`}
-                          onClick={() => {
-                            changeSuiteOption(suiteOption.id, choice.value);
-                          }}
-                        />
-                      ))}
-                  </RadioGroup>
-                </FormControl>
-              ))}
-
-              <List></List>
-            </Paper>
-          </Grid>
-        </Grid>
-      </Grid> */}
     </Container>
   );
 };

--- a/client/src/components/SuiteOptionsPage/styles.tsx
+++ b/client/src/components/SuiteOptionsPage/styles.tsx
@@ -9,16 +9,17 @@ export default makeStyles((theme: Theme) => ({
   main: {
     height: '100%',
     display: 'flex',
-    padding: '0 60px',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    justifyContent: 'space-evenly',
   },
   selectedItem: {
     backgroundColor: 'rgba(248, 139, 48, 0.2) !important',
   },
   startTesting: {
-    marginTop: '20px',
+    margin: '20px 0',
     padding: '20px',
     borderRadius: '16px',
-    width: '400px',
   },
   startTestingButton: {
     fontWeight: 600,

--- a/client/src/components/TestSuite/TestSession.tsx
+++ b/client/src/components/TestSuite/TestSession.tsx
@@ -25,7 +25,7 @@ import TestSuiteReport from './TestSuiteDetails/TestSuiteReport';
 import ConfigMessagesDetailsPanel from './ConfigMessagesDetails/ConfigMessagesDetailsPanel';
 import useStyles from './styles';
 
-import { useAppStore } from '../../store/app';
+import { useAppStore } from '~/store/app';
 
 function mapRunnableRecursive(testGroup: TestGroup, map: Map<string, Runnable>) {
   map.set(testGroup.id, testGroup);


### PR DESCRIPTION
Updates options page to use the same layout as the landing page. Redesign may come later, this is mainly for usability.

<img width="1192" alt="Screen Shot 2022-07-19 at 11 22 27 AM" src="https://user-images.githubusercontent.com/11209247/179787881-46ca0d63-e3be-4710-8571-8dc9c1e2fa54.png">

