### PR TITLE
Draft: feature/FI-1611-report-options

### DIFF
--- a/client/src/components/Footer/Footer.tsx
+++ b/client/src/components/Footer/Footer.tsx
@@ -3,17 +3,15 @@ import useStyles from './styles';
 import { Box, Link, Typography, Divider } from '@mui/material';
 import logo from '~/images/inferno_logo.png';
 import { getStaticPath } from '~/api/infernoApiService';
+import { FooterLink } from '~/models/testSuiteModels';
 
 interface FooterProps {
   version: string;
+  linkList?: FooterLink[];
 }
 
-const Footer: FC<FooterProps> = ({ version }) => {
+const Footer: FC<FooterProps> = ({ version, linkList }) => {
   const styles = useStyles();
-  const linkList = [
-    { label: 'Open Source', url: 'https://github.com/inferno-framework/inferno-core' },
-    { label: 'Issues', url: 'https://github.com/inferno-framework/inferno-core/issues' },
-  ];
 
   return (
     <footer className={styles.footer}>
@@ -42,23 +40,24 @@ const Footer: FC<FooterProps> = ({ version }) => {
             </Box>
           )}
         </Box>
-        <Box display="flex" alignItems="center" p={2}>
-          {linkList.map((link, i) => {
-            return (
-              <React.Fragment key={link.url}>
-                <Link
-                  href={link.url}
-                  target="_blank"
-                  rel="noreferrer"
-                  underline="hover"
-                  className={styles.linkText}
-                >
-                  {link.label}
-                </Link>
-                {i !== linkList.length - 1 && <Divider orientation="vertical" flexItem />}
-              </React.Fragment>
-            );
-          })}
+        <Box display="flex" alignItems="center" p={2} data-testid="footer-links">
+          {linkList &&
+            linkList.map((link, i) => {
+              return (
+                <React.Fragment key={link.url}>
+                  <Link
+                    href={link.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    underline="hover"
+                    className={styles.linkText}
+                  >
+                    {link.label}
+                  </Link>
+                  {i !== linkList.length - 1 && <Divider orientation="vertical" flexItem />}
+                </React.Fragment>
+              );
+            })}
         </Box>
       </Box>
     </footer>

--- a/client/src/components/Footer/__tests__/Footer.test.tsx
+++ b/client/src/components/Footer/__tests__/Footer.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import Footer from '..';
 import ThemeProvider from 'components/ThemeProvider';
 
@@ -9,4 +9,32 @@ test('renders Inferno Footer', () => {
       <Footer version={'dummyVersion'} />
     </ThemeProvider>
   );
+});
+
+test('has no links if not provided any', () => {
+  render(
+    <ThemeProvider>
+      <Footer version={'dummyVersion'} />
+    </ThemeProvider>
+  );
+
+  // testing a negative is nearly meaningless
+  const link = screen.queryByRole('link', { name: /Open Source/ });
+  expect(link).not.toBeInTheDocument();
+});
+
+test('can be given a list of links to display', () => {
+  const links = [
+    { label: 'One', url: 'http://one.com' },
+    { label: 'Two', url: 'http://two.com' },
+  ];
+
+  render(
+    <ThemeProvider>
+      <Footer version={'dummyVersion'} linkList={links} />
+    </ThemeProvider>
+  );
+
+  expect(screen.getByRole('link', { name: /One/ })).toHaveAttribute('href', 'http://one.com');
+  expect(screen.getByRole('link', { name: /Two/ })).toHaveAttribute('href', 'http://two.com');
 });

--- a/client/src/components/TestSuite/TestSessionWrapper.tsx
+++ b/client/src/components/TestSuite/TestSessionWrapper.tsx
@@ -127,7 +127,7 @@ const TestSessionWrapper: FC<unknown> = () => {
           getSessionData={tryGetSessionData}
           toggleDrawer={toggleDrawer}
         />
-        <Footer version={coreVersion} />
+        <Footer version={coreVersion} linkList={testSession.test_suite.links} />
       </Box>
     );
   } else if (

--- a/client/src/models/testSuiteModels.ts
+++ b/client/src/models/testSuiteModels.ts
@@ -104,6 +104,7 @@ export type TestSuite = Runnable & {
   version?: string;
   presets?: PresetSummary[];
   suite_options?: SuiteOption[];
+  links?: FooterLink[];
 };
 
 export interface TestSession {
@@ -157,3 +158,8 @@ export interface SuiteOptionChoice {
   id: string;
   value: string;
 }
+
+export type FooterLink = {
+  label: string;
+  url: string;
+};

--- a/dev_suites/dev_demo_ig_stu1/demo_suite.rb
+++ b/dev_suites/dev_demo_ig_stu1/demo_suite.rb
@@ -5,6 +5,16 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
   class DemoSuite < Inferno::TestSuite
     title 'Demonstration Suite'
     id 'demo'
+    links [
+      {
+        label: 'Open Source',
+        url: 'https://github.com/inferno-framework/inferno-core'
+      },
+      {
+        label: 'Issues',
+        url: 'https://github.com/inferno-framework/inferno-core/issues'
+      }
+    ]
 
     # Ideas:
     # * Suite metadata (name, associated ig, version, etc etc)

--- a/dev_suites/dev_infrastructure_test/infrastructure_test.rb
+++ b/dev_suites/dev_infrastructure_test/infrastructure_test.rb
@@ -17,6 +17,16 @@ module InfrastructureTest
       `code here`
     )
     version '42.0'
+    links [
+      {
+        label: 'Open Source',
+        url: 'https://github.com/inferno-framework/inferno-core'
+      },
+      {
+        label: 'Issues',
+        url: 'https://github.com/inferno-framework/inferno-core/issues'
+      }
+    ]
 
     input :suite_input
     output :suite_output

--- a/dev_suites/dev_options_suite/options_suite.rb
+++ b/dev_suites/dev_options_suite/options_suite.rb
@@ -51,12 +51,16 @@ module OptionsSuite
       title 'All Versions Test 2'
       id :all_versions_test2
 
+      required_suite_options ig_version: '1'
+
       run { pass }
     end
 
     test do
       title 'All Versions Test 3'
       id :all_versions_test3
+
+      required_suite_options ig_version: '2'
 
       run { pass }
     end

--- a/dev_suites/dev_options_suite/options_suite.rb
+++ b/dev_suites/dev_options_suite/options_suite.rb
@@ -80,6 +80,16 @@ module OptionsSuite
 
 
     )
+    links [
+      {
+        label: 'Open Source',
+        url: 'https://github.com/inferno-framework/inferno-core'
+      },
+      {
+        label: 'Issues',
+        url: 'https://github.com/inferno-framework/inferno-core/issues'
+      }
+    ]
 
     validator required_suite_options: { ig_version: '1' } do
       url 'v1_validator'

--- a/lib/inferno/apps/web/serializers/test_group.rb
+++ b/lib/inferno/apps/web/serializers/test_group.rb
@@ -16,10 +16,12 @@ module Inferno
         field :optional?, name: :optional
 
         field :test_groups do |group, options|
-          TestGroup.render_as_hash(group.groups(options[:suite_options]))
+          suite_options = options[:suite_options]
+          TestGroup.render_as_hash(group.groups(suite_options), suite_options: suite_options)
         end
         field :tests do |group, options|
-          Test.render_as_hash(group.tests(options[:suite_options]))
+          suite_options = options[:suite_options]
+          Test.render_as_hash(group.tests(suite_options), suite_options: suite_options)
         end
         field :available_inputs, name: :inputs, extractor: HashValueExtractor, blueprint: Input
         field :output_definitions, name: :outputs, extractor: HashValueExtractor

--- a/lib/inferno/apps/web/serializers/test_suite.rb
+++ b/lib/inferno/apps/web/serializers/test_suite.rb
@@ -19,7 +19,8 @@ module Inferno
         view :full do
           include_view :summary
           field :test_groups do |suite, options|
-            TestGroup.render_as_hash(suite.groups(options[:suite_options]))
+            suite_options = options[:suite_options]
+            TestGroup.render_as_hash(suite.groups(suite_options), suite_options: suite_options)
           end
           field :configuration_messages
           field :available_inputs, name: :inputs, extractor: HashValueExtractor, blueprint: Input

--- a/lib/inferno/apps/web/serializers/test_suite.rb
+++ b/lib/inferno/apps/web/serializers/test_suite.rb
@@ -11,6 +11,7 @@ module Inferno
           field :input_instructions
           field :test_count
           field :version
+          field :links
           association :suite_options, blueprint: SuiteOption
           association :presets, view: :summary, blueprint: Preset
         end

--- a/lib/inferno/entities/test_suite.rb
+++ b/lib/inferno/entities/test_suite.rb
@@ -93,6 +93,12 @@ module Inferno
         def suite_options
           @suite_options ||= []
         end
+
+        def links(links = nil)
+          return @links if links.nil?
+
+          @links = links
+        end
       end
     end
   end

--- a/spec/inferno/dsl/runnable_spec.rb
+++ b/spec/inferno/dsl/runnable_spec.rb
@@ -112,8 +112,8 @@ RSpec.describe Inferno::DSL::Runnable do
 
       it 'only counts the included runnables' do
         total_count = suite.test_count
-        v1_count = v1_group.test_count
-        v2_count = v2_group.test_count
+        v1_count = v1_group.test_count + 1
+        v2_count = v2_group.test_count + 1
         v1_option = Inferno::DSL::SuiteOption.new(id: :ig_version, value: '1')
         v2_option = Inferno::DSL::SuiteOption.new(id: :ig_version, value: '2')
 

--- a/spec/inferno/entities/test_suite_spec.rb
+++ b/spec/inferno/entities/test_suite_spec.rb
@@ -160,4 +160,23 @@ RSpec.describe Inferno::Entities::TestSuite do
       end
     end
   end
+
+  describe '.links' do
+    let(:links) do
+      [
+        { label: 'One', url: 'http://one.com' },
+        { label: 'Two', url: 'http://two.com' }
+      ]
+    end
+    let(:test_suite) do
+      suite_class.links links
+      suite_class
+    end
+
+    specify 'it can optionally have a list of http links for display' do
+      link = test_suite.links.first
+      expect(link[:label]).to eq('One')
+      expect(link[:url]).to eq('http://one.com')
+    end
+  end
 end

--- a/spec/inferno/test_runner_spec.rb
+++ b/spec/inferno/test_runner_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe Inferno::TestRunner do
 
       results = results_repo.current_results_for_test_session(test_session.id)
 
-      expect(results.length).to eq(7)
+      expect(results.length).to eq(6)
 
       runnable_ids = results.map(&:runnable).map(&:id)
 

--- a/spec/inferno/web/serializers/test_session_spec.rb
+++ b/spec/inferno/web/serializers/test_session_spec.rb
@@ -28,5 +28,12 @@ RSpec.describe Inferno::Web::Serializers::TestSession do
 
     expect(serialized_session['test_suite']).to eq(serialized_suite)
     expect(serialized_session['test_suite']['test_groups'].length).to eq(2)
+
+    all_versions_group = serialized_session['test_suite']['test_groups'].first
+    all_versions_test_titles = all_versions_group['tests'].map { |test| test['title'] }
+
+    expect(all_versions_test_titles).to include('All Versions Test 1')
+    expect(all_versions_test_titles).to include('All Versions Test 2')
+    expect(all_versions_test_titles).to_not include('All Versions Test 3')
   end
 end

--- a/spec/inferno/web/serializers/test_suite_spec.rb
+++ b/spec/inferno/web/serializers/test_suite_spec.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/hash/indifferent_access'
+
 RSpec.describe Inferno::Web::Serializers::TestSuite do
   let(:suite) { InfrastructureTest::Suite }
   let(:summary_keys) do
@@ -11,7 +13,8 @@ RSpec.describe Inferno::Web::Serializers::TestSuite do
       'test_count',
       'version',
       'presets',
-      'suite_options'
+      'suite_options',
+      'links'
     ]
   end
   let(:full_keys) do
@@ -53,6 +56,9 @@ RSpec.describe Inferno::Web::Serializers::TestSuite do
     expect(serialized_suite['version']).to eq(suite.version)
     expect(serialized_suite['configuration_messages']).to eq(expected_messages)
     expect(serialized_suite['presets']).to eq([])
+
+    expected_links = suite.links.map(&:with_indifferent_access)
+    expect(serialized_suite['links']).to eq(expected_links)
   end
 
   it 'includes preset summaries' do


### PR DESCRIPTION
Adds selected options to report view header.

This should be reviewed after feature/FI-1610-options-display is merged in. 

<img width="600" alt="Screen Shot 2022-07-19 at 11 25 20 AM" src="https://user-images.githubusercontent.com/11209247/179788606-480d6245-af0e-428b-9263-c0379032819d.png">

<img width="800" alt="Screen Shot 2022-07-19 at 11 25 31 AM" src="https://user-images.githubusercontent.com/11209247/179788634-a68bc0f2-98fa-4b0c-9c48-faacb99bcb8f.png">

