### PR TITLE
options-width

### DIFF
--- a/client/src/components/App/App.tsx
+++ b/client/src/components/App/App.tsx
@@ -49,9 +49,9 @@ const App: FC<unknown> = () => {
     }
   }, [testSuites]);
 
-  function handleResize() {
+  const handleResize = () => {
     setWindowIsSmall(window.innerWidth < 1000);
-  }
+  };
 
   if (!testSuites || (testSuites.length === 1 && !testSession)) {
     return <></>;

--- a/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
+++ b/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
@@ -168,7 +168,7 @@ const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuites }) => {
           id="description-container"
           display={!windowIsSmall && descriptionIsTall ? 'flex' : ''}
           flex={!windowIsSmall && descriptionIsTall ? '1 1 0' : ''}
-          maxWidth={`${minDescriptionWidth}px`}
+          maxWidth={!descriptionIsTall ? `${minDescriptionWidth}px` : 'unset'}
           maxHeight="100%"
           overflow="auto"
           ml={3}

--- a/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
+++ b/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
@@ -41,7 +41,8 @@ const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuites }) => {
   const [selectedSuiteOptions, setSelectedSuiteOptions] = React.useState<SuiteOption[]>(
     initialSelectedSuiteOptions || []
   );
-  const [descriptionWidth, setDescriptionWidth] = React.useState<number>(400);
+  const [descriptionIsTall, setDescriptionIsTall] = React.useState<boolean>(false);
+  const [minDescriptionWidth, setMinDescriptionWidth] = React.useState<number>(0);
 
   useEffect(() => {
     window.addEventListener('resize', handleResize);
@@ -55,17 +56,10 @@ const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuites }) => {
   const handleResize = () => {
     const description = document.getElementById('description-container');
     const selectionPanel = document.getElementById('selection-panel');
-    if (description && selectionPanel) {
-      const descriptionHasScrollBar = description.scrollHeight > description.clientHeight;
-      if (descriptionHasScrollBar && !windowIsSmall) {
-        const descriptionMargin =
-          parseFloat(window.getComputedStyle(description).marginLeft) +
-          parseFloat(window.getComputedStyle(description).marginRight);
-        setDescriptionWidth(window.innerWidth - selectionPanel.clientWidth - descriptionMargin);
-      } else if (!windowIsSmall) {
-        // Minimum width if !windowIsSmall (minimum window width is 1000)
-        setDescriptionWidth(1000 - selectionPanel.clientWidth);
-      }
+    if (!windowIsSmall && description) {
+      setDescriptionIsTall(description.scrollHeight > description.clientHeight);
+      // Minimum width if !windowIsSmall (minimum window width is 1000)
+      setMinDescriptionWidth(1000 - (selectionPanel?.clientWidth || 0));
     }
   };
 
@@ -171,12 +165,14 @@ const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuites }) => {
       >
         {/* Description */}
         <Box
+          id="description-container"
+          display={!windowIsSmall && descriptionIsTall ? 'flex' : ''}
+          flex={!windowIsSmall && descriptionIsTall ? '1 1 0' : ''}
+          maxWidth={`${minDescriptionWidth}px`}
           maxHeight="100%"
           overflow="auto"
-          id="description-container"
           ml={3}
           my={3}
-          sx={{ maxWidth: windowIsSmall ? 'none' : descriptionWidth }}
         >
           <Typography
             variant="h6"


### PR DESCRIPTION
# Summary
If the suite options description is long (scrollbar), the width of the container will resize to optimally use space. 

# Testing Guidance
You may need to mock a description that is long for this. While the description is long, resizing the window should also resize the description container. 

If the description is short, no resizing is necessary. This should only occur on larger screens; small screens should behave as normal.
