### PR TITLE
Fixes phantom scrollbar.

### DIFF
--- a/client/src/components/LandingPage/LandingPage.tsx
+++ b/client/src/components/LandingPage/LandingPage.tsx
@@ -102,7 +102,7 @@ const LandingPage: FC<LandingPageProps> = ({ testSuites }) => {
           <Typography variant="h4" component="h2" align="center">
             Test Suites
           </Typography>
-          <Box overflow="scroll">
+          <Box overflow="auto">
             <List>
               {testSuites ? (
                 testSuites.map((testSuite: TestSuite) => renderOption(testSuite))

--- a/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
+++ b/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
@@ -158,7 +158,7 @@ const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuites }) => {
               <Box minWidth="45px" />
             </Box>
 
-            <Box overflow="scroll" px={4} py={2}>
+            <Box overflow="auto" px={4} py={2}>
               {testSuite?.suite_options ? (
                 testSuite.suite_options.map((suiteOption: SuiteOption, i) =>
                   renderOption(suiteOption, i)

--- a/client/src/components/TestSuite/TestSession.tsx
+++ b/client/src/components/TestSuite/TestSession.tsx
@@ -341,7 +341,7 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
       )}
       <main
         style={{
-          overflow: 'scroll',
+          overflow: 'auto',
           width: '100%',
           backgroundColor: lightTheme.palette.common.grayLight,
         }}

--- a/client/src/components/TestSuite/styles.tsx
+++ b/client/src/components/TestSuite/styles.tsx
@@ -10,7 +10,7 @@ export default makeStyles((theme: Theme) => ({
     flexGrow: 1,
     padding: '24px 48px',
     overflowX: 'hidden',
-    overflow: 'scroll',
+    overflow: 'auto',
     '@media print': {
       margin: 0,
       position: 'absolute',


### PR DESCRIPTION
# Summary

Removes all the scrollbars spacers that show up in my Firefox installation.  This isn't just in the new options page -- this has been in the main interface also for some time.  Asking to merge into another PR that isn't quite in yet.

![Screen Shot 2022-08-15 at 1 02 33 PM](https://user-images.githubusercontent.com/412901/184681161-4c3786f2-19a8-4271-854e-df6ca166c8ba.png)


# Testing Guidance

Perhaps just make sure that I didn't inadvertently break anything?  But seems to work properly for me now.