### PR TITLE
Fix UI bug where the TestListItem accordian would expand to the wrong tab

### DIFF
--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/RequestsList.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/RequestsList.tsx
@@ -153,14 +153,14 @@ const RequestsList: FC<RequestsListProps> = ({ requests, resultId, updateRequest
   return (
     <>
       {requests.length > 0 ? (
-        <TableContainer>
+        <TableContainer data-testid="requests-list">
           <Table size="small" className={styles.table}>
             <TableHead>{requestListHeader}</TableHead>
             <TableBody>{requestListItems}</TableBody>
           </Table>
         </TableContainer>
       ) : (
-        <Box p={2}>
+        <Box p={2} data-testid="requests-list">
           <Typography variant="subtitle2" component="p">
             No Requests
           </Typography>
@@ -171,6 +171,7 @@ const RequestsList: FC<RequestsListProps> = ({ requests, resultId, updateRequest
         modalVisible={showDetails}
         hideModal={() => setShowDetails(false)}
         usedRequest={detailedRequest?.result_id !== resultId}
+        data-testid="requests-detail-modal"
       />
     </>
   );

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
@@ -25,6 +25,7 @@ import TestRunButton from '~/components/TestSuite/TestRunButton/TestRunButton';
 import type { MessageCounts } from './helper';
 import { countMessageTypes } from './helper';
 import TestRunDetail from './TestRunDetail';
+import type { TabProps } from './TestRunDetail';
 
 interface TestListItemProps {
   test: Test;
@@ -183,6 +184,33 @@ const TestListItem: FC<TestListItemProps> = ({
     </>
   );
 
+  // Find first tab with data.  If no tabs have data, return the About tab index.
+  const findPopulatedTabIndex = (): number => {
+    const firstTab = tabs.findIndex(
+      (tab) => tab.label !== 'About' && tab.value && tab.value?.length > 0
+    );
+
+    if (firstTab === -1) {
+      return tabs.findIndex((tab) => tab.label === 'About');
+    } else {
+      return firstTab;
+    }
+  };
+
+  const handleAccordionClick = () => {
+    const firstTab = findPopulatedTabIndex();
+    setTabIndex(firstTab);
+    setOpen(!open);
+  };
+
+  const tabs: TabProps[] = [
+    { label: 'Messages', value: test.result?.messages },
+    { label: 'Requests', value: test.result?.requests },
+    { label: 'Inputs', value: test.result?.inputs },
+    { label: 'Outputs', value: test.result?.outputs },
+    { label: 'About', value: test.description },
+  ];
+
   return (
     <>
       <Accordion
@@ -191,7 +219,7 @@ const TestListItem: FC<TestListItemProps> = ({
         sx={view === 'report' ? { pointerEvents: 'none' } : {}}
         expanded={open}
         TransitionProps={{ unmountOnExit: true }}
-        onClick={() => setOpen(!open)}
+        onClick={handleAccordionClick}
       >
         <AccordionSummary
           id={`${test.id}-summary`}
@@ -217,11 +245,17 @@ const TestListItem: FC<TestListItemProps> = ({
         <Divider />
         <AccordionDetails
           title={`${test.id}-detail`}
+          data-testid={`${test.id}-detail`}
           className={styles.accordionDetailContainer}
           onClick={(e) => e.stopPropagation()}
         >
           {view === 'run' && (
-            <TestRunDetail test={test} currentTabIndex={tabIndex} updateRequest={updateRequest} />
+            <TestRunDetail
+              test={test}
+              tabs={tabs}
+              currentTabIndex={tabIndex}
+              updateRequest={updateRequest}
+            />
           )}
           {view === 'report' && showReportDetails && reportDetails}
         </AccordionDetails>

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestRunDetail.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestRunDetail.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useMemo } from 'react';
+import React, { FC, useMemo } from 'react';
 import { Box, Card, Divider, ListItem, Tab, Tabs, Tooltip, Typography } from '@mui/material';
 import { Message, Request, Test, TestInput, TestOutput } from '~/models/testSuiteModels';
 import { shouldShowDescription } from '~/components/TestSuite/TestSuiteUtilities';
@@ -15,36 +15,17 @@ interface TestRunDetailProps {
   test: Test;
   currentTabIndex: number;
   updateRequest?: (requestId: string, resultId: string, request: Request) => void;
+  tabs: TabProps[];
 }
 
-interface TabProps {
+export interface TabProps {
   label: string;
   value: Message[] | Request[] | TestInput[] | TestOutput[] | string | null | undefined;
 }
 
-const TestRunDetail: FC<TestRunDetailProps> = ({ test, currentTabIndex, updateRequest }) => {
+const TestRunDetail: FC<TestRunDetailProps> = ({ test, currentTabIndex, tabs, updateRequest }) => {
   const styles = useStyles();
   const [tabIndex, setTabIndex] = React.useState(currentTabIndex);
-  const tabs: TabProps[] = [
-    { label: 'Messages', value: test.result?.messages },
-    { label: 'Requests', value: test.result?.requests },
-    { label: 'Inputs', value: test.result?.inputs },
-    { label: 'Outputs', value: test.result?.outputs },
-    { label: 'About', value: test.description },
-  ];
-
-  useEffect(() => {
-    // Set active tab to first tab with data
-    // If no tabs have data, set to About
-    let tabIndex = 0;
-    const disableableTabs = tabs.filter((tab) => tab.label !== 'About');
-    for (let i = 0; i < disableableTabs.length; i++) {
-      const content = disableableTabs[i].value;
-      if (!content || content?.length === 0) tabIndex++;
-      else break;
-    }
-    setTabIndex(tabIndex);
-  }, [test.result]);
 
   const testDescription: JSX.Element = (
     <ListItem>
@@ -94,7 +75,7 @@ const TestRunDetail: FC<TestRunDetailProps> = ({ test, currentTabIndex, updateRe
   };
 
   return (
-    <Card>
+    <Card data-testid="test-run-detail">
       <Tabs
         value={tabIndex}
         variant="scrollable"

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/__tests__/TestListItem.test.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/__tests__/TestListItem.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import ThemeProvider from 'components/ThemeProvider';
 
 import TestListItem from '../TestListItem';
-import { Test, TestInput, TestOutput } from '~/models/testSuiteModels';
+import { Message, Request, Result, Test, TestInput, TestOutput } from '~/models/testSuiteModels';
 
 describe('The TestListItem component', () => {
   test('it renders a table with the test description as markdown', () => {
@@ -39,5 +39,149 @@ describe('The TestListItem component', () => {
 
     expect(screen.getByText('Head1').closest('thead')).toBeInTheDocument();
     expect(screen.getByText('Row1').closest('tbody')).toBeInTheDocument();
+  });
+
+  describe('Accordion tab navigation', () => {
+    const outputs: TestOutput[] = [{ name: 'One', value: 'one' }];
+    const inputs: TestInput[] = [{ name: 'two', value: 'two' }];
+
+    it('navigates to the About tab when no other content', () => {
+      const result: Result = {
+        id: 'id',
+        result: 'result',
+        test_run_id: 'test_run_id',
+        test_session_id: 'test_session_id',
+        updated_at: 'updated_at',
+        outputs: [],
+      };
+
+      const test: Test = {
+        id: 'test_id',
+        title: 'Test Title',
+        inputs: inputs,
+        short_id: 'short_id',
+        outputs: outputs,
+        user_runnable: false,
+        description: `Some Description`,
+        result: result,
+      };
+
+      render(
+        <ThemeProvider>
+          <TestListItem test={test} testRunInProgress={false} view="run" />
+        </ThemeProvider>
+      );
+
+      const target = screen.getByTestId('test_id-summary');
+      fireEvent.click(target);
+
+      expect(screen.getByText('Some Description')).toBeInTheDocument();
+    });
+
+    it('navigates to the requests tab', () => {
+      const request: Request = {
+        direction: 'outgoing',
+        id: 'id',
+        index: 0,
+        status: 422,
+        timestamp: 'timestamp',
+        url: 'http://url',
+        verb: 'get',
+        result_id: 'result_id',
+        response_body: 'response_body',
+      };
+
+      const message: Message = {
+        message: 'Message One',
+        type: 'warning',
+      };
+
+      const result: Result = {
+        id: 'result_id',
+        result: 'result',
+        test_run_id: 'test_run_id',
+        test_session_id: 'test_session_id',
+        updated_at: 'updated_at',
+        outputs: [],
+        requests: [request],
+        messages: [message],
+      };
+
+      const test: Test = {
+        id: 'test_id',
+        title: 'Test Title',
+        inputs: inputs,
+        short_id: 'short_id',
+        outputs: outputs,
+        user_runnable: false,
+        description: `No Description`,
+        result: result,
+      };
+
+      render(
+        <ThemeProvider>
+          <TestListItem test={test} testRunInProgress={false} view="run" />
+        </ThemeProvider>
+      );
+
+      const target = screen.getByLabelText('View 1 request(s)');
+      fireEvent.click(target);
+
+      const requestsTab = screen.getByText('Requests');
+      expect(requestsTab.getAttribute('tabindex')).toBe('0');
+    });
+
+    it('navigates to the messages tab', () => {
+      const request: Request = {
+        direction: 'outgoing',
+        id: 'id',
+        index: 0,
+        status: 422,
+        timestamp: 'timestamp',
+        url: 'http://url',
+        verb: 'get',
+        result_id: 'result_id',
+        response_body: 'response_body',
+      };
+
+      const message: Message = {
+        message: 'Message One',
+        type: 'warning',
+      };
+
+      const result: Result = {
+        id: 'result_id',
+        result: 'result',
+        test_run_id: 'test_run_id',
+        test_session_id: 'test_session_id',
+        updated_at: 'updated_at',
+        outputs: [],
+        requests: [request],
+        messages: [message],
+      };
+
+      const test: Test = {
+        id: 'test_id',
+        title: 'Test Title',
+        inputs: inputs,
+        short_id: 'short_id',
+        outputs: outputs,
+        user_runnable: false,
+        description: `No Description`,
+        result: result,
+      };
+
+      render(
+        <ThemeProvider>
+          <TestListItem test={test} testRunInProgress={false} view="run" />
+        </ThemeProvider>
+      );
+
+      const target = screen.getByLabelText('View 1 message(s)');
+      fireEvent.click(target);
+
+      const requestsTab = screen.getByText('Messages');
+      expect(requestsTab.getAttribute('tabindex')).toBe('0');
+    });
   });
 });


### PR DESCRIPTION
# Summary

A useEffect that was concerned with setting the tab index when the tab was empty of content was conflicting with another function which would set the tab index to the clicked on "ProblemBadge".  In theory, the old useEffect should not have affected the badge clicking but it clearly is.

Changing from the hook that fires on a data dependency to one that fires on the accordian expansion click solves the problem.  I've added tests to cover the previous situations.

I did not move the TabProps interface out of TestRunDetail.  I think that's a good place for it but I am using the type in the parent element.

# Testing Guidance

Run and or inspect the tests that are added in this PR.  ;)

You can manually test too if you want.  Find test messages that have a variety of states:
1. Click on a test message with a warning.
2. Click on a test message with a request.
3. Click on a test message with nothing (infrastructure test suite).

But these should be covered by the tests.

Closes FI-1769