### PR TITLE
Unhardcode base url in preset JSON for deployment

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,3 +2,4 @@ LOAD_DEV_SUITES=*
 VALIDATOR_URL=https://inferno.healthit.gov/validatorapi
 JS_HOST=http://localhost:3000
 BASE_PATH=inferno
+FHIR_ENDPOINT_URL=https://inferno.healthit.gov

--- a/.env.development
+++ b/.env.development
@@ -2,4 +2,4 @@ LOAD_DEV_SUITES=*
 VALIDATOR_URL=https://inferno.healthit.gov/validatorapi
 JS_HOST=http://localhost:3000
 BASE_PATH=inferno
-FHIR_ENDPOINT_URL=https://inferno.healthit.gov
+REFERENCE_SERVER_URL=https://inferno.healthit.gov

--- a/config/presets/demo_preset.json.erb
+++ b/config/presets/demo_preset.json.erb
@@ -8,7 +8,7 @@
       "type": "text",
       "title": "URL",
       "description": "Insert url of FHIR server",
-      "value": "<%= ENV.fetch('FHIR_ENDPOINT_URL', 'https://inferno.healthit.gov') %>/reference-server/r4"
+      "value": "<%= ENV.fetch('REFERENCE_SERVER_URL', 'https://inferno.healthit.gov') %>/reference-server/r4"
     },
     {
       "name": "patient_id",
@@ -64,7 +64,7 @@
       "title": "URL",
       "description": "Example of locked, filled input field",
       "locked": true,
-      "value": "<%= ENV.fetch('FHIR_ENDPOINT_URL', 'https://inferno.healthit.gov') %>/reference-server/r4"
+      "value": "<%= ENV.fetch('REFERENCE_SERVER_URL', 'https://inferno.healthit.gov') %>/reference-server/r4"
     },
     {
       "name": "textarea_locked",

--- a/config/presets/demo_preset.json.erb
+++ b/config/presets/demo_preset.json.erb
@@ -8,7 +8,7 @@
       "type": "text",
       "title": "URL",
       "description": "Insert url of FHIR server",
-      "value": "https://inferno.healthit.gov/reference-server/r4"
+      "value": "<%= ENV.fetch('FHIR_ENDPOINT_URL', 'https://inferno.healthit.gov') %>/reference-server/r4"
     },
     {
       "name": "patient_id",
@@ -64,7 +64,7 @@
       "title": "URL",
       "description": "Example of locked, filled input field",
       "locked": true,
-      "value": "https://inferno.healthit.gov/reference-server/r4"
+      "value": "<%= ENV.fetch('FHIR_ENDPOINT_URL', 'https://inferno.healthit.gov') %>/reference-server/r4"
     },
     {
       "name": "textarea_locked",

--- a/config/presets/g10_certification_preset.json.erb
+++ b/config/presets/g10_certification_preset.json.erb
@@ -8,7 +8,7 @@
       "type": "text",
       "title": "Standalone FHIR Endpoint",
       "description": "URL of the FHIR endpoint used by standalone applications",
-      "value": "https://inferno.healthit.gov/reference-server/r4"
+      "value": "<%= ENV.fetch('FHIR_ENDPOINT_URL', 'https://inferno.healthit.gov') %>/reference-server/r4"
     },
     {
       "name": "standalone_client_id",
@@ -118,7 +118,7 @@
       "type": "text",
       "title": "Backend Services Token Endpoint",
       "description": "The OAuth 2.0 Token Endpoint used by the Backend Services specification\n                        to provide bearer tokens.",
-      "value": "https://inferno.healthit.gov/bulk-data-server/auth/token"
+      "value": "<%= ENV.fetch('FHIR_ENDPOINT_URL', 'https://inferno.healthit.gov') %>/bulk-data-server/auth/token"
     },
     {
       "name": "bulk_client_id",
@@ -158,7 +158,7 @@
       "type": "text",
       "title": "Bulk Data FHIR URL",
       "description": "The URL of the Bulk FHIR server.",
-      "value": "https://inferno.healthit.gov/bulk-data-server/eyJlcnIiOiIiLCJwYWdlIjoxMDAwMCwiZHVyIjoxMCwidGx0IjoxNSwibSI6MSwic3R1Ijo0fQ/fhir"
+      "value": "<%= ENV.fetch('FHIR_ENDPOINT_URL', 'https://inferno.healthit.gov') %>/bulk-data-server/eyJlcnIiOiIiLCJwYWdlIjoxMDAwMCwiZHVyIjoxMCwidGx0IjoxNSwibSI6MSwic3R1Ijo0fQ/fhir"
     },
     {
       "name": "group_id",

--- a/config/presets/g10_certification_preset.json.erb
+++ b/config/presets/g10_certification_preset.json.erb
@@ -8,7 +8,7 @@
       "type": "text",
       "title": "Standalone FHIR Endpoint",
       "description": "URL of the FHIR endpoint used by standalone applications",
-      "value": "<%= ENV.fetch('FHIR_ENDPOINT_URL', 'https://inferno.healthit.gov') %>/reference-server/r4"
+      "value": "<%= ENV.fetch('REFERENCE_SERVER_URL', 'https://inferno.healthit.gov') %>/reference-server/r4"
     },
     {
       "name": "standalone_client_id",
@@ -118,7 +118,7 @@
       "type": "text",
       "title": "Backend Services Token Endpoint",
       "description": "The OAuth 2.0 Token Endpoint used by the Backend Services specification\n                        to provide bearer tokens.",
-      "value": "<%= ENV.fetch('FHIR_ENDPOINT_URL', 'https://inferno.healthit.gov') %>/bulk-data-server/auth/token"
+      "value": "<%= ENV.fetch('REFERENCE_SERVER_URL', 'https://inferno.healthit.gov') %>/bulk-data-server/auth/token"
     },
     {
       "name": "bulk_client_id",
@@ -158,7 +158,7 @@
       "type": "text",
       "title": "Bulk Data FHIR URL",
       "description": "The URL of the Bulk FHIR server.",
-      "value": "<%= ENV.fetch('FHIR_ENDPOINT_URL', 'https://inferno.healthit.gov') %>/bulk-data-server/eyJlcnIiOiIiLCJwYWdlIjoxMDAwMCwiZHVyIjoxMCwidGx0IjoxNSwibSI6MSwic3R1Ijo0fQ/fhir"
+      "value": "<%= ENV.fetch('REFERENCE_SERVER_URL', 'https://inferno.healthit.gov') %>/bulk-data-server/eyJlcnIiOiIiLCJwYWdlIjoxMDAwMCwiZHVyIjoxMCwidGx0IjoxNSwibSI6MSwic3R1Ijo0fQ/fhir"
     },
     {
       "name": "group_id",

--- a/config/presets/smart_preset.json.erb
+++ b/config/presets/smart_preset.json.erb
@@ -6,7 +6,7 @@
     {
       "name": "url",
       "type": "text",
-      "value": "https://inferno.healthit.gov/reference-server/r4"
+      "value": "<%= ENV.fetch('FHIR_ENDPOINT_URL', 'https://inferno.healthit.gov') %>/reference-server/r4"
     },
     {
       "name": "standalone_client_id",

--- a/config/presets/smart_preset.json.erb
+++ b/config/presets/smart_preset.json.erb
@@ -6,7 +6,7 @@
     {
       "name": "url",
       "type": "text",
-      "value": "<%= ENV.fetch('FHIR_ENDPOINT_URL', 'https://inferno.healthit.gov') %>/reference-server/r4"
+      "value": "<%= ENV.fetch('REFERENCE_SERVER_URL', 'https://inferno.healthit.gov') %>/reference-server/r4"
     },
     {
       "name": "standalone_client_id",

--- a/config/presets/us_core_preset.json.erb
+++ b/config/presets/us_core_preset.json.erb
@@ -8,7 +8,7 @@
       "type": "text",
       "title": "FHIR Endpoint",
       "description": "URL of the FHIR endpoint",
-      "value": "<%= ENV.fetch('FHIR_ENDPOINT_URL', 'https://inferno.healthit.gov') %>/reference-server/r4"
+      "value": "<%= ENV.fetch('REFERENCE_SERVER_URL', 'https://inferno.healthit.gov') %>/reference-server/r4"
     },
     {
       "name": "smart_credentials",

--- a/config/presets/us_core_preset.json.erb
+++ b/config/presets/us_core_preset.json.erb
@@ -1,34 +1,34 @@
 {
-  "title": "Preset for US Core v3.1.1",
+  "title": "Inferno Reference Server",
   "id": null,
-  "test_suite_id": "us_core_v311",
+  "test_suite_id": "us_core_311",
   "inputs": [
     {
       "name": "url",
+      "type": "text",
       "title": "FHIR Endpoint",
       "description": "URL of the FHIR endpoint",
-      "type": "text",
-      "value": "https://inferno.healthit.gov/reference-server/r4"
+      "value": "<%= ENV.fetch('FHIR_ENDPOINT_URL', 'https://inferno.healthit.gov') %>/reference-server/r4"
     },
     {
       "name": "smart_credentials",
-      "title": "OAuth Credentials",
       "type": "oauth_credentials",
+      "title": "OAuth Credentials",
       "optional": true,
-      "value": "{\"access_token\": \"SAMPLE_TOKEN\"}"
+      "value": "{\"access_token\":\"SAMPLE_TOKEN\"}"
     },
     {
       "name": "patient_ids",
+      "type": "text",
       "title": "Patient IDs",
       "description": "Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements",
-      "type": "text",
       "value": "85,355"
     },
     {
       "name": "implantable_device_codes",
+      "type": "text",
       "title": "Implantable Device Type Code",
       "description": "Enter the code for an Implantable Device type, or multiple codes separated by commas. If blank, Inferno will validate all Device resources against the Implantable Device profile",
-      "type": "text",
       "optional": true,
       "value": null
     }

--- a/config/presets/us_core_v311_reference_server_preset.json.erb
+++ b/config/presets/us_core_v311_reference_server_preset.json.erb
@@ -1,34 +1,34 @@
 {
-  "title": "Inferno Reference Server",
+  "title": "Preset for US Core v3.1.1",
   "id": null,
-  "test_suite_id": "us_core_311",
+  "test_suite_id": "us_core_v311",
   "inputs": [
     {
       "name": "url",
-      "type": "text",
       "title": "FHIR Endpoint",
       "description": "URL of the FHIR endpoint",
-      "value": "https://inferno.healthit.gov/reference-server/r4"
+      "type": "text",
+      "value": "<%= ENV.fetch('FHIR_ENDPOINT_URL', 'https://inferno.healthit.gov') %>/reference-server/r4"
     },
     {
       "name": "smart_credentials",
-      "type": "oauth_credentials",
       "title": "OAuth Credentials",
+      "type": "oauth_credentials",
       "optional": true,
-      "value": "{\"access_token\":\"SAMPLE_TOKEN\"}"
+      "value": "{\"access_token\": \"SAMPLE_TOKEN\"}"
     },
     {
       "name": "patient_ids",
-      "type": "text",
       "title": "Patient IDs",
       "description": "Comma separated list of patient IDs that in sum contain all MUST SUPPORT elements",
+      "type": "text",
       "value": "85,355"
     },
     {
       "name": "implantable_device_codes",
-      "type": "text",
       "title": "Implantable Device Type Code",
       "description": "Enter the code for an Implantable Device type, or multiple codes separated by commas. If blank, Inferno will validate all Device resources against the Implantable Device profile",
+      "type": "text",
       "optional": true,
       "value": null
     }

--- a/config/presets/us_core_v311_reference_server_preset.json.erb
+++ b/config/presets/us_core_v311_reference_server_preset.json.erb
@@ -8,7 +8,7 @@
       "title": "FHIR Endpoint",
       "description": "URL of the FHIR endpoint",
       "type": "text",
-      "value": "<%= ENV.fetch('FHIR_ENDPOINT_URL', 'https://inferno.healthit.gov') %>/reference-server/r4"
+      "value": "<%= ENV.fetch('REFERENCE_SERVER_URL', 'https://inferno.healthit.gov') %>/reference-server/r4"
     },
     {
       "name": "smart_credentials",

--- a/lib/inferno/config/boot/presets.rb
+++ b/lib/inferno/config/boot/presets.rb
@@ -4,7 +4,7 @@ Inferno::Application.boot(:presets) do
   init do
     use :suites
 
-    files_to_load = Dir.glob(File.join(Dir.pwd, 'config', 'presets', '*.json'))
+    files_to_load = Dir.glob(['config/presets/*.json', 'config/presets/*.json.erb'])
     files_to_load.map! { |path| File.realpath(path) }
     presets_repo = Inferno::Repositories::Presets.new
 

--- a/lib/inferno/repositories/presets.rb
+++ b/lib/inferno/repositories/presets.rb
@@ -1,3 +1,5 @@
+require 'erb'
+
 require_relative 'in_memory_repository'
 require_relative '../entities/preset'
 
@@ -6,7 +8,14 @@ module Inferno
     # Repository that deals with persistence for the `Preset` entity.
     class Presets < InMemoryRepository
       def insert_from_file(path)
-        preset_hash = JSON.parse(File.read(path))
+        case path
+        when /\.json$/
+          preset_hash = JSON.parse(File.read(path))
+        when /\.erb$/
+          templated = ERB.new(File.read(path)).result
+          preset_hash = JSON.parse(templated)
+        end
+
         preset_hash.deep_symbolize_keys!
         preset_hash[:id] ||= SecureRandom.uuid
         preset = Entities::Preset.new(preset_hash)

--- a/spec/fixtures/simple_preset.json
+++ b/spec/fixtures/simple_preset.json
@@ -1,0 +1,14 @@
+{
+  "title": "Simple JSON Preset",
+  "id": null,
+  "test_suite_id": "simple_json",
+  "inputs": [
+    {
+      "name": "url",
+      "type": "text",
+      "title": "Title",
+      "description": "Description",
+      "value": "https://hardcoded.example.org"
+    }
+  ]
+}

--- a/spec/fixtures/simple_preset.json.erb
+++ b/spec/fixtures/simple_preset.json.erb
@@ -8,7 +8,7 @@
       "type": "text",
       "title": "Title",
       "description": "Description",
-      "value": "<%= ENV.fetch('FHIR_ENDPOINT_URL', 'http://default.example.com') %>"
+      "value": "<%= ENV.fetch('REFERENCE_SERVER_URL', 'http://default.example.com') %>"
     }
   ]
 }

--- a/spec/fixtures/simple_preset.json.erb
+++ b/spec/fixtures/simple_preset.json.erb
@@ -1,0 +1,14 @@
+{
+  "title": "Simple JSON Preset",
+  "id": null,
+  "test_suite_id": "simple_json",
+  "inputs": [
+    {
+      "name": "url",
+      "type": "text",
+      "title": "Title",
+      "description": "Description",
+      "value": "<%= ENV.fetch('FHIR_ENDPOINT_URL', 'http://default.example.com') %>"
+    }
+  ]
+}

--- a/spec/inferno/repositories/presets_spec.rb
+++ b/spec/inferno/repositories/presets_spec.rb
@@ -46,11 +46,11 @@ RSpec.describe Inferno::Repositories::Presets do
 
     context 'when given an ERB template and an ENV' do
       before do
-        ENV['FHIR_ENDPOINT_URL'] = 'http://example.com'
+        ENV['REFERENCE_SERVER_URL'] = 'http://example.com'
       end
 
       after do
-        ENV.delete('FHIR_ENDPOINT_URL')
+        ENV.delete('REFERENCE_SERVER_URL')
       end
 
       it 'creates and inserts a preset' do

--- a/spec/inferno/repositories/presets_spec.rb
+++ b/spec/inferno/repositories/presets_spec.rb
@@ -1,0 +1,71 @@
+require_relative '../../../lib/inferno/repositories/presets'
+require_relative '../../../lib/inferno/entities/preset'
+
+RSpec.describe Inferno::Repositories::Presets do
+  subject(:presets) { described_class.new }
+
+  describe '#insert_from_file' do
+    let(:simple_json) do
+      File.realpath(File.join(Dir.pwd, 'spec/fixtures/simple_preset.json'))
+    end
+
+    let(:simple_erb) do
+      File.realpath(File.join(Dir.pwd, 'spec/fixtures/simple_preset.json.erb'))
+    end
+
+    let(:uuid) { 'very-random-uuid' }
+
+    before { allow(SecureRandom).to receive(:uuid).and_return(uuid) }
+
+    context 'when given a JSON document' do
+      let(:expected_preset) do
+        Inferno::Entities::Preset.new(
+          {
+            id: uuid,
+            test_suite_id: 'simple_json',
+            type: 'text',
+            title: 'Simple JSON Preset',
+            inputs: [
+              name: 'url',
+              type: 'text',
+              title: 'Title',
+              description: 'Description',
+              value: 'https://hardcoded.example.org'
+            ]
+          }
+        )
+      end
+
+      it 'creates and inserts a preset' do
+        inserted = presets.insert_from_file(simple_json)
+
+        # to_json is a lazy way of comparing two instances' equality
+        expect(inserted.to_json).to eq(expected_preset.to_json)
+      end
+    end
+
+    context 'when given an ERB template and an ENV' do
+      before do
+        ENV['FHIR_ENDPOINT_URL'] = 'http://example.com'
+      end
+
+      after do
+        ENV.delete('FHIR_ENDPOINT_URL')
+      end
+
+      it 'creates and inserts a preset' do
+        inserted = presets.insert_from_file(simple_erb)
+
+        expect(inserted.inputs.first[:value]).to eq('http://example.com')
+      end
+    end
+
+    context 'when given an ERB template' do
+      it 'creates and inserts a preset' do
+        inserted = presets.insert_from_file(simple_erb)
+
+        expect(inserted.inputs.first[:value]).to eq('http://default.example.com')
+      end
+    end
+  end
+end


### PR DESCRIPTION
We were talking about deployment pains and right now I think the team is commenting out the equivalent of this during deploy.  Since what this URL represents is not hardcoded, can be any URL even for staging (or dev as we call it), it should not be hardcoded and should be in an ENV (named `REFERENCE_SERVER_URL` here).

I'm not quite sure on the `.env` templates and what should go in what.  Should there be an example in the readme?  Is `.env.development` enough?

We should also add `REFERENCE_SERVER_URL` to the deployment repo.

I wanted to test the init that happens in `lib/inferno/config/boot/presets.rb` but it seemed a bit myopic.  That code does get invoked during test.  So maybe something could be done there.  I did make a change to it (just for a simpler syntax) and normally I'd have a regression test or something to cover the change.  So, happy to add to that.

Anything else, let me know what you think.