### PR TITLE
Fix test run creation performance

### DIFF
--- a/config/presets/g10_certification_preset.json.erb
+++ b/config/presets/g10_certification_preset.json.erb
@@ -246,6 +246,21 @@
       "value": null
     },
     {
+      "name": "ehr_patient_client_id",
+      "description": "Client ID provided during registration of Inferno as an EHR launch application",
+      "title": "EHR Launch Client ID",
+      "type": "text",
+      "value": "SAMPLE_CONFIDENTIAL_CLIENT_ID"
+    },
+    {
+      "name": "ehr_patient_client_secret",
+      "description": "Client Secret provided during registration of Inferno as an EHR launch application",
+      "optional": true,
+      "title": "EHR Launch Client Secret",
+      "type": "text",
+      "value": "SAMPLE_CONFIDENTIAL_CLIENT_SECRET"
+    },
+    {
       "name": "single_patient_registration_supported",
       "type": "radio",
       "title": "Health IT Module demonstrated support for application registration for single patients.",

--- a/lib/inferno/apps/web/controllers/test_runs/create.rb
+++ b/lib/inferno/apps/web/controllers/test_runs/create.rb
@@ -19,9 +19,10 @@ module Inferno
           end
 
           def persist_inputs(params, test_run)
+            available_inputs = test_run.runnable.available_inputs
             params[:inputs]&.each do |input_params|
               input =
-                test_run.runnable.available_inputs
+                available_inputs
                   .find { |_, runnable_input| runnable_input.name == input_params[:name] }
                   &.last
 


### PR DESCRIPTION
# Summary
`Runnable#available_inputs` is expensive, and it was being called repeatedly when creating a test run. When creating a test run for a large test suite with a large number of inputs (like the whole g10 suite with options), it would time out.

# Testing Guidance
Follow the instructions in the `Gemfile` for testing with the g10 suite. On `main`, it will hang when trying to run the entire suite. On this branch it won't.