### PR TITLE
Feature/fi 1756 direction

### DIFF
--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -77,14 +77,16 @@ const Header: FC<HeaderProps> = ({
               </Typography>
             )}
           </Box>
-          <Typography
-            variant="subtitle2"
-            component="h2"
-            className={styles.title}
-            color={lightTheme.palette.common.gray}
-          >
-            {suiteOptionsString}
-          </Typography>
+          {suiteOptionsString && (
+            <Typography
+              variant="subtitle2"
+              component="h2"
+              className={styles.title}
+              color={lightTheme.palette.common.gray}
+            >
+              {suiteOptionsString}
+            </Typography>
+          )}
         </Box>
 
         <Box display="flex" minWidth="fit-content" pl={2}>

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/RequestsList.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/RequestsList.tsx
@@ -17,7 +17,7 @@ import { Request } from '~/models/testSuiteModels';
 import RequestDetailModal from '~/components/RequestDetailModal/RequestDetailModal';
 import { getRequestDetails } from '~/api/RequestsApi';
 import useStyles from './styles';
-import { ContentCopy } from '@mui/icons-material';
+import { ContentCopy, SaveAlt } from '@mui/icons-material';
 
 interface RequestsListProps {
   resultId: string;
@@ -30,10 +30,7 @@ const RequestsList: FC<RequestsListProps> = ({ requests, resultId, updateRequest
   const [showDetails, setShowDetails] = React.useState(false);
   const [copySuccess, setCopySuccess] = React.useState({});
   const [detailedRequest, setDetailedRequest] = React.useState<Request>();
-  const headerTitles =
-    view === 'run'
-      ? ['Direction', 'Type', 'URL', 'Status', 'Details']
-      : ['Direction', 'Type', 'URL', 'Status'];
+  const headerTitles = ['Type', 'URL', 'Status'];
   const styles = useStyles();
 
   const showDetailsClick = (request: Request) => {
@@ -100,6 +97,8 @@ const RequestsList: FC<RequestsListProps> = ({ requests, resultId, updateRequest
           </Typography>
         </TableCell>
       ))}
+      <TableCell key={'Direction'} /> {/* Empty header text */}
+      {view === 'run' && <TableCell key={'Details'} />} {/* Empty header text */}
     </TableRow>
   );
 
@@ -107,11 +106,6 @@ const RequestsList: FC<RequestsListProps> = ({ requests, resultId, updateRequest
     .sort((request1, request2) => request1.index - request2.index)
     .map((request: Request, index: number) => (
       <TableRow key={`reqRow-${index}`}>
-        <TableCell>
-          <Typography variant="subtitle2" component="p">
-            {request.direction}
-          </Typography>
-        </TableCell>
         <TableCell>
           <Box display="flex">
             {renderReferenceIcon(request)}
@@ -170,6 +164,13 @@ const RequestsList: FC<RequestsListProps> = ({ requests, resultId, updateRequest
           <Typography variant="subtitle2" component="p" className={styles.bolderText}>
             {request.status}
           </Typography>
+        </TableCell>
+        <TableCell>
+          {request.direction === 'incoming' && (
+            <Tooltip title="Direction: incoming">
+              <SaveAlt />
+            </Tooltip>
+          )}
         </TableCell>
         {view === 'run' && <TableCell>{renderDetailsButton(request)}</TableCell>}
       </TableRow>

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/RequestsList.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/RequestsList.tsx
@@ -97,8 +97,20 @@ const RequestsList: FC<RequestsListProps> = ({ requests, resultId, updateRequest
           </Typography>
         </TableCell>
       ))}
-      <TableCell key={'Direction'} /> {/* Empty header text */}
-      {view === 'run' && <TableCell key={'Details'} />} {/* Empty header text */}
+      <TableCell
+        key={'Direction'}
+        role="none"
+        aria-hidden="true"
+        aria-label="header-request-direction"
+      ></TableCell>
+      {view === 'run' && (
+        <TableCell
+          key={'Details'}
+          role="none"
+          aria-hidden="true"
+          aria-label="header-request-details"
+        />
+      )}
     </TableRow>
   );
 


### PR DESCRIPTION
# Summary
Adds incoming icon to requests list.

<img width="559" alt="Screen Shot 2022-11-14 at 6 32 51 PM" src="https://user-images.githubusercontent.com/11209247/201789766-f4c34171-ff41-4c7b-bbe8-8a7b202de7be.png">

## Notes
Axe Deque may have issues with empty table headers. This may need to be resolved before moving forward.

# Testing Guidance
Ensure that any test with incoming requests show the new icon and tooltip on hover.

One test that works:
Run (g)(10) against the reference server and check test 1.3.05.
