### PR TITLE
FI-1646 Progress Bar Bug w/ Options

### DIFF
--- a/lib/inferno/apps/web/controllers/test_runs/create.rb
+++ b/lib/inferno/apps/web/controllers/test_runs/create.rb
@@ -59,7 +59,7 @@ module Inferno
 
             test_run = repo.create(create_params(params).merge(status: 'queued'))
 
-            self.body = serialize(test_run)
+            self.body = serialize(test_run, suite_options: test_session.suite_options)
 
             persist_inputs(params, test_run)
 

--- a/lib/inferno/apps/web/controllers/test_runs/show.rb
+++ b/lib/inferno/apps/web/controllers/test_runs/show.rb
@@ -3,7 +3,7 @@ module Inferno
     module Controllers
       module TestRuns
         class Show < Controller
-          include Import[ test_sessions_repo: 'repositories.test_sessions' ]
+          include Import[test_sessions_repo: 'repositories.test_sessions']
 
           def call(params)
             test_run = repo.find(params[:id])

--- a/lib/inferno/apps/web/controllers/test_runs/show.rb
+++ b/lib/inferno/apps/web/controllers/test_runs/show.rb
@@ -3,6 +3,8 @@ module Inferno
     module Controllers
       module TestRuns
         class Show < Controller
+          include Import[ test_sessions_repo: 'repositories.test_sessions' ]
+
           def call(params)
             test_run = repo.find(params[:id])
             halt 404 if test_run.nil?
@@ -17,7 +19,8 @@ module Inferno
                 end
             end
 
-            self.body = serialize(test_run)
+            test_session = test_sessions_repo.find(test_run.test_session_id)
+            self.body = serialize(test_run, suite_options: test_session.suite_options)
           end
         end
       end

--- a/lib/inferno/apps/web/serializers/test_group.rb
+++ b/lib/inferno/apps/web/serializers/test_group.rb
@@ -17,8 +17,8 @@ module Inferno
         field :test_count do |group, options|
           suite_options = options[:suite_options]
           child_test_count = group.tests(suite_options).count
-          group.groups(suite_options).inject(child_test_count) do |total_test_count, group|
-            total_test_count + (group.test_count(suite_options))
+          group.groups(suite_options).inject(child_test_count) do |total_test_count, child_group|
+            total_test_count + child_group.test_count(suite_options)
           end
         end
         field :test_groups do |group, options|

--- a/lib/inferno/apps/web/serializers/test_group.rb
+++ b/lib/inferno/apps/web/serializers/test_group.rb
@@ -10,11 +10,17 @@ module Inferno
         field :description
         field :short_description
         field :input_instructions
-        field :test_count
         field :run_as_group?, name: :run_as_group
         field :user_runnable?, name: :user_runnable
         field :optional?, name: :optional
 
+        field :test_count do |group, options|
+          suite_options = options[:suite_options]
+          child_test_count = group.tests(suite_options).count
+          group.groups(suite_options).inject(child_test_count) do |total_test_count, group|
+            total_test_count + (group.test_count(suite_options))
+          end
+        end
         field :test_groups do |group, options|
           suite_options = options[:suite_options]
           TestGroup.render_as_hash(group.groups(suite_options), suite_options: suite_options)

--- a/lib/inferno/apps/web/serializers/test_group.rb
+++ b/lib/inferno/apps/web/serializers/test_group.rb
@@ -15,11 +15,7 @@ module Inferno
         field :optional?, name: :optional
 
         field :test_count do |group, options|
-          suite_options = options[:suite_options]
-          child_test_count = group.tests(suite_options).count
-          group.groups(suite_options).inject(child_test_count) do |total_test_count, child_group|
-            total_test_count + child_group.test_count(suite_options)
-          end
+          group.test_count(options[:suite_options])
         end
         field :test_groups do |group, options|
           suite_options = options[:suite_options]

--- a/lib/inferno/apps/web/serializers/test_run.rb
+++ b/lib/inferno/apps/web/serializers/test_run.rb
@@ -6,7 +6,9 @@ module Inferno
         field :test_session_id
 
         field :status
-        field :test_count
+        field :test_count do |test_run, options|
+          test_run.test_count(options[:suite_options])
+        end
 
         field :test_group_id, if: :field_present?
         field :test_suite_id, if: :field_present?

--- a/lib/inferno/apps/web/serializers/test_suite.rb
+++ b/lib/inferno/apps/web/serializers/test_suite.rb
@@ -9,9 +9,16 @@ module Inferno
           field :description
           field :short_description
           field :input_instructions
-          field :test_count
           field :version
           field :links
+
+          field :test_count do |suite, options|
+            suite_options = options[:suite_options]
+            suite.groups(suite_options).inject(0) do |total_test_count, group|
+              total_test_count + (group.test_count(suite_options))
+            end
+          end
+
           association :suite_options, blueprint: SuiteOption
           association :presets, view: :summary, blueprint: Preset
         end

--- a/lib/inferno/apps/web/serializers/test_suite.rb
+++ b/lib/inferno/apps/web/serializers/test_suite.rb
@@ -13,10 +13,7 @@ module Inferno
           field :links
 
           field :test_count do |suite, options|
-            suite_options = options[:suite_options]
-            suite.groups(suite_options).inject(0) do |total_test_count, group|
-              total_test_count + group.test_count(suite_options)
-            end
+            suite.test_count(options[:suite_options])
           end
 
           association :suite_options, blueprint: SuiteOption

--- a/lib/inferno/apps/web/serializers/test_suite.rb
+++ b/lib/inferno/apps/web/serializers/test_suite.rb
@@ -15,7 +15,7 @@ module Inferno
           field :test_count do |suite, options|
             suite_options = options[:suite_options]
             suite.groups(suite_options).inject(0) do |total_test_count, group|
-              total_test_count + (group.test_count(suite_options))
+              total_test_count + group.test_count(suite_options)
             end
           end
 

--- a/lib/inferno/entities/test_run.rb
+++ b/lib/inferno/entities/test_run.rb
@@ -68,8 +68,8 @@ module Inferno
         super.merge(test_session: test_session).compact
       end
 
-      def test_count
-        @test_count ||= runnable.test_count
+      def test_count(selected_suite_options = [])
+        @test_count ||= runnable.test_count(selected_suite_options)
       end
     end
   end

--- a/spec/inferno/web/serializers/test_group_spec.rb
+++ b/spec/inferno/web/serializers/test_group_spec.rb
@@ -2,6 +2,18 @@ RSpec.describe Inferno::Web::Serializers::TestGroup do
   let(:group) { InfrastructureTest::SerializerGroup }
   let(:test) { group.tests.first }
 
+  before do
+    options_multi_group = Class.new(OptionsSuite::AllVersionsGroup) do
+      group from: :v1_group,
+            required_suite_options: { ig_version: '1' }
+
+      group from: :v2_group,
+            required_suite_options: { ig_version: '2' }
+    end
+
+    stub_const('OptionsMultiGroup', options_multi_group)
+  end
+
   it 'serializes a group' do
     serialized_group = JSON.parse(described_class.render(group))
 
@@ -47,14 +59,6 @@ RSpec.describe Inferno::Web::Serializers::TestGroup do
   end
 
   it 'serializes using selected options to filter groups and tests' do
-    class OptionsMultiGroup < OptionsSuite::AllVersionsGroup
-      group from: :v1_group,
-            required_suite_options: { ig_version: '1' }
-
-      group from: :v2_group,
-            required_suite_options: { ig_version: '2' }
-    end
-
     options = [Inferno::DSL::SuiteOption.new(id: :ig_version, value: '2')]
     serialized_group = JSON.parse(described_class.render(OptionsMultiGroup,
                                                          suite_options: options))

--- a/spec/inferno/web/serializers/test_group_spec.rb
+++ b/spec/inferno/web/serializers/test_group_spec.rb
@@ -45,4 +45,27 @@ RSpec.describe Inferno::Web::Serializers::TestGroup do
       end
     end
   end
+
+  it 'serializes using selected options to filter groups and tests' do
+    class OptionsMultiGroup < OptionsSuite::AllVersionsGroup
+      group from: :v1_group,
+            required_suite_options: { ig_version: '1' }
+
+      group from: :v2_group,
+            required_suite_options: { ig_version: '2' }
+    end
+
+    options = [Inferno::DSL::SuiteOption.new(id: :ig_version, value: '2')]
+    serialized_group = JSON.parse(described_class.render(OptionsMultiGroup,
+                                                         suite_options: options))
+
+    expected_tests = OptionsMultiGroup.tests(options).map(&:id)
+    expected_groups = OptionsMultiGroup.groups(options).map(&:id)
+    received_tests = serialized_group['tests'].collect { |test| test['id'] }
+    recieved_groups = serialized_group['test_groups'].collect { |group| group['id'] }
+
+    expect(received_tests).to eq(expected_tests)
+    expect(recieved_groups).to eq(expected_groups)
+    expect(serialized_group['test_count']).to eq(4)
+  end
 end

--- a/spec/inferno/web/serializers/test_suite_spec.rb
+++ b/spec/inferno/web/serializers/test_suite_spec.rb
@@ -70,4 +70,18 @@ RSpec.describe Inferno::Web::Serializers::TestSuite do
     expect(serialized_suite['presets']).to all(have_key('id'))
     expect(serialized_suite['presets']).to all(have_key('title'))
   end
+
+  it 'serializes using selected options to filter groups' do
+    options_suite = OptionsSuite::Suite
+    options = [Inferno::DSL::SuiteOption.new(id: :ig_version, value: '1')]
+    serialized_suite = JSON.parse(described_class.render(options_suite,
+                                                         view: :full,
+                                                         suite_options: options))
+
+    expected_groups = options_suite.groups(options).map(&:id)
+    received_groups = serialized_suite['test_groups'].collect { |group| group['id'] }
+
+    expect(received_groups).to eq(expected_groups)
+    expect(serialized_suite['test_count']).to eq(3)
+  end
 end


### PR DESCRIPTION
**Issue:** The denominator of the Progress Bar reflects the total number of tests within a runnable; instead, it should only show the number of tests available given the selected options. This results from `test_runs` not using/receiving `suite_options` to filter its `test_count`.

**Fix:** Passed `suite_options` in the serializer calls (_create.rb_ and _show.rb_) for `test_run`. Additionally, added `suite_option` filtering for `test_count` both `TestSuites` and `TestGroups` (separate from the issue, but relevant to the goal of the ticket). 