### PR TITLE
Feature/FI-1688-suite_summary-options-redesign

### DIFF
--- a/client/src/components/Footer/styles.tsx
+++ b/client/src/components/Footer/styles.tsx
@@ -13,6 +13,7 @@ export default makeStyles((theme: Theme) => ({
     maxHeight: '56px', // For responsive screens
     zIndex: `${theme.zIndex.drawer + 1} !important` as any,
     backgroundColor: theme.palette.common.orangeLightest,
+    borderTop: `1px ${theme.palette.common.grayLighter} solid`,
     position: 'sticky',
     bottom: 0,
     '@media print': {

--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -50,7 +50,7 @@ const Header: FC<HeaderProps> = ({
           >
             <img src={getStaticPath(icon as string)} alt="Inferno logo" className={styles.logo} />
           </IconButton>
-          <Box display="flex" alignItems="baseline" alignSelf="center" width="max-content">
+          <Box display="flex" alignItems="baseline" alignSelf="center" width="max-content" pt={0.5}>
             <Typography variant="h5" component="h1" className={styles.title}>
               {suiteTitle}
               {suiteOptionsString}

--- a/client/src/components/Header/styles.tsx
+++ b/client/src/components/Header/styles.tsx
@@ -33,6 +33,8 @@ export default makeStyles((theme: Theme) => ({
   title: {
     padding: '0 8px',
     width: 'max-content',
+    fontWeight: 600,
+    color: theme.palette.common.orangeDarker,
   },
   version: {
     fontStyle: 'italic',

--- a/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
+++ b/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
@@ -13,6 +13,7 @@ import {
   Tooltip,
 } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import HelpOutlineOutlinedIcon from '@mui/icons-material/HelpOutlineOutlined';
 import useStyles from './styles';
 import { useHistory, useParams } from 'react-router-dom';
 import { postTestSessions } from '~/api/TestSessionApi';
@@ -82,7 +83,15 @@ const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuites }) => {
   const renderOption = (suiteOption: SuiteOption, i: number) => {
     return (
       <FormControl fullWidth id={`suite-option-input-${i}`} key={`suite-form-control${i}`}>
-        <FormLabel>{suiteOption.title}</FormLabel>
+        <FormLabel sx={{ display: 'flex', alignItems: 'center' }}>
+          {suiteOption.title}
+          {suiteOption.description && (
+            <Tooltip title={suiteOption.description}>
+              <HelpOutlineOutlinedIcon fontSize="small" color="secondary" sx={{ px: 0.5 }} />
+            </Tooltip>
+          )}
+        </FormLabel>
+
         <RadioGroup
           row
           aria-label={`suite-option-group-${suiteOption.id}`}
@@ -150,7 +159,9 @@ const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuites }) => {
               wordBreak: 'break-word',
             }}
           >
-            <ReactMarkdown>{testSuite?.description || ''}</ReactMarkdown>
+            <ReactMarkdown>
+              {testSuite?.suite_summary || testSuite?.description || ''}
+            </ReactMarkdown>
           </Typography>
         </Box>
         {/* Selection panel */}

--- a/client/src/components/TestSuite/TestSession.tsx
+++ b/client/src/components/TestSuite/TestSession.tsx
@@ -27,7 +27,6 @@ import ConfigMessagesDetailsPanel from './ConfigMessagesDetails/ConfigMessagesDe
 import useStyles from './styles';
 
 import { useAppStore } from '~/store/app';
-import lightTheme from '~/styles/theme';
 
 function mapRunnableRecursive(testGroup: TestGroup, map: Map<string, Runnable>) {
   map.set(testGroup.id, testGroup);
@@ -343,7 +342,6 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
         style={{
           overflow: 'auto',
           width: '100%',
-          backgroundColor: lightTheme.palette.common.grayLight,
         }}
       >
         <Box className={styles.contentContainer}>

--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
@@ -34,11 +34,11 @@ const TestGroupCard: FC<TestGroupCardProps> = ({
   const runnableType = 'tests' in runnable ? RunnableType.TestGroup : RunnableType.TestSuite;
 
   return (
-    <Card className={styles.testGroupCard} variant="outlined">
+    <Card variant="outlined" sx={{ mb: 3 }}>
       <Box className={styles.testGroupCardHeader}>
         {runnable.result && <ResultIcon result={runnable.result} />}
         <span className={styles.testGroupCardHeaderText}>
-          <Typography color="text.primary" className={styles.currentItem} component="div">
+          <Typography className={styles.currentItem} component="div">
             {'short_id' in runnable && (
               <Typography className={styles.shortId}>{`${runnable.short_id} `}</Typography>
             )}
@@ -57,6 +57,7 @@ const TestGroupCard: FC<TestGroupCardProps> = ({
           )}
         </span>
       </Box>
+      <Divider />
       {view === 'run' && shouldShowDescription(runnable, description) && (
         <>
           <Box m={2.5}>{description}</Box>

--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupListItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupListItem.tsx
@@ -95,7 +95,7 @@ const TestGroupListItem: FC<TestGroupListItemProps> = ({
           sx={{ userSelect: 'auto' }}
         >
           <List className={styles.testGroupCardList}>
-            <ListItem sx={{ padding: 0 }}>
+            <ListItem sx={{ p: 0 }}>
               <ListItemText
                 primary={
                   <Typography className={styles.nestedDescriptionHeader}>

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
@@ -11,6 +11,7 @@ import {
   Accordion,
   AccordionSummary,
   AccordionDetails,
+  Card,
 } from '@mui/material';
 import { RunnableType, Test, Request, ViewType } from '~/models/testSuiteModels';
 import TabPanel from './TabPanel';
@@ -221,58 +222,60 @@ const TestListItem: FC<TestListItemProps> = ({
           className={styles.accordionDetailContainer}
           onClick={(e) => e.stopPropagation()}
         >
-          <Tabs
-            value={panelIndex}
-            variant="scrollable"
-            className={styles.tabs}
-            onChange={(e, newIndex) => {
-              setPanelIndex(newIndex);
-            }}
-          >
-            <Tab label="Messages" {...a11yProps(0)} sx={darkTabText} />
-            <Tab label="HTTP Requests" {...a11yProps(1)} sx={darkTabText} />
-            <Tab label="Inputs" {...a11yProps(2)} sx={darkTabText} />
-            <Tab label="Outputs" {...a11yProps(3)} sx={darkTabText} />
-            <Tab label="About" {...a11yProps(4)} sx={darkTabText} />
-          </Tabs>
-          <Divider />
-          <TabPanel id={test.id} currentPanelIndex={panelIndex} index={0}>
-            <MessagesList messages={test.result?.messages || []} />
-          </TabPanel>
-          <TabPanel id={test.id} currentPanelIndex={panelIndex} index={1}>
-            {updateRequest && (
-              <RequestsList
-                requests={test.result?.requests || []}
-                resultId={test.result?.id || ''}
-                updateRequest={updateRequest}
+          <Card>
+            <Tabs
+              value={panelIndex}
+              variant="scrollable"
+              className={styles.tabs}
+              onChange={(e, newIndex) => {
+                setPanelIndex(newIndex);
+              }}
+            >
+              <Tab label="Messages" {...a11yProps(0)} sx={darkTabText} />
+              <Tab label="HTTP Requests" {...a11yProps(1)} sx={darkTabText} />
+              <Tab label="Inputs" {...a11yProps(2)} sx={darkTabText} />
+              <Tab label="Outputs" {...a11yProps(3)} sx={darkTabText} />
+              <Tab label="About" {...a11yProps(4)} sx={darkTabText} />
+            </Tabs>
+            <Divider />
+            <TabPanel id={test.id} currentPanelIndex={panelIndex} index={0}>
+              <MessagesList messages={test.result?.messages || []} />
+            </TabPanel>
+            <TabPanel id={test.id} currentPanelIndex={panelIndex} index={1}>
+              {updateRequest && (
+                <RequestsList
+                  requests={test.result?.requests || []}
+                  resultId={test.result?.id || ''}
+                  updateRequest={updateRequest}
+                />
+              )}
+            </TabPanel>
+            <TabPanel id={test.id} currentPanelIndex={panelIndex} index={2}>
+              <InputOutputsList
+                inputOutputs={test.result?.inputs || []}
+                noValuesMessage="No Inputs"
+                headerName="Input"
               />
-            )}
-          </TabPanel>
-          <TabPanel id={test.id} currentPanelIndex={panelIndex} index={2}>
-            <InputOutputsList
-              inputOutputs={test.result?.inputs || []}
-              noValuesMessage="No Inputs"
-              headerName="Input"
-            />
-          </TabPanel>
-          <TabPanel id={test.id} currentPanelIndex={panelIndex} index={3}>
-            <InputOutputsList
-              inputOutputs={test.result?.outputs || []}
-              noValuesMessage="No Outputs"
-              headerName="Output"
-            />
-          </TabPanel>
-          <TabPanel id={test.id} currentPanelIndex={panelIndex} index={4}>
-            {shouldShowDescription(test, testDescription) ? (
-              testDescription
-            ) : (
-              <Box p={2}>
-                <Typography variant="subtitle2" component="p">
-                  No Description
-                </Typography>
-              </Box>
-            )}
-          </TabPanel>
+            </TabPanel>
+            <TabPanel id={test.id} currentPanelIndex={panelIndex} index={3}>
+              <InputOutputsList
+                inputOutputs={test.result?.outputs || []}
+                noValuesMessage="No Outputs"
+                headerName="Output"
+              />
+            </TabPanel>
+            <TabPanel id={test.id} currentPanelIndex={panelIndex} index={4}>
+              {shouldShowDescription(test, testDescription) ? (
+                testDescription
+              ) : (
+                <Box p={2}>
+                  <Typography variant="subtitle2" component="p">
+                    No Description
+                  </Typography>
+                </Box>
+              )}
+            </TabPanel>
+          </Card>
         </AccordionDetails>
       </Accordion>
     </>

--- a/client/src/components/TestSuite/TestSuiteDetails/TestSuiteReport.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestSuiteReport.tsx
@@ -55,7 +55,7 @@ const TestSuiteReport: FC<TestSuiteReportProps> = ({ testSuite, suiteOptions }) 
   });
 
   const header = (
-    <Card className={styles.testGroupCard} variant="outlined">
+    <Card variant="outlined" sx={{ mb: 3 }}>
       <Box className={styles.testGroupCardHeader}>
         <span className={styles.testGroupCardHeaderText}>
           <Typography key="1" color="text.primary" className={styles.currentItem}>

--- a/client/src/components/TestSuite/TestSuiteDetails/styles.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/styles.tsx
@@ -21,23 +21,15 @@ export default makeStyles((theme: Theme) => ({
     display: 'inline',
   },
   testGroupCardHeader: {
-    padding: '8px 16px',
-    fontWeight: 600,
-    fontSize: '16px',
-    borderBottom: '1px solid rgba(0,0,0,.12)',
-    backgroundColor: theme.palette.common.blueGrayLightest,
-    borderTopLeftRadius: '4px',
-    borderTopRightRadius: '4px',
     display: 'flex',
-    minHeight: '36.5px',
-    alignItems: 'center',
     overflow: 'auto',
+    alignItems: 'center',
+    minHeight: '36.5px',
+    padding: '8px 16px',
+    backgroundColor: theme.palette.common.blueGrayLightest,
     '@media print': {
       padding: '0 8px',
     },
-  },
-  testGroupCard: {
-    marginBottom: '24px',
   },
   testGroupCardList: {
     padding: 0,

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -18,5 +18,5 @@ body, html {
 }
 
 body {
-  background-color: #FDF6EC;
+  background-color: #eeeeee;
 }

--- a/client/src/models/testSuiteModels.ts
+++ b/client/src/models/testSuiteModels.ts
@@ -105,6 +105,7 @@ export type TestSuite = Runnable & {
   presets?: PresetSummary[];
   suite_options?: SuiteOption[];
   links?: FooterLink[];
+  suite_summary?: string;
 };
 
 export interface TestSession {

--- a/client/src/styles/theme.tsx
+++ b/client/src/styles/theme.tsx
@@ -30,7 +30,7 @@ const colors = {
   red: '#d95d77',
   orange: '#F88B30',
   orangeDarker: '#C05702',
-  orangeLightest: '#FDF6EC',
+  orangeLightest: '#fff8f2',
   green: '#2fa874',
   blue: '#51788D',
   blueLight: '#9ad2f0',
@@ -38,12 +38,12 @@ const colors = {
   blueGrayLighter: '#e6ebf2',
   blueGrayLightest: '#f1f8ff',
   gray: 'rgba(0, 0, 0, 0.6)',
-  grayLight: '#cfd8dc',
-  grayLighter: '#eaeef2',
-  grayLightest: '#f2f2f2',
-  grayMedium: '#bbbdc0',
-  grayDark: '#595959',
-  grayDarkest: '#3a3a3a',
+  grayLight: '#bdbdbd',
+  grayLighter: '#e0e0e0',
+  grayLightest: '#eeeeee',
+  grayMedium: '#757575',
+  grayDark: '#616161',
+  grayDarkest: '#424242',
 };
 
 const paletteBase = {

--- a/dev_suites/dev_options_suite/options_suite.rb
+++ b/dev_suites/dev_options_suite/options_suite.rb
@@ -75,7 +75,7 @@ module OptionsSuite
     id :options
     description %(
       Suite description should go here
-      
+
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
       tempor incididunt ut labore et dolore magna aliqua.
 

--- a/dev_suites/dev_options_suite/options_suite.rb
+++ b/dev_suites/dev_options_suite/options_suite.rb
@@ -74,6 +74,8 @@ module OptionsSuite
     title 'Options Suite'
     id :options
     description %(
+      Suite description should go here
+      
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
       tempor incididunt ut labore et dolore magna aliqua.
 
@@ -85,8 +87,21 @@ module OptionsSuite
       aliquam. Nulla facilisi nullam vehicula ipsum a. Donec enim diam vulputate
       ut. Ornare arcu dui vivamus arcu felis bibendum ut tristique et. Malesuada
       fames ac turpis egestas maecenas pharetra convallis posuere morbi.
+    )
+    suite_summary %(
+      Suite options summary should go here
 
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua.
 
+      Feugiat in ante metus dictum. Dignissim cras tincidunt lobortis feugiat.
+      Consequat mauris nunc congue nisi vitae suscipit tellus mauris. Venenatis
+      a condimentum vitae sapien pellentesque habitant morbi tristique senectus.
+
+      Faucibus scelerisque eleifend donec pretium vulputate sapien nec sagittis
+      aliquam. Nulla facilisi nullam vehicula ipsum a. Donec enim diam vulputate
+      ut. Ornare arcu dui vivamus arcu felis bibendum ut tristique et. Malesuada
+      fames ac turpis egestas maecenas pharetra convallis posuere morbi.
     )
     links [
       {

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -580,6 +580,8 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/SuiteOption"
+      suite_summary:
+        type: "string"
   SuiteOption:
     type: "object"
     properties:

--- a/lib/inferno/apps/web/serializers/test_suite.rb
+++ b/lib/inferno/apps/web/serializers/test_suite.rb
@@ -12,6 +12,7 @@ module Inferno
           field :test_count
           field :version
           field :links
+          field :suite_summary
           association :suite_options, blueprint: SuiteOption
           association :presets, view: :summary, blueprint: Preset
         end

--- a/lib/inferno/entities/test_suite.rb
+++ b/lib/inferno/entities/test_suite.rb
@@ -99,6 +99,12 @@ module Inferno
 
           @links = links
         end
+
+        def suite_summary(suite_summary = nil)
+          return @suite_summary if suite_summary.nil?
+
+          @suite_summary = format_markdown(suite_summary)
+        end
       end
     end
   end

--- a/spec/inferno/web/serializers/test_suite_spec.rb
+++ b/spec/inferno/web/serializers/test_suite_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe Inferno::Web::Serializers::TestSuite do
       'version',
       'presets',
       'suite_options',
-      'links'
+      'links',
+      'suite_summary',
     ]
   end
   let(:full_keys) do
@@ -34,6 +35,7 @@ RSpec.describe Inferno::Web::Serializers::TestSuite do
     expect(serialized_suite['test_count']).to eq(suite.test_count)
     expect(serialized_suite['version']).to eq(suite.version)
     expect(serialized_suite['presets']).to eq([])
+    expect(serialized_suite['suite_summary']).to eq(suite.suite_summary)
   end
 
   it 'serializes a full suite view' do
@@ -56,6 +58,7 @@ RSpec.describe Inferno::Web::Serializers::TestSuite do
     expect(serialized_suite['version']).to eq(suite.version)
     expect(serialized_suite['configuration_messages']).to eq(expected_messages)
     expect(serialized_suite['presets']).to eq([])
+    expect(serialized_suite['suite_summary']).to eq(suite.suite_summary)
 
     expected_links = suite.links.map(&:with_indifferent_access)
     expect(serialized_suite['links']).to eq(expected_links)

--- a/spec/inferno/web/serializers/test_suite_spec.rb
+++ b/spec/inferno/web/serializers/test_suite_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Inferno::Web::Serializers::TestSuite do
       'presets',
       'suite_options',
       'links',
-      'suite_summary',
+      'suite_summary'
     ]
   end
   let(:full_keys) do


### PR DESCRIPTION
# Summary

1. Adds `suite_summary` as a field to TestSuites to be displayed in the options page
2. Adds tooltips to options with descriptions
3. Reconfigures some theme colors to use a neutral background + correctly stagger shades according to Material Design palettes
4. Restyles some components with minor upgrades (e.g. adding a Card to TestListItem)

# Testing Guidance

- Options suite should show the suite options summary instead of description, adding `suite_summary` to any test suite with options should also show the summary
- Hovering over  ? icons in the options page should show descriptions as tooltips

<img width="800" alt="Screen Shot 2022-08-18 at 2 59 36 PM" src="https://user-images.githubusercontent.com/11209247/185473511-29ac92fe-3db6-4e2c-b06f-57a6ad29b99e.png">
<img width="500" alt="Screen Shot 2022-08-18 at 2 59 47 PM" src="https://user-images.githubusercontent.com/11209247/185473520-403f807e-b027-4f52-891b-62a38a056866.png">

# Notes
Still taking feedback for all design changes!
