### PR TITLE
Add ga to docs pages

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -43,3 +43,5 @@ aux_links:
     - "/inferno-core/api-docs"
 
 aux_links_new_tab: true
+
+ga_tracking: G-9NZFQXEN4C


### PR DESCRIPTION
Confirmed that this works by running it locally.

![Screen Shot 2022-08-11 at 3 49 28 PM](https://user-images.githubusercontent.com/412901/184226980-3336118e-59a9-41a2-9a71-a8c103166562.png)
