### PR TITLE
Codecov configurations update

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -59,6 +59,7 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         name: frontend-coverage
+        flags: frontend
         token: ${{ secrets.CODECOV_TOKEN }}
 
   lint:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -36,6 +36,12 @@ jobs:
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Run tests
       run: bundle exec rake
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        name: backend-coverage
+        flags: backend
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   lint:
     needs: build

--- a/Gemfile
+++ b/Gemfile
@@ -39,11 +39,11 @@ group :development do
 end
 
 group :test do
-  gem 'codecov'
   gem 'database_cleaner-sequel'
   gem 'rack-test'
   gem 'rspec'
-  gem 'simplecov'
+  gem 'simplecov', require: false
+  gem 'simplecov-cobertura'
   gem 'webmock'
   gem 'factory_bot'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,7 +42,7 @@ GEM
       i18n
     blueprinter (0.25.2)
     byebug (11.1.3)
-    codecov (0.6.0)
+    codecov (0.5.2)
       simplecov (>= 0.15, < 0.22)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
@@ -260,6 +260,9 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
+    simplecov-cobertura (2.1.0)
+      rexml
+      simplecov (~> 0.19)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.3)
     sqlite3 (1.5.4-arm64-darwin)
@@ -292,7 +295,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  codecov
+  codecov (= 0.5.2)
   database_cleaner-sequel
   factory_bot
   inferno_core!
@@ -305,6 +308,7 @@ DEPENDENCIES
   rubocop-rspec
   rubocop-sequel
   simplecov
+  simplecov-cobertura
   webmock
   yard
   yard-junk

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,8 +16,8 @@ SimpleCov.start do
 end
 
 if ENV['GITHUB_ACTIONS']
-  require 'codecov'
-  SimpleCov.formatter = SimpleCov::Formatter::Codecov
+  require 'simplecov-cobertura'
+  SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
 end
 
 require 'webmock/rspec'


### PR DESCRIPTION
# Summary

* Following the migration guide from here: https://docs.codecov.com/docs/deprecated-uploader-migration-guide#ruby-uploader
* The guide says to change gems and use the XML formatter
* The ruby action can do a similar upload as the frontend without using the codecov gem which lets us tag the backend
* The report will be broken out (as a two row table: backend & frontend) and summarized now

I tested as best as I could on a fork.

# Testing Guidance

The only way to test this would be to modify the actions to work off a branch. This is what I did on the fork.  But the original problem is about inflection of code coverage.  I tried to find a pattern and I believe it started when I added the frontend coverage in.  But then I found some commits where it breaks the theory of the merged report not including the front or the backend etc.