### PR TITLE
Fi-1665 Request modal bug

### DIFF
--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/RequestsList.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/RequestsList.tsx
@@ -28,7 +28,7 @@ const RequestsList: FC<RequestsListProps> = ({ requests, resultId, updateRequest
   const styles = useStyles();
 
   function showDetailsClick(request: Request) {
-    if (request.request_headers === null) {
+    if (request.request_headers == null) {
       getRequestDetails(request.id)
         .then((updatedRequest) => {
           if (updatedRequest) {

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/RequestsList.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/RequestsList.tsx
@@ -28,7 +28,7 @@ const RequestsList: FC<RequestsListProps> = ({ requests, resultId, updateRequest
   const styles = useStyles();
 
   function showDetailsClick(request: Request) {
-    if (request.request_headers == null) {
+    if (request.request_headers === undefined) {
       getRequestDetails(request.id)
         .then((updatedRequest) => {
           if (updatedRequest) {


### PR DESCRIPTION
A bug was introduced in https://github.com/inferno-framework/inferno-core/pull/230/ where a minor syntax update led to the request detail modal not being populated.

I originally reverted to the fuzzy equality to `null` because we know that worked properly in all cases, but then decided to change to strict equality to `undefined` in case the fuzzy equality was flagged by a linter (wouldn't want this to get reflagged and changed back).  I can't think of a reason why moving this to `undefined` would be problematic, and it seems to work.

I didn't see any other obvious problems that other update may have introduced, but worth a scan of the PR linked in the first sentence of this to double-check.

Before fix, in Demo suite run group 2.1, and look for a request, click on details, and you should see:

![Screen Shot 2022-08-08 at 3 24 43 PM](https://user-images.githubusercontent.com/412901/183499821-401e7c8f-c5c7-4104-8361-a4f11c5bd908.png)

after fix, it will look like:

![Screen Shot 2022-08-08 at 3 25 27 PM](https://user-images.githubusercontent.com/412901/183499849-894f845f-203a-4056-8dbc-2f3a8fe26cce.png)
 

