### PR TITLE
Feature/test details

### DIFF
--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/ProblemBadge.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/ProblemBadge.tsx
@@ -29,6 +29,13 @@ const ProblemBadge: FC<ProblemBadgeProps> = ({
 }) => {
   const styles = useStyles();
 
+  const openPanel = () => {
+    if (view !== 'report') {
+      setPanelIndex(panelIndex);
+      setOpen(true);
+    }
+  };
+
   // Custom icon button to resolve nested interactive control error
   return (
     <Badge
@@ -36,6 +43,16 @@ const ProblemBadge: FC<ProblemBadgeProps> = ({
       max={9}
       overlap="circular"
       className={clsx([color, badgeStyle, styles.badgeBase])}
+      onClick={(e) => {
+        e.stopPropagation();
+        openPanel();
+      }}
+      onKeyDown={(e) => {
+        e.stopPropagation();
+        if (e.key === 'Enter') {
+          openPanel();
+        }
+      }}
     >
       <Tooltip describeChild title={description}>
         <Icon
@@ -45,16 +62,12 @@ const ProblemBadge: FC<ProblemBadgeProps> = ({
           className={clsx([styles.badgeIcon, color])}
           onClick={(e) => {
             e.stopPropagation();
-            if (view !== 'report') {
-              setPanelIndex(panelIndex);
-              setOpen(true);
-            }
+            openPanel();
           }}
           onKeyDown={(e) => {
             e.stopPropagation();
-            if (e.key === 'Enter' && view !== 'report') {
-              setPanelIndex(panelIndex);
-              setOpen(true);
+            if (e.key === 'Enter') {
+              openPanel();
             }
           }}
         />

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/RequestsList.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/RequestsList.tsx
@@ -1,6 +1,5 @@
 import React, { FC } from 'react';
 import {
-  Button,
   Typography,
   TableRow,
   TableCell,
@@ -10,7 +9,9 @@ import {
   Tooltip,
   TableHead,
   Box,
+  Button,
 } from '@mui/material';
+import InputIcon from '@mui/icons-material/Input';
 import { Request } from '~/models/testSuiteModels';
 import RequestDetailModal from '~/components/RequestDetailModal/RequestDetailModal';
 import { getRequestDetails } from '~/api/RequestsApi';
@@ -25,9 +26,10 @@ interface RequestsListProps {
 const RequestsList: FC<RequestsListProps> = ({ requests, resultId, updateRequest }) => {
   const [showDetails, setShowDetails] = React.useState(false);
   const [detailedRequest, setDetailedRequest] = React.useState<Request>();
+  const headerTitles = ['Direction', 'Type', 'URL', 'Status', ''];
   const styles = useStyles();
 
-  function showDetailsClick(request: Request) {
+  const showDetailsClick = (request: Request) => {
     if (request.request_headers === undefined) {
       getRequestDetails(request.id)
         .then((updatedRequest) => {
@@ -46,9 +48,32 @@ const RequestsList: FC<RequestsListProps> = ({ requests, resultId, updateRequest
       setDetailedRequest(request);
       setShowDetails(true);
     }
-  }
+  };
 
-  const headerTitles = ['Direction', 'Type', 'URL', 'Status', 'Details'];
+  const renderReferenceIcon = (request: Request) => {
+    if (request.result_id !== resultId) {
+      return (
+        <Tooltip title="This request was performed in another test and the result is used by this test">
+          <InputIcon fontSize="small" sx={{ pr: 1 }} />
+        </Tooltip>
+      );
+    }
+  };
+
+  const renderDetailsButton = (request: Request) => {
+    return (
+      <Button
+        onClick={() => showDetailsClick(request)}
+        color="secondary"
+        variant="contained"
+        size="small"
+        disableElevation
+      >
+        Details
+      </Button>
+    );
+  };
+
   const requestListHeader = (
     <TableRow key="req-header">
       {headerTitles.map((title) => (
@@ -61,45 +86,36 @@ const RequestsList: FC<RequestsListProps> = ({ requests, resultId, updateRequest
     </TableRow>
   );
 
-  const requestListItems = requests.map((request: Request, index: number) => {
-    return (
-      <TableRow key={`reqRow-${index}`}>
-        <TableCell>
-          <Typography variant="subtitle2" component="p">
-            {request.direction}
-          </Typography>
-        </TableCell>
-        <TableCell>
+  const requestListItems = requests.map((request: Request, index: number) => (
+    <TableRow key={`reqRow-${index}`}>
+      <TableCell>
+        <Typography variant="subtitle2" component="p">
+          {request.direction}
+        </Typography>
+      </TableCell>
+      <TableCell>
+        <Box display="flex">
+          {renderReferenceIcon(request)}
           <Typography variant="subtitle2" component="p">
             {request.verb}
           </Typography>
-        </TableCell>
-        <TableCell className={styles.requestUrlContainer}>
-          <Tooltip title={request.url} placement="bottom-start">
-            <Typography variant="subtitle2" component="p" className={styles.requestUrl}>
-              {request.url}
-            </Typography>
-          </Tooltip>
-        </TableCell>
-        <TableCell>
-          <Typography variant="subtitle2" component="p" className={styles.bolderText}>
-            {request.status}
+        </Box>
+      </TableCell>
+      <TableCell className={styles.requestUrlContainer}>
+        <Tooltip title={request.url} placement="bottom-start">
+          <Typography variant="subtitle2" component="p" className={styles.requestUrl}>
+            {request.url}
           </Typography>
-        </TableCell>
-        <TableCell>
-          <Button
-            onClick={() => showDetailsClick(request)}
-            variant="contained"
-            color="secondary"
-            size="small"
-            disableElevation
-          >
-            Details
-          </Button>
-        </TableCell>
-      </TableRow>
-    );
-  });
+        </Tooltip>
+      </TableCell>
+      <TableCell>
+        <Typography variant="subtitle2" component="p" className={styles.bolderText}>
+          {request.status}
+        </Typography>
+      </TableCell>
+      <TableCell>{renderDetailsButton(request)}</TableCell>
+    </TableRow>
+  ));
 
   return (
     <>

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
@@ -221,7 +221,7 @@ const TestListItem: FC<TestListItemProps> = ({
           key={`${tab.label}-${index}`}
           label={
             <Tooltip title={`No ${tab.label.toLowerCase()} available`}>
-              <span>{tab.label}</span>
+              <>{tab.label}</>
             </Tooltip>
           }
           {...a11yProps(index)}

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
@@ -221,7 +221,7 @@ const TestListItem: FC<TestListItemProps> = ({
           key={`${tab.label}-${index}`}
           label={
             <Tooltip title={`No ${tab.label.toLowerCase()} available`}>
-              <>{tab.label}</>
+              <Typography>{tab.label}</Typography>
             </Tooltip>
           }
           {...a11yProps(index)}


### PR DESCRIPTION
# Summary
Fixes a number of small issues to the TestDetail component:
- Disable tabs with no data, adds a tooltip to indicate no data (open to feedback about how this behaves)
- Added icon to Requests tab rows to indicate request is a reference
- Added click behavior to badges to open correct tab

# Testing Guidance
- Run tests, open some accordions: check that tabs with no data are disabled and the immediately open tab is the first tab with data
<img width="810" alt="Screen Shot 2022-08-25 at 11 51 02 AM" src="https://user-images.githubusercontent.com/11209247/186711782-58fab6a9-fd6c-4815-923b-2231a24701d1.png">

- All requests that are references should display an icon
<img width="806" alt="Screen Shot 2022-08-25 at 11 43 37 AM" src="https://user-images.githubusercontent.com/11209247/186710236-cfbbc07f-5087-4dfc-8b6d-cbe3f76911d8.png">

- Clicking on the badge on an icon instead of the icon itself should open the correct tab
