### PR TITLE
feature/FI-1778-tooltip

### DIFF
--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupListItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupListItem.tsx
@@ -38,7 +38,8 @@ const TestGroupListItem: FC<TestGroupListItemProps> = ({
   view,
 }) => {
   const styles = useStyles();
-  const [mouseOnHover, setMouseOnHover] = React.useState(false);
+  const [descriptionMouseHover, setDescriptionMouseHover] = React.useState(false);
+  const [groupMouseHover, setGroupMouseHover] = React.useState(false);
   const [expanded, setExpanded] = React.useState(
     testGroup.result?.result === 'cancel' ||
       testGroup.result?.result === 'fail' ||
@@ -88,11 +89,11 @@ const TestGroupListItem: FC<TestGroupListItemProps> = ({
         key={`${testGroup.id}-description`}
         className={styles.accordion}
         TransitionProps={{ unmountOnExit: true }}
-        onMouseEnter={() => setMouseOnHover(true)}
-        onMouseLeave={() => setMouseOnHover(false)}
+        onMouseEnter={() => setDescriptionMouseHover(true)}
+        onMouseLeave={() => setDescriptionMouseHover(false)}
       >
         <AccordionSummary
-          id={mouseOnHover ? '' : `${testGroup.id}-description-summary`}
+          id={descriptionMouseHover ? '' : `${testGroup.id}-description-summary`}
           aria-controls={`${testGroup.id}-description-detail`}
           expandIcon={<ExpandMoreIcon sx={{ padding: '0 5px' }} />}
           sx={{ userSelect: 'auto' }}
@@ -111,7 +112,7 @@ const TestGroupListItem: FC<TestGroupListItemProps> = ({
         </AccordionSummary>
         <Divider />
         <AccordionDetails
-          title={mouseOnHover ? '' : `${testGroup.id}-description-detail`}
+          title={descriptionMouseHover ? '' : `${testGroup.id}-description-detail`}
           className={styles.accordionDetailContainer}
         >
           <ReactMarkdown className={`${styles.accordionDetail} ${styles.nestedDescription}`}>
@@ -130,11 +131,11 @@ const TestGroupListItem: FC<TestGroupListItemProps> = ({
       expanded={expanded}
       onChange={() => setExpanded(!expanded)}
       TransitionProps={{ unmountOnExit: true }}
-      onMouseEnter={() => setMouseOnHover(true)}
-      onMouseLeave={() => setMouseOnHover(false)}
+      onMouseEnter={() => setGroupMouseHover(true)}
+      onMouseLeave={() => setGroupMouseHover(false)}
     >
       <AccordionSummary
-        id={mouseOnHover ? '' : `${testGroup.id}-summary`}
+        id={groupMouseHover ? '' : `${testGroup.id}-summary`}
         aria-controls={`${testGroup.id}-detail`}
         className={styles.accordionSummary}
         expandIcon={view === 'run' && <ExpandMoreIcon sx={{ userSelect: 'auto' }} />}
@@ -175,7 +176,7 @@ const TestGroupListItem: FC<TestGroupListItemProps> = ({
           <InputOutputsList headerName="Input" inputOutputs={testGroup.result?.inputs || []} />
         )}
       <AccordionDetails
-        title={mouseOnHover ? '' : `${testGroup.id}-detail`}
+        title={groupMouseHover ? '' : `${testGroup.id}-detail`}
         className={styles.accordionDetailContainer}
       >
         {testGroup.description && view === 'run' && nestedDescriptionPanel}

--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupListItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupListItem.tsx
@@ -38,6 +38,7 @@ const TestGroupListItem: FC<TestGroupListItemProps> = ({
   view,
 }) => {
   const styles = useStyles();
+  const [mouseOnHover, setMouseOnHover] = React.useState(false);
   const [expanded, setExpanded] = React.useState(
     testGroup.result?.result === 'cancel' ||
       testGroup.result?.result === 'fail' ||
@@ -87,9 +88,11 @@ const TestGroupListItem: FC<TestGroupListItemProps> = ({
         key={`${testGroup.id}-description`}
         className={styles.accordion}
         TransitionProps={{ unmountOnExit: true }}
+        onMouseEnter={() => setMouseOnHover(true)}
+        onMouseLeave={() => setMouseOnHover(false)}
       >
         <AccordionSummary
-          id={`${testGroup.id}-description-summary`}
+          id={mouseOnHover ? '' : `${testGroup.id}-description-summary`}
           aria-controls={`${testGroup.id}-description-detail`}
           expandIcon={<ExpandMoreIcon sx={{ padding: '0 5px' }} />}
           sx={{ userSelect: 'auto' }}
@@ -108,7 +111,7 @@ const TestGroupListItem: FC<TestGroupListItemProps> = ({
         </AccordionSummary>
         <Divider />
         <AccordionDetails
-          title={`${testGroup.id}-description-detail`}
+          title={mouseOnHover ? '' : `${testGroup.id}-description-detail`}
           className={styles.accordionDetailContainer}
         >
           <ReactMarkdown className={`${styles.accordionDetail} ${styles.nestedDescription}`}>
@@ -127,9 +130,11 @@ const TestGroupListItem: FC<TestGroupListItemProps> = ({
       expanded={expanded}
       onChange={() => setExpanded(!expanded)}
       TransitionProps={{ unmountOnExit: true }}
+      onMouseEnter={() => setMouseOnHover(true)}
+      onMouseLeave={() => setMouseOnHover(false)}
     >
       <AccordionSummary
-        id={`${testGroup.id}-summary`}
+        id={mouseOnHover ? '' : `${testGroup.id}-summary`}
         aria-controls={`${testGroup.id}-detail`}
         className={styles.accordionSummary}
         expandIcon={view === 'run' && <ExpandMoreIcon sx={{ userSelect: 'auto' }} />}
@@ -170,7 +175,7 @@ const TestGroupListItem: FC<TestGroupListItemProps> = ({
           <InputOutputsList headerName="Input" inputOutputs={testGroup.result?.inputs || []} />
         )}
       <AccordionDetails
-        title={`${testGroup.id}-detail`}
+        title={mouseOnHover ? '' : `${testGroup.id}-detail`}
         className={styles.accordionDetailContainer}
       >
         {testGroup.description && view === 'run' && nestedDescriptionPanel}

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
@@ -46,7 +46,7 @@ const TestListItem: FC<TestListItemProps> = ({
   const messagesExist = !!test.result?.messages && test.result?.messages.length > 0;
   const requestsExist = !!test.result?.requests && test.result?.requests.length > 0;
   const [open, setOpen] = React.useState(false);
-  const [mouseOnHover, setMouseOnHover] = React.useState(false);
+  const [itemMouseHover, setItemMouseHover] = React.useState(false);
   const [tabIndex, setTabIndex] = React.useState(0);
   const tabs: TabProps[] = [
     { label: 'Messages', value: test.result?.messages },
@@ -213,11 +213,11 @@ const TestListItem: FC<TestListItemProps> = ({
         expanded={open}
         TransitionProps={{ unmountOnExit: true }}
         onClick={handleAccordionClick}
-        onMouseEnter={() => setMouseOnHover(true)}
-        onMouseLeave={() => setMouseOnHover(false)}
+        onMouseEnter={() => setItemMouseHover(true)}
+        onMouseLeave={() => setItemMouseHover(false)}
       >
         <AccordionSummary
-          id={mouseOnHover ? '' : `${test.id}-summary`}
+          id={itemMouseHover ? '' : `${test.id}-summary`}
           data-testid={`${test.id}-summary`}
           aria-controls={`${test.id}-detail`}
           role={view === 'report' ? 'region' : 'button'}
@@ -240,7 +240,7 @@ const TestListItem: FC<TestListItemProps> = ({
         <Divider />
         {/* Remove default tooltip on hover */}
         <AccordionDetails
-          title={mouseOnHover ? '' : `${test.id}-detail`}
+          title={itemMouseHover ? '' : `${test.id}-detail`}
           data-testid={`${test.id}-detail`}
           className={styles.accordionDetailContainer}
           onClick={(e) => e.stopPropagation()}

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
@@ -46,6 +46,7 @@ const TestListItem: FC<TestListItemProps> = ({
   const messagesExist = !!test.result?.messages && test.result?.messages.length > 0;
   const requestsExist = !!test.result?.requests && test.result?.requests.length > 0;
   const [open, setOpen] = React.useState(false);
+  const [mouseOnHover, setMouseOnHover] = React.useState(false);
   const [tabIndex, setTabIndex] = React.useState(0);
   const tabs: TabProps[] = [
     { label: 'Messages', value: test.result?.messages },
@@ -212,9 +213,11 @@ const TestListItem: FC<TestListItemProps> = ({
         expanded={open}
         TransitionProps={{ unmountOnExit: true }}
         onClick={handleAccordionClick}
+        onMouseEnter={() => setMouseOnHover(true)}
+        onMouseLeave={() => setMouseOnHover(false)}
       >
         <AccordionSummary
-          id={`${test.id}-summary`}
+          id={mouseOnHover ? '' : `${test.id}-summary`}
           data-testid={`${test.id}-summary`}
           aria-controls={`${test.id}-detail`}
           role={view === 'report' ? 'region' : 'button'}
@@ -235,8 +238,9 @@ const TestListItem: FC<TestListItemProps> = ({
           </Box>
         </AccordionSummary>
         <Divider />
+        {/* Remove default tooltip on hover */}
         <AccordionDetails
-          title={`${test.id}-detail`}
+          title={mouseOnHover ? '' : `${test.id}-detail`}
           data-testid={`${test.id}-detail`}
           className={styles.accordionDetailContainer}
           onClick={(e) => e.stopPropagation()}

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestRunDetail.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestRunDetail.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useMemo } from 'react';
-import { Box, Card, Divider, ListItem, Tab, Tabs, Tooltip, Typography } from '@mui/material';
+import { Box, Card, Divider, Tab, Tabs, Tooltip, Typography } from '@mui/material';
 import { Message, Request, Test, TestInput, TestOutput } from '~/models/testSuiteModels';
 import { shouldShowDescription } from '~/components/TestSuite/TestSuiteUtilities';
 import TabPanel from '~/components/TestSuite/TestSuiteDetails/TestListItem/TabPanel';
@@ -28,7 +28,7 @@ const TestRunDetail: FC<TestRunDetailProps> = ({ test, currentTabIndex, tabs, up
   const [tabIndex, setTabIndex] = React.useState(currentTabIndex);
 
   const testDescription: JSX.Element = (
-    <ListItem>
+    <Box mx={2}>
       <Typography variant="subtitle2" component="div">
         {useMemo(
           () => (
@@ -37,7 +37,7 @@ const TestRunDetail: FC<TestRunDetailProps> = ({ test, currentTabIndex, tabs, up
           [test.description]
         )}
       </Typography>
-    </ListItem>
+    </Box>
   );
 
   const a11yProps = (index: number) => ({


### PR DESCRIPTION
# Summary

Sets ids and titles to empty on hover. 

# Testing Guidance

Confirm that default tooltips no longer show. This should be checked for a11y as well -- I suspect it would be best to add a dev flag somewhere for this change.
