### PR TITLE
FI-1783: Improve display for runnables

### DIFF
--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -417,6 +417,16 @@ module Inferno
           end
         end
       end
+
+      def inspect
+        non_dynamic_ancestor = ancestors.find { |ancestor| !ancestor.to_s.start_with? '#' }
+        "#<#{non_dynamic_ancestor}".tap do |inspect_string|
+          inspect_string.concat(" @id=#{id.inspect},")
+          inspect_string.concat(" @short_id=#{short_id.inspect},") if respond_to? :short_id
+          inspect_string.concat(" @title=#{title.inspect}")
+          inspect_string.concat('>')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
# Summary
Define `.inspect` for runnables so that they meaningful display strings while developing/debugging.

Before:
```
[1] pry(main)> DemoIG_STU1::DemoSuite
=> DemoIG_STU1::DemoSuite
[2] pry(main)> DemoIG_STU1::DemoSuite.children
=> [#<Class:0x000000010eb8cf90>,
 #<Class:0x000000010eb6d168>,
 #<Class:0x000000010ea4fd58>,
 #<Class:0x000000010e92ea28>,
 #<Class:0x000000010e9252c0>,
 #<Class:0x000000010e91dc78>,
 #<Class:0x000000010e917738>,
 #<Class:0x000000010e90cbd0>]
[3] pry(main)> DemoIG_STU1::DemoSuite.children.first.children
=> [#<Class:0x000000010eb86898>, #<Class:0x000000010eb7ec10>]
```

After:
```
[1] pry(main)> DemoIG_STU1::DemoSuite
=> #<DemoIG_STU1::DemoSuite @id="demo", @title="Demonstration Suite">
[2] pry(main)> DemoIG_STU1::DemoSuite.children
=> [#<Inferno::Entities::TestGroup @id="demo-Group01", @short_id="1", @title="OAuth credentials proof of concept">,
 #<Inferno::Entities::TestGroup @id="demo-simple_group", @short_id="2", @title="Group 1">,
 #<Inferno::Entities::TestGroup @id="demo-repetitive_group", @short_id="3", @title="Group 2">,
 #<Inferno::Entities::TestGroup @id="demo-locked_group", @short_id="4", @title="Locked Inputs Group">,
 #<Inferno::Entities::TestGroup @id="demo-wait_group", @short_id="5", @title="Wait Group">,
 #<Inferno::Entities::TestGroup @id="demo-easily_cancelled_test", @short_id="6", @title="Tests that should be easily cancelled">,
 #<Inferno::Entities::TestGroup @id="demo-run_as_group_examples", @short_id="7", @title="Run as Group Examples">,
 #<Inferno::Entities::TestGroup @id="demo-Group08", @short_id="8", @title="missing_inputs group">]
[3] pry(main)> DemoIG_STU1::DemoSuite.children.first.children
=> [#<Inferno::Entities::TestGroup @id="demo-Group01-Group01", @short_id="1.1", @title="Launch that would provide a bearer token & relevant content from code exchange response">,
 #<Inferno::Entities::TestGroup @id="demo-Group01-Group02", @short_id="1.2", @title="Some simple test that may use smart credentials">]
```

# Testing Guidance
Run `bundle exec inferno c` and look at some runnables.