### PR TITLE
FI-1732: Fix .env* load order

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,4 @@
 LOAD_DEV_SUITES=*
-VALIDATOR_URL=https://inferno.healthit.gov/validatorapi
 JS_HOST=http://localhost:3000
 BASE_PATH=inferno
 REFERENCE_SERVER_URL=https://inferno.healthit.gov

--- a/lib/inferno/config/boot.rb
+++ b/lib/inferno/config/boot.rb
@@ -4,4 +4,9 @@ ENV['APP_ENV'] ||= 'development'
 
 root_path = Dir.pwd
 
-Dotenv.load(File.join(root_path, '.env'), File.join(root_path, ".env.#{ENV.fetch('APP_ENV', nil)}"))
+Dotenv.load(
+  File.join(root_path, ".env.#{ENV.fetch('APP_ENV', nil)}.local"),
+  File.join(root_path, '.env.local'),
+  File.join(root_path, ".env.#{ENV.fetch('APP_ENV', nil)}"),
+  File.join(root_path, '.env')
+)


### PR DESCRIPTION
# Summary
Inferno is loading `.env` files out of order, e.g. it loads `.env` before `.env.development`. The `dotenv` gem does not overwrite environment variables, so values set in `.env` would take precedence over those set in `.env.development`. This branch adds support for `.local` files and loads them [in the same order `dotenv-rails` would](https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use) (which is what most people would expect). 

# Testing Guidance
Unit tests should still pass. You should be able to run tests as usual. You should be able to change values in `.env` and have the values in `.env.development` take precedence.
