### PR TITLE
Release 039

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.9
+* Improve options selection UI background color when a banner is used.
+* Add suite_summary field that is displayed on suite options/landing page.
+
 # 0.3.8
 * Improve options selection UI.
 * Fix bug where test count was not taking suite options into account.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    inferno_core (0.3.8)
+    inferno_core (0.3.9)
       activesupport (~> 6.1)
       blueprinter (= 0.25.2)
       dotenv (~> 2.7)

--- a/lib/inferno/version.rb
+++ b/lib/inferno/version.rb
@@ -1,4 +1,4 @@
 module Inferno
   # Standard patterns for gem versions: https://guides.rubygems.org/patterns/
-  VERSION = '0.3.8'.freeze
+  VERSION = '0.3.9'.freeze
 end


### PR DESCRIPTION
# Summary

Release so we can start using `suite_summary` field in our g10 test kit ASAP, as this options page is an important part of the new user experience.
