### PR TITLE
FI-1644: Input filtering

### DIFF
--- a/dev_suites/dev_infrastructure_test/serializer_test.rb
+++ b/dev_suites/dev_infrastructure_test/serializer_test.rb
@@ -5,10 +5,12 @@ module InfrastructureTest
     description 'TEST_DESCRIPTION'
 
     input :input1,
+          title: 'INPUT1_TITLE',
           description: 'INPUT1_DESCRIPTION',
           default: 'INPUT1_DEFAULT',
           type: 'text'
     input :input2,
+          title: 'INPUT2_TITLE',
           description: 'INPUT2_DESCRIPTION',
           default: 'INPUT2_DEFAULT',
           type: 'text'

--- a/dev_suites/dev_options_suite/options_suite.rb
+++ b/dev_suites/dev_options_suite/options_suite.rb
@@ -3,6 +3,8 @@ module OptionsSuite
     title 'V1 Group'
     id :v1_group
 
+    input :v1_input
+
     test do
       title 'V1 Test'
       id :v1_test
@@ -16,6 +18,8 @@ module OptionsSuite
   class V2Group < Inferno::TestGroup
     title 'V2 Group'
     id :v2_group
+
+    input :v2_input
 
     test do
       title 'V2 Test 1'

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -685,13 +685,13 @@ definitions:
         type: "string"
       value:
         type: "string"
-      label:
+      title:
         type: "string"
         readOnly: true
       description:
         type: "string"
         readOnly: true
-      required:
+      optional:
         type: "boolean"
         readOnly: true
       type:

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -697,6 +697,9 @@ definitions:
       type:
         type: "string"
         readOnly: true
+      locked:
+        type: "boolean"
+        readOnly: true
       options:
         type: "array"
         readOnly: true

--- a/lib/inferno/apps/web/controllers/test_runs/create.rb
+++ b/lib/inferno/apps/web/controllers/test_runs/create.rb
@@ -26,7 +26,7 @@ module Inferno
                   &.last
 
               if input.nil?
-                Inferno::Application['logger'].warning(
+                Inferno::Application['logger'].warn(
                   "Unknown input `#{input_params[:name]}` for #{test_run.runnable.id}: #{test_run.runnable.title}"
                 )
                 next

--- a/lib/inferno/apps/web/controllers/test_runs/create.rb
+++ b/lib/inferno/apps/web/controllers/test_runs/create.rb
@@ -11,8 +11,8 @@ module Inferno
 
           PARAMS = [:test_session_id, :test_suite_id, :test_group_id, :test_id].freeze
 
-          def verify_runnable(runnable, inputs)
-            missing_inputs = runnable&.missing_inputs(inputs)
+          def verify_runnable(runnable, inputs, selected_suite_options)
+            missing_inputs = runnable&.missing_inputs(inputs, selected_suite_options)
             user_runnable = runnable&.user_runnable?
             raise Inferno::Exceptions::RequiredInputsNotFound, missing_inputs if missing_inputs&.any?
             raise Inferno::Exceptions::NotUserRunnableException unless user_runnable
@@ -51,7 +51,11 @@ module Inferno
               return
             end
 
-            verify_runnable(repo.build_entity(create_params(params)).runnable, params[:inputs])
+            verify_runnable(
+              repo.build_entity(create_params(params)).runnable,
+              params[:inputs],
+              test_session.suite_options
+            )
 
             test_run = repo.create(create_params(params).merge(status: 'queued'))
 

--- a/lib/inferno/apps/web/serializers/input.rb
+++ b/lib/inferno/apps/web/serializers/input.rb
@@ -10,8 +10,9 @@ module Inferno
         field :description, if: :field_present?
         field :type, if: :field_present?
         field :default, if: :field_present?
-        field :options, if: :field_present?
         field :optional, if: :field_present?
+        field :options, if: :field_present?
+        field :locked, if: :field_present?
         field :value, if: :field_present?
       end
     end

--- a/lib/inferno/apps/web/serializers/input.rb
+++ b/lib/inferno/apps/web/serializers/input.rb
@@ -6,9 +6,12 @@ module Inferno
       class Input < Serializer
         identifier :name
 
-        field :label, if: :field_present?
+        field :title, if: :field_present?
         field :description, if: :field_present?
-        field :required, if: :field_present?
+        field :type, if: :field_present?
+        field :default, if: :field_present?
+        field :options, if: :field_present?
+        field :optional, if: :field_present?
         field :value, if: :field_present?
       end
     end

--- a/lib/inferno/apps/web/serializers/test.rb
+++ b/lib/inferno/apps/web/serializers/test.rb
@@ -7,7 +7,10 @@ module Inferno
         field :short_id
         field :title
         field :short_title
-        field :available_inputs, name: :inputs, extractor: HashValueExtractor, blueprint: Input
+        field :inputs do |test, options|
+          suite_options = options[:suite_options]
+          test.available_inputs(suite_options).map { |_name, input| Input.render_as_hash(input) }
+        end
         field :output_definitions, name: :outputs, extractor: HashValueExtractor
         field :description
         field :short_description

--- a/lib/inferno/apps/web/serializers/test.rb
+++ b/lib/inferno/apps/web/serializers/test.rb
@@ -9,7 +9,7 @@ module Inferno
         field :short_title
         field :inputs do |test, options|
           suite_options = options[:suite_options]
-          test.available_inputs(suite_options).map { |_name, input| Input.render_as_hash(input) }
+          Input.render_as_hash(test.available_inputs(suite_options).values)
         end
         field :output_definitions, name: :outputs, extractor: HashValueExtractor
         field :description

--- a/lib/inferno/apps/web/serializers/test_group.rb
+++ b/lib/inferno/apps/web/serializers/test_group.rb
@@ -23,7 +23,10 @@ module Inferno
           suite_options = options[:suite_options]
           Test.render_as_hash(group.tests(suite_options), suite_options: suite_options)
         end
-        field :available_inputs, name: :inputs, extractor: HashValueExtractor, blueprint: Input
+        field :inputs do |group, options|
+          suite_options = options[:suite_options]
+          Input.render_as_hash(group.available_inputs(suite_options).values)
+        end
         field :output_definitions, name: :outputs, extractor: HashValueExtractor
       end
     end

--- a/lib/inferno/apps/web/serializers/test_suite.rb
+++ b/lib/inferno/apps/web/serializers/test_suite.rb
@@ -23,7 +23,10 @@ module Inferno
             TestGroup.render_as_hash(suite.groups(suite_options), suite_options: suite_options)
           end
           field :configuration_messages
-          field :available_inputs, name: :inputs, extractor: HashValueExtractor, blueprint: Input
+          field :inputs do |suite, options|
+            suite_options = options[:suite_options]
+            Input.render_as_hash(suite.available_inputs(suite_options).values)
+          end
         end
       end
     end

--- a/lib/inferno/dsl/input_output_handling.rb
+++ b/lib/inferno/dsl/input_output_handling.rb
@@ -90,17 +90,17 @@ module Inferno
       end
 
       # @private
-      def required_inputs
-        available_inputs
+      def required_inputs(selected_suite_options)
+        available_inputs(selected_suite_options)
           .reject { |_, input| input.optional }
           .map { |_, input| input.name }
       end
 
       # @private
-      def missing_inputs(submitted_inputs)
+      def missing_inputs(submitted_inputs, selected_suite_options)
         submitted_inputs = [] if submitted_inputs.nil?
 
-        required_inputs.map(&:to_s) - submitted_inputs.map { |input| input[:name] }
+        required_inputs(selected_suite_options).map(&:to_s) - submitted_inputs.map { |input| input[:name] }
       end
 
       # Define a particular order for inputs to be presented in the API/UI

--- a/lib/inferno/entities/input.rb
+++ b/lib/inferno/entities/input.rb
@@ -13,7 +13,8 @@ module Inferno
         :default,
         :optional,
         :options,
-        :locked
+        :locked,
+        :value
       ].freeze
       include Entities::Attributes
 

--- a/spec/inferno/dsl/input_output_handling_spec.rb
+++ b/spec/inferno/dsl/input_output_handling_spec.rb
@@ -39,6 +39,19 @@ RSpec.describe Inferno::DSL::InputOutputHandling do
       expect(group.available_inputs.keys).to eq([:b])
       expect(test.available_inputs.keys).to eq([:b])
     end
+
+    it 'filters inputs based on selected suite_options' do
+      v1_option = Inferno::DSL::SuiteOption.new(id: :ig_version, value: '1')
+      v2_option = Inferno::DSL::SuiteOption.new(id: :ig_version, value: '2')
+      v1_inputs = OptionsSuite::Suite.available_inputs([v1_option])
+      v2_inputs = OptionsSuite::Suite.available_inputs([v2_option])
+
+      expect(v1_inputs.length).to eq(1)
+      expect(v2_inputs.length).to eq(1)
+
+      expect(v1_inputs).to include(:v1_input)
+      expect(v2_inputs).to include(:v2_input)
+    end
   end
 
   describe '.missing_inputs' do

--- a/spec/inferno/dsl/input_output_handling_spec.rb
+++ b/spec/inferno/dsl/input_output_handling_spec.rb
@@ -59,11 +59,11 @@ RSpec.describe Inferno::DSL::InputOutputHandling do
       example_test = Class.new(Inferno::Entities::Test)
       example_test.input :a, :b, :c
       example_test.input :d, optional: true
-      missing_inputs = example_test.missing_inputs([{ name: 'a', value: 'a' }])
+      missing_inputs = example_test.missing_inputs([{ name: 'a', value: 'a' }], nil)
       expect(missing_inputs).to eq(['b', 'c'])
 
       missing_inputs = example_test.missing_inputs([{ name: 'a', value: 'a' }, { name: 'b', value: 'b' },
-                                                    { name: 'c', value: 'c' }])
+                                                    { name: 'c', value: 'c' }], nil)
       expect(missing_inputs).to eq([])
     end
 
@@ -74,12 +74,12 @@ RSpec.describe Inferno::DSL::InputOutputHandling do
         input :a, :b, :c
         input :d, optional: true
       end
-      missing_inputs = example_test_group.missing_inputs([{ name: 'a', value: 'a' }, { name: 'e', value: 'e' }])
+      missing_inputs = example_test_group.missing_inputs([{ name: 'a', value: 'a' }, { name: 'e', value: 'e' }], nil)
       expect(missing_inputs).to eq(['f', 'b', 'c'])
 
       missing_inputs = example_test_group.missing_inputs([{ name: 'a', value: 'a' }, { name: 'b', value: 'b' },
                                                           { name: 'c', value: 'c' }, { name: 'e', value: 'e' },
-                                                          { name: 'f', value: 'f' }])
+                                                          { name: 'f', value: 'f' }], nil)
       expect(missing_inputs).to eq([])
     end
 
@@ -92,7 +92,7 @@ RSpec.describe Inferno::DSL::InputOutputHandling do
       example_test_group.test 'child test uses output' do
         input :c, :d
       end
-      missing_inputs = example_test_group.missing_inputs([{ name: 'a', value: 'a' }, { name: 'd', value: 'd' }])
+      missing_inputs = example_test_group.missing_inputs([{ name: 'a', value: 'a' }, { name: 'd', value: 'd' }], nil)
       expect(missing_inputs).to eq(['b'])
     end
 
@@ -104,7 +104,7 @@ RSpec.describe Inferno::DSL::InputOutputHandling do
       example_test_group.test 'child test with output' do
         output :a
       end
-      missing_inputs = example_test_group.missing_inputs([{ name: 'b', value: 'b' }])
+      missing_inputs = example_test_group.missing_inputs([{ name: 'b', value: 'b' }], nil)
       expect(missing_inputs).to eq(['a'])
     end
 
@@ -118,9 +118,27 @@ RSpec.describe Inferno::DSL::InputOutputHandling do
         input :url1, name: :url2
       end
 
-      missing_inputs = example_test_group.missing_inputs([{ name: 'url1', value: 'xyz' }])
+      missing_inputs = example_test_group.missing_inputs([{ name: 'url1', value: 'xyz' }], nil)
 
       expect(missing_inputs).to eq([])
+    end
+
+    it 'handles suite options' do
+      suite = OptionsSuite::Suite
+      v1_option = Inferno::DSL::SuiteOption.new(id: :ig_version, value: '1')
+      v2_option = Inferno::DSL::SuiteOption.new(id: :ig_version, value: '2')
+
+      missing_inputs = suite.missing_inputs([{ name: 'v1_input', value: 'abc' }], nil)
+      expect(missing_inputs).to eq(['v2_input'])
+
+      missing_inputs = suite.missing_inputs([{ name: 'v1_input', value: 'abc' }], [v1_option])
+      expect(missing_inputs).to be_empty
+
+      missing_inputs = suite.missing_inputs([{ name: 'v1_input', value: 'abc' }], [v2_option])
+      expect(missing_inputs).to eq(['v2_input'])
+
+      missing_inputs = suite.missing_inputs([{ name: 'v2_input', value: 'abc' }], [v1_option])
+      expect(missing_inputs).to eq(['v1_input'])
     end
   end
 

--- a/spec/inferno/web/serializers/test_group_spec.rb
+++ b/spec/inferno/web/serializers/test_group_spec.rb
@@ -24,9 +24,13 @@ RSpec.describe Inferno::Web::Serializers::TestGroup do
     expect(serialized_group['tests'].length).to eq(group.tests.length)
 
     group.available_inputs.each do |_identifier, definition|
-      raw_input = serialized_group['inputs'].find { |serialized_input| serialized_input['name'] == definition.name }
+      raw_input = serialized_group['inputs']
+        .find { |serialized_input| serialized_input['name'] == definition.name }
+        .symbolize_keys
+
       expect(raw_input).to be_present
-      input = Inferno::Entities::Input.new(raw_input.symbolize_keys)
+
+      input = Inferno::Entities::Input.new(raw_input)
 
       expect(input).to eq(definition)
     end

--- a/spec/inferno/web/serializers/test_spec.rb
+++ b/spec/inferno/web/serializers/test_spec.rb
@@ -20,9 +20,13 @@ RSpec.describe Inferno::Web::Serializers::Test do
     expect(serialized_test['outputs'].length).to eq(test.outputs.length)
 
     test.available_inputs.each do |_identifier, definition|
-      raw_input = serialized_test['inputs'].find { |serialized_input| serialized_input['name'] == definition.name }
+      raw_input = serialized_test['inputs']
+        .find { |serialized_input| serialized_input['name'] == definition.name }
+        .symbolize_keys
+
       expect(raw_input).to be_present
-      input = Inferno::Entities::Input.new(raw_input.symbolize_keys)
+
+      input = Inferno::Entities::Input.new(raw_input)
 
       expect(input).to eq(definition)
     end


### PR DESCRIPTION
This branch filters inputs based on selected suite options. This is needed to support multiple version of the SMART IG where different input behaviors are required for the different versions. For example, PKCE is optional in SMART v1, but required in SMART v2, so the input needs to be handled differently depending on which version is being used.

Also includes the tiny fix for #228 