### PR TITLE
Fix missing require

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.4.2
 * Add a missing require to the session data repository.
+* Fix UI bugs.
 
 # 0.4.1
 * Fix a routing issue which made Inferno unavailable on the root of a domain in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.4.2
+* Add a missing require to the session data repository.
+
 # 0.4.1
 * Fix a routing issue which made Inferno unavailable on the root of a domain in
   test kits.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    inferno_core (0.4.1)
+    inferno_core (0.4.2)
       activesupport (~> 6.1)
       blueprinter (= 0.25.2)
       dotenv (~> 2.7)

--- a/lib/inferno/repositories/session_data.rb
+++ b/lib/inferno/repositories/session_data.rb
@@ -1,3 +1,5 @@
+require_relative '../dsl/oauth_credentials'
+
 module Inferno
   module Repositories
     class SessionData < Repository

--- a/lib/inferno/version.rb
+++ b/lib/inferno/version.rb
@@ -1,4 +1,4 @@
 module Inferno
   # Standard patterns for gem versions: https://guides.rubygems.org/patterns/
-  VERSION = '0.4.1'.freeze
+  VERSION = '0.4.2'.freeze
 end


### PR DESCRIPTION
# Summary
There was a missing require in the session data repo.

# Testing Guidance
If you run the [fi-1736-dev-improvements](https://github.com/inferno-framework/inferno-template/tree/fi-1736-dev-improvements) branch in the template repo, the tests will fail due to the missing require.

If you update the core version in the gemspec in that branch to `0.4.2.pre`, you should be able to run the tests.