### PR TITLE
Lock dry-core to avoid foreman exception

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ PATH
       dotenv (~> 2.7)
       dry-configurable (= 0.13.0)
       dry-container (= 0.9.0)
+      dry-core (= 0.8.1)
       dry-system (= 0.20.0)
       faraday (~> 1.2)
       faraday_middleware (~> 1.2)

--- a/inferno_core.gemspec
+++ b/inferno_core.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'dotenv', '~> 2.7'
   spec.add_runtime_dependency 'dry-configurable', '0.13.0'
   spec.add_runtime_dependency 'dry-container', '0.9.0'
+  spec.add_runtime_dependency 'dry-core', '0.8.1'
   spec.add_runtime_dependency 'dry-system', '0.20.0'
   spec.add_runtime_dependency 'faraday', '~> 1.2'
   spec.add_runtime_dependency 'faraday_middleware', '~> 1.2'


### PR DESCRIPTION
# Summary

Does not happen when executing the services individually but within foreman get:
```
uninitialized constant Dry::Core::ClassAttributes::IDENTITY (NameError)
```
The bundle was resolving 0.9.0 of dry-core which was unexpected to others. So, locking dry-core.

# Testing Guidance

Run `./bin/inferno start`.  In my case, it resolved `0.9.0` which might not be true for your system.  Additionally, locking `dry-core 0.9.0` bumps many gems but throws this exception.
