### PR TITLE
Fix pane scrolling bug when developing a testkit locally

### DIFF
--- a/client/src/components/TestSuite/TestSession.tsx
+++ b/client/src/components/TestSuite/TestSession.tsx
@@ -302,12 +302,19 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
     }
   }
 
-  const bannerHeight = document.getElementsByClassName('banner')[0]?.clientHeight;
+  const bannerHeight = () => {
+    const bannerElementHeight = document.getElementsByClassName('banner')[0]?.clientHeight;
+    if (bannerElementHeight === undefined || bannerElementHeight === null) {
+      return 0;
+    }
+
+    return bannerElementHeight;
+  };
 
   return (
     <Box
       className={styles.testSuiteMain}
-      maxHeight={`calc(100vh - 64px - 56px - ${bannerHeight}px)`}
+      maxHeight={`calc(100vh - 64px - 56px - ${bannerHeight()}px)`}
     >
       {renderTestRunProgressBar()}
       {windowIsSmall ? (


### PR DESCRIPTION
The TestSession component has a left pane and a TestSuite right pane. The bug on main is that they both scroll together.  This is because a style is missing on this element `maxHeight`.  I believe this is happening because of the javascript template literal.  I saw inflection locally.  Essentially I built the gem off of main and saw the bug, then I changed to a static string and the bug was fixed. Then I changed this to use a function (essentially same behavior as the template literal) and the bug was still fixed.

This was surprising.  I don't know why you can't
```
`calc(100vh - 64px - 56px - ${bannerHeight}px)`
```
When bannerHeight is just a variable but it doesn't seem to work.

My guess is maybe this code is loaded before the DOM fires.  In that case having a binding function would fix this.  I bet the template literal errors or becomes undefined and the build process strips out the style.

# Summary

The bug is that the panes are locked together when scrolling (only when in use in a test kit locally).  In order to reproduce you have start up a test kit.  In order to fix it and see inflection, you have to build a gem locally and install it manually.  For that reason, I'm including gifs.

![before](https://user-images.githubusercontent.com/45436454/191063334-15d0057a-cf96-41c6-ab5d-d79ec26204b2.gif)

This PR's behavior (the fix)

![after](https://user-images.githubusercontent.com/45436454/191063460-f48025cf-73cf-4c0f-97fc-ae57fcb8507f.gif)



# Testing Guidance

