### PR TITLE
fix double scrollbar bug

### DIFF
--- a/lib/inferno/apps/web/index.html.erb
+++ b/lib/inferno/apps/web/index.html.erb
@@ -38,6 +38,7 @@
         height: 100%;
         display: flex;
         flex-direction: column;
+        overflow: hidden;
       }
       .banner {
         flex-shrink: 1;


### PR DESCRIPTION
# Summary
Removes the extra scrollbar and flexes the main container instead when a banner is present.


# Testing Guidance
Make sure this is no longer showing up:

<img width="247" alt="Screen Shot 2022-09-19 at 11 50 46 AM" src="https://user-images.githubusercontent.com/11209247/191062019-2ebb8dd6-1417-4ff4-a05d-ac71bb236503.png">

Also confirm that deployment version is working fine, as well as smaller screens.
