### PR TITLE
FI-1735: Check for foreman installation

### DIFF
--- a/docker-compose.background.yml
+++ b/docker-compose.background.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   validator_service:
-    image: validator
+    image: infernocommunity/fhir-validator-service
     # Update this path to match your directory structure
     volumes:
       - ./igs:/home/igs

--- a/lib/inferno/apps/cli/main.rb
+++ b/lib/inferno/apps/cli/main.rb
@@ -19,6 +19,10 @@ module Inferno
 
       desc 'start', 'Start Inferno'
       def start
+        if `gem list -i foreman`.chomp == 'false'
+          puts "You must install foreman with 'gem install foreman' prior to running inferno."
+        end
+
         system 'foreman start --env=/dev/null'
       end
 


### PR DESCRIPTION
# Summary
Add a message to `inferno start` if foreman isn't installed.

# Testing Guidance
`gem uninstall foreman`, then run `bin/inferno start`.
