### PR TITLE
FI-1645 Allow empty payloads on session creation again.

### DIFF
--- a/lib/inferno/apps/web/controllers/test_sessions/create.rb
+++ b/lib/inferno/apps/web/controllers/test_sessions/create.rb
@@ -6,9 +6,8 @@ module Inferno
           PARAMS = [:test_suite_id, :suite_options].freeze
 
           def call(raw_params)
-            query_params = raw_params.to_h
-            body_params = JSON.parse(request.body.string).symbolize_keys
-            params = query_params.merge(body_params)
+            params = raw_params.to_h
+            params.merge!(JSON.parse(request.body.string).symbolize_keys) unless request.body.string.blank?
 
             session = repo.create(create_params(params))
 


### PR DESCRIPTION
If you `POST http://localhost:4567/inferno/api/test_sessions?test_suite_id=demo` with no payload, recent updates make this call fail because it assumes the payload is valid JSON always.  This just checks to see if it is empty.

Leaving as-is would break our deployment g10 redirect (https://inferno.healthit.gov/onc-certification-g10-test-kit), and we'd have to update README.  No reason to not keep it backwards-compatible.

See #225 