### PR TITLE
FI-1719: Fix request order

### DIFF
--- a/client/src/components/RequestDetailModal/__mocked_data__/mockData.ts
+++ b/client/src/components/RequestDetailModal/__mocked_data__/mockData.ts
@@ -3,6 +3,7 @@ import { Request } from 'models/testSuiteModels';
 export const mockedRequest: Request = {
   direction: 'outgoing',
   id: '20a3709a-eebf-42a7-9035-a58b00c8f104',
+  index: 1,
   request_body: null,
   request_headers: [
     { name: 'user-agent', value: 'Ruby FHIR Client' },
@@ -29,6 +30,7 @@ export const mockedRequest: Request = {
 export const codeResponseWithHTML: Request = {
   direction: 'outgoing',
   id: 'de793781-5eed-421a-88d3-8029499f4bce',
+  index: 2,
   status: 200,
   timestamp: '2022-04-21T22:22:04.039Z',
   url: 'NA',
@@ -42,6 +44,7 @@ export const codeResponseWithHTML: Request = {
 export const codeResponseWithJSON: Request = {
   direction: 'outgoing',
   id: 'de793781-5eed-421a-88d3-8029499f4bce',
+  index: 3,
   status: 200,
   timestamp: '2022-04-21T22:22:04.039Z',
   url: 'NA',

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/RequestsList.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/RequestsList.tsx
@@ -86,36 +86,38 @@ const RequestsList: FC<RequestsListProps> = ({ requests, resultId, updateRequest
     </TableRow>
   );
 
-  const requestListItems = requests.map((request: Request, index: number) => (
-    <TableRow key={`reqRow-${index}`}>
-      <TableCell>
-        <Typography variant="subtitle2" component="p">
-          {request.direction}
-        </Typography>
-      </TableCell>
-      <TableCell>
-        <Box display="flex">
-          {renderReferenceIcon(request)}
+  const requestListItems = [...requests]
+    .sort((request1, request2) => request1.index - request2.index)
+    .map((request: Request, index: number) => (
+      <TableRow key={`reqRow-${index}`}>
+        <TableCell>
           <Typography variant="subtitle2" component="p">
-            {request.verb}
+            {request.direction}
           </Typography>
-        </Box>
-      </TableCell>
-      <TableCell className={styles.requestUrlContainer}>
-        <Tooltip title={request.url} placement="bottom-start">
-          <Typography variant="subtitle2" component="p" className={styles.requestUrl}>
-            {request.url}
+        </TableCell>
+        <TableCell>
+          <Box display="flex">
+            {renderReferenceIcon(request)}
+            <Typography variant="subtitle2" component="p">
+              {request.verb}
+            </Typography>
+          </Box>
+        </TableCell>
+        <TableCell className={styles.requestUrlContainer}>
+          <Tooltip title={request.url} placement="bottom-start">
+            <Typography variant="subtitle2" component="p" className={styles.requestUrl}>
+              {request.url}
+            </Typography>
+          </Tooltip>
+        </TableCell>
+        <TableCell>
+          <Typography variant="subtitle2" component="p" className={styles.bolderText}>
+            {request.status}
           </Typography>
-        </Tooltip>
-      </TableCell>
-      <TableCell>
-        <Typography variant="subtitle2" component="p" className={styles.bolderText}>
-          {request.status}
-        </Typography>
-      </TableCell>
-      <TableCell>{renderDetailsButton(request)}</TableCell>
-    </TableRow>
-  ));
+        </TableCell>
+        <TableCell>{renderDetailsButton(request)}</TableCell>
+      </TableRow>
+    ));
 
   return (
     <>

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/__tests__/RequestList.test.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/__tests__/RequestList.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import ThemeProvider from 'components/ThemeProvider';
+
+import RequestsList from '../RequestsList';
+import {
+  mockedRequest,
+  codeResponseWithHTML,
+} from '../../../../RequestDetailModal/__mocked_data__/mockData';
+
+describe('The RequestsList component', () => {
+  test('it orders requests based on their index', () => {
+    const requests = [codeResponseWithHTML, mockedRequest];
+
+    render(
+      <ThemeProvider>
+        <RequestsList requests={requests} resultId="abc" updateRequest={() => {}} />
+      </ThemeProvider>
+    );
+
+    const renderedRequests = document.querySelectorAll('tbody > tr');
+
+    expect(renderedRequests.length).toEqual(requests.length);
+    expect(renderedRequests[0]).toHaveTextContent(mockedRequest.url);
+    expect(renderedRequests[1]).toHaveTextContent(codeResponseWithHTML.url);
+  });
+});

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/__tests__/RequestList.test.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/__tests__/RequestList.test.tsx
@@ -6,7 +6,7 @@ import RequestsList from '../RequestsList';
 import {
   mockedRequest,
   codeResponseWithHTML,
-} from '../../../../RequestDetailModal/__mocked_data__/mockData';
+} from '~/components/RequestDetailModal/__mocked_data__/mockData';
 
 describe('The RequestsList component', () => {
   test('it orders requests based on their index', () => {

--- a/client/src/models/testSuiteModels.ts
+++ b/client/src/models/testSuiteModels.ts
@@ -13,6 +13,7 @@ export type RequestHeader = {
 export type Request = {
   direction: string;
   id: string;
+  index: number;
   status: number;
   timestamp: string;
   url: string;

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -448,6 +448,7 @@ definitions:
     type: "object"
     required:
     - "id"
+    - "index"
     - "created_at"
     - "verb"
     - "url"
@@ -456,6 +457,8 @@ definitions:
     properties:
       id:
         type: "string"
+      index:
+        type: "integer"
       created_at:
         type: "string"
       verb:
@@ -473,6 +476,7 @@ definitions:
     type: "object"
     required:
     - "id"
+    - "index"
     - "created_at"
     - "verb"
     - "url"
@@ -481,6 +485,8 @@ definitions:
     properties:
       id:
         type: "string"
+      index:
+        type: "integer"
       created_at:
         type: "string"
       verb:

--- a/lib/inferno/apps/web/serializers/request.rb
+++ b/lib/inferno/apps/web/serializers/request.rb
@@ -3,7 +3,8 @@ module Inferno
     module Serializers
       class Request < Serializer
         view :summary do
-          field :id
+          identifier :id
+          field :index
           field :created_at, name: :timestamp
           field :verb
           field :url

--- a/lib/inferno/apps/web/serializers/result.rb
+++ b/lib/inferno/apps/web/serializers/result.rb
@@ -1,4 +1,5 @@
 require 'json'
+require_relative 'request'
 
 module Inferno
   module Web
@@ -27,7 +28,9 @@ module Inferno
         end
 
         association :messages, blueprint: Message, if: :field_present?
-        association :requests, blueprint: Request, view: :summary, if: :field_present?
+        field :requests do |result, _options|
+          Request.render_as_hash(result.requests.sort_by(&:index), view: :summary)
+        end
       end
     end
   end

--- a/spec/requests/results_spec.rb
+++ b/spec/requests/results_spec.rb
@@ -9,8 +9,15 @@ RSpec.describe '/(test_sessions/test_runs)/:id/results' do
   let(:test_session) { test_run.test_session }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let!(:result) do
-    repo_create(:result, message_count: 1, test_run_id: test_run.id, test_session_id: test_session.id)
+    repo_create(
+      :result,
+      message_count: 1,
+      request_count: 2,
+      test_run_id: test_run.id,
+      test_session_id: test_session.id
+    )
   end
+  let(:requests) { result.requests }
 
   describe '/test_runs/:test_run_id/results' do
     it 'renders the results json for a test_run' do
@@ -34,6 +41,18 @@ RSpec.describe '/(test_sessions/test_runs)/:id/results' do
 
       expect(message['message']).to eq(persisted_message.message)
       expect(message['type']).to eq(persisted_message.type)
+    end
+
+    it 'includes the indices for request summaries' do
+      get router.path(:api_test_run_results, test_run_id: test_run.id)
+
+      expect(last_response.status).to eq(200)
+      expect(parsed_body.length).to eq(1)
+
+      serialized_requests = parsed_body.first['requests']
+
+      expect(serialized_requests).to all(include('index'))
+      expect(serialized_requests.first['index']).to be_an(Integer)
     end
   end
 

--- a/spec/requests/results_spec.rb
+++ b/spec/requests/results_spec.rb
@@ -54,6 +54,17 @@ RSpec.describe '/(test_sessions/test_runs)/:id/results' do
       expect(serialized_requests).to all(include('index'))
       expect(serialized_requests.first['index']).to be_an(Integer)
     end
+
+    it 'sorts the request summaries' do
+      get router.path(:api_test_run_results, test_run_id: test_run.id)
+
+      expect(last_response.status).to eq(200)
+      expect(parsed_body.length).to eq(1)
+
+      serialized_requests = parsed_body.first['requests']
+
+      expect(serialized_requests.first['index']).to be < serialized_requests.last['index']
+    end
   end
 
   describe '/test_sessions/:test_session_id/results' do


### PR DESCRIPTION
# Summary
We store an index for each request so that we can order them correctly, but that index was not being serialized to the front end. This branch adds the index to the request summary serializer and sorts the requests in the front end.

# Testing Guidance
This is difficult to really test because it requires that multiple requests be made in the same millisecond. Unit tests demonstrate the functionality.