### PR TITLE
bug/FI-1755-print-update

### DIFF
--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/RequestsList.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/RequestsList.tsx
@@ -123,13 +123,38 @@ const RequestsList: FC<RequestsListProps> = ({ requests, resultId, updateRequest
         <TableCell className={styles.requestUrlContainer}>
           <Box display="flex" alignItems="center">
             <Tooltip title={request.url} placement="bottom-start">
-              <Typography variant="subtitle2" component="p" className={styles.requestUrl}>
+              <Typography
+                variant="subtitle2"
+                component="p"
+                sx={
+                  view === 'run'
+                    ? {
+                        overflow: 'hidden',
+                        maxHeight: '1.5em',
+                        wordBreak: 'break-all',
+                        display: '-webkit-box',
+                        WebkitBoxOrient: 'vertical',
+                        WebkitLineClamp: '1',
+                      }
+                    : {}
+                }
+              >
                 {request.url}
               </Typography>
             </Tooltip>
             <Tooltip
               open={copySuccess[request.url as keyof typeof copySuccess] || false}
               title="Text copied!"
+              sx={
+                view === 'report'
+                  ? {
+                      display: 'none',
+                      '@media print': {
+                        display: 'none',
+                      },
+                    }
+                  : {}
+              }
             >
               <IconButton
                 size="small"

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/styles.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/styles.tsx
@@ -94,14 +94,6 @@ export default makeStyles((theme: Theme) => ({
       margin: 0,
     },
   },
-  requestUrl: {
-    overflow: 'hidden',
-    maxHeight: '1.5em',
-    wordBreak: 'break-all',
-    display: '-webkit-box',
-    WebkitBoxOrient: 'vertical',
-    WebkitLineClamp: '1',
-  },
   requestUrlContainer: {
     width: '100%',
   },


### PR DESCRIPTION
# Summary

Removes copy button and URL truncation from print view.
<img width="593" alt="Screen Shot 2022-10-26 at 4 07 38 PM" src="https://user-images.githubusercontent.com/11209247/198126443-1cc1903a-f0fa-4326-b849-f10d640d5187.png">


# Testing Guidance

Run tests with requests (Demo Groups should work for this). In the report view and print view, the requests should look like the screenshot above.