### PR TITLE
Feature/fi 1720 copy url

### DIFF
--- a/client/src/components/RequestDetailModal/RequestDetailModal.tsx
+++ b/client/src/components/RequestDetailModal/RequestDetailModal.tsx
@@ -4,6 +4,7 @@ import {
   DialogContent,
   DialogTitle,
   Divider,
+  IconButton,
   Tooltip,
   Typography,
 } from '@mui/material';
@@ -13,6 +14,7 @@ import CodeBlock from './CodeBlock';
 import HeaderTable from './HeaderTable';
 import useStyles from './styles';
 import InputIcon from '@mui/icons-material/Input';
+import { ContentCopy } from '@mui/icons-material';
 
 export interface RequestDetailModalProps {
   request?: Request;
@@ -50,6 +52,18 @@ const RequestDetailModal: FC<RequestDetailModalProps> = ({
           <Box pr={1} className={styles.modalTitleURL}>
             {request?.url}
           </Box>
+          {request?.url && (
+            <Box pr={1}>
+              <IconButton
+                color="secondary"
+                onClick={() => {
+                  void navigator.clipboard.writeText(request.url);
+                }}
+              >
+                <ContentCopy fontSize="inherit" />
+              </IconButton>
+            </Box>
+          )}
           <Box display="flex" flexShrink={0}>
             &#8594; {request?.status}
           </Box>

--- a/client/src/components/RequestDetailModal/RequestDetailModal.tsx
+++ b/client/src/components/RequestDetailModal/RequestDetailModal.tsx
@@ -29,7 +29,17 @@ const RequestDetailModal: FC<RequestDetailModalProps> = ({
   modalVisible,
   usedRequest,
 }) => {
+  const [copySuccess, setCopySuccess] = React.useState(false);
   const styles = useStyles();
+
+  const copyTextClick = async (text: string) => {
+    await navigator.clipboard.writeText(text).then(() => {
+      setCopySuccess(true);
+      setTimeout(() => {
+        setCopySuccess(false);
+      }, 2000); // 2 second delay
+    });
+  };
 
   const usedRequestIcon = (
     <Tooltip title="This request was performed in another test and the result is used by this test">
@@ -53,16 +63,13 @@ const RequestDetailModal: FC<RequestDetailModalProps> = ({
             {request?.url}
           </Box>
           {request?.url && (
-            <Box pr={1}>
-              <IconButton
-                color="secondary"
-                onClick={() => {
-                  void navigator.clipboard.writeText(request.url);
-                }}
-              >
-                <ContentCopy fontSize="inherit" />
-              </IconButton>
-            </Box>
+            <Tooltip open={copySuccess} title="Text copied!">
+              <Box pr={1}>
+                <IconButton color="secondary" onClick={() => void copyTextClick(request.url)}>
+                  <ContentCopy fontSize="inherit" />
+                </IconButton>
+              </Box>
+            </Tooltip>
           )}
           <Box display="flex" flexShrink={0}>
             &#8594; {request?.status}

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/RequestsList.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/RequestsList.tsx
@@ -1,5 +1,8 @@
 import React, { FC } from 'react';
 import {
+  Box,
+  Button,
+  IconButton,
   Typography,
   TableRow,
   TableCell,
@@ -8,14 +11,13 @@ import {
   TableBody,
   Tooltip,
   TableHead,
-  Box,
-  Button,
 } from '@mui/material';
 import InputIcon from '@mui/icons-material/Input';
 import { Request } from '~/models/testSuiteModels';
 import RequestDetailModal from '~/components/RequestDetailModal/RequestDetailModal';
 import { getRequestDetails } from '~/api/RequestsApi';
 import useStyles from './styles';
+import { ContentCopy } from '@mui/icons-material';
 
 interface RequestsListProps {
   resultId: string;
@@ -25,6 +27,7 @@ interface RequestsListProps {
 
 const RequestsList: FC<RequestsListProps> = ({ requests, resultId, updateRequest }) => {
   const [showDetails, setShowDetails] = React.useState(false);
+  const [copySuccess, setCopySuccess] = React.useState(false);
   const [detailedRequest, setDetailedRequest] = React.useState<Request>();
   const headerTitles = ['Direction', 'Type', 'URL', 'Status', ''];
   const styles = useStyles();
@@ -48,6 +51,12 @@ const RequestsList: FC<RequestsListProps> = ({ requests, resultId, updateRequest
       setDetailedRequest(request);
       setShowDetails(true);
     }
+  };
+
+  const copyTextClick = async (text: string) => {
+    await navigator.clipboard.writeText(text).then(() => {
+      setCopySuccess(true);
+    });
   };
 
   const renderReferenceIcon = (request: Request) => {
@@ -102,11 +111,22 @@ const RequestsList: FC<RequestsListProps> = ({ requests, resultId, updateRequest
         </Box>
       </TableCell>
       <TableCell className={styles.requestUrlContainer}>
-        <Tooltip title={request.url} placement="bottom-start">
-          <Typography variant="subtitle2" component="p" className={styles.requestUrl}>
-            {request.url}
-          </Typography>
-        </Tooltip>
+        <Box display="flex" alignItems="center">
+          <Tooltip title={request.url} placement="bottom-start">
+            <Typography variant="subtitle2" component="p" className={styles.requestUrl}>
+              {request.url}
+            </Typography>
+          </Tooltip>
+          <Tooltip open={copySuccess} title="Text copied!">
+            <IconButton
+              size="small"
+              color="secondary"
+              onClick={() => void copyTextClick(request.url)}
+            >
+              <ContentCopy fontSize="inherit" />
+            </IconButton>
+          </Tooltip>
+        </Box>
       </TableCell>
       <TableCell>
         <Typography variant="subtitle2" component="p" className={styles.bolderText}>

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/RequestsList.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/RequestsList.tsx
@@ -27,7 +27,7 @@ interface RequestsListProps {
 
 const RequestsList: FC<RequestsListProps> = ({ requests, resultId, updateRequest }) => {
   const [showDetails, setShowDetails] = React.useState(false);
-  const [copySuccess, setCopySuccess] = React.useState(false);
+  const [copySuccess, setCopySuccess] = React.useState({});
   const [detailedRequest, setDetailedRequest] = React.useState<Request>();
   const headerTitles = ['Direction', 'Type', 'URL', 'Status', ''];
   const styles = useStyles();
@@ -55,7 +55,11 @@ const RequestsList: FC<RequestsListProps> = ({ requests, resultId, updateRequest
 
   const copyTextClick = async (text: string) => {
     await navigator.clipboard.writeText(text).then(() => {
-      setCopySuccess(true);
+      setCopySuccess({ ...copySuccess, [text]: true });
+      setTimeout(() => {
+        // Reset map instead of setting false to avoid async bug
+        setCopySuccess({});
+      }, 2000); // 2 second delay
     });
   };
 
@@ -117,7 +121,10 @@ const RequestsList: FC<RequestsListProps> = ({ requests, resultId, updateRequest
               {request.url}
             </Typography>
           </Tooltip>
-          <Tooltip open={copySuccess} title="Text copied!">
+          <Tooltip
+            open={copySuccess[request.url as keyof typeof copySuccess] || false}
+            title="Text copied!"
+          >
             <IconButton
               size="small"
               color="secondary"


### PR DESCRIPTION
# Summary
Adds copy buttons to requests lists and request details modal. Tooltip should appear on a successful copy.

https://user-images.githubusercontent.com/11209247/191786005-c8e8f1fb-6f0a-4f49-8509-a0238947a05e.mov

# Testing Guidance
Try copying request urls in both the list and the modal when clicking the `Details` button. Also try breaking the tooltip by clicking around/outside the window when it appears.
