### PR TITLE
FI-1481: Add home link to header on logo and suite title

### DIFF
--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 import { AppBar, Box, Button, IconButton, Toolbar, Typography } from '@mui/material';
-import { useHistory } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import { Menu, NoteAdd } from '@mui/icons-material';
 import { getStaticPath } from '~/api/infernoApiService';
 import { SuiteOptionChoice } from '~/models/testSuiteModels';
@@ -51,7 +51,9 @@ const Header: FC<HeaderProps> = ({
             <Menu fontSize="inherit" />
           </IconButton>
         ) : (
-          <img src={getStaticPath(icon as string)} alt="Inferno logo" className={styles.logo} />
+          <Link to="/" aria-label="Inferno Home">
+            <img src={getStaticPath(icon as string)} alt="Inferno logo" className={styles.logo} />
+          </Link>
         )}
         <Box
           display="flex"
@@ -63,13 +65,10 @@ const Header: FC<HeaderProps> = ({
           tabIndex={0}
         >
           <Box display="flex" flexDirection="row" alignItems="baseline">
-            <Typography
-              variant="h5"
-              component="h1"
-              className={styles.title}
-              color={lightTheme.palette.common.orangeDarker}
-            >
-              {suiteTitle}
+            <Typography variant="h5" component="h1" className={styles.title}>
+              <Link to="/" aria-label="Inferno Home" className={styles.homeLink}>
+                {suiteTitle}
+              </Link>
             </Typography>
             {suiteVersion && (
               <Typography variant="overline" className={styles.version}>

--- a/client/src/components/Header/__tests__/Header.test.tsx
+++ b/client/src/components/Header/__tests__/Header.test.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import ThemeProvider from 'components/ThemeProvider';
+import React from 'react';
 import Header from '../Header';
 
 // this testing helper is needed to test react hooks outside of render
-import { renderHook, act } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { MemoryRouter } from 'react-router-dom';
 import { useAppStore } from '~/store/app';
 
 // boilerplate for mocking zustand which uses hooks outside of a component
@@ -20,13 +21,15 @@ test('renders wide screen Inferno Header', () => {
   let drawerOpen = true;
 
   render(
-    <ThemeProvider>
-      <Header
-        suiteTitle="Suite Title"
-        drawerOpen={drawerOpen}
-        toggleDrawer={() => (drawerOpen = !drawerOpen)}
-      />
-    </ThemeProvider>
+    <MemoryRouter>
+      <ThemeProvider>
+        <Header
+          suiteTitle="Suite Title"
+          drawerOpen={drawerOpen}
+          toggleDrawer={() => (drawerOpen = !drawerOpen)}
+        />
+      </ThemeProvider>
+    </MemoryRouter>
   );
 
   const logoElement = screen.getByRole('img');

--- a/client/src/components/Header/__tests__/HeaderSmall.test.tsx
+++ b/client/src/components/Header/__tests__/HeaderSmall.test.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ThemeProvider from 'components/ThemeProvider';
+import React from 'react';
 import Header from '../Header';
 
 // this testing helper is needed to test react hooks outside of render
-import { renderHook, act } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { MemoryRouter } from 'react-router-dom';
 import { useAppStore } from '~/store/app';
 
 // boilerplate for mocking zustand which uses hooks outside of a component
@@ -21,13 +22,15 @@ test('renders narrow screen Inferno Header', () => {
   let drawerOpen = false;
 
   render(
-    <ThemeProvider>
-      <Header
-        suiteTitle="Suite Title"
-        drawerOpen={drawerOpen}
-        toggleDrawer={() => (drawerOpen = !drawerOpen)}
-      />
-    </ThemeProvider>
+    <MemoryRouter>
+      <ThemeProvider>
+        <Header
+          suiteTitle="Suite Title"
+          drawerOpen={drawerOpen}
+          toggleDrawer={() => (drawerOpen = !drawerOpen)}
+        />
+      </ThemeProvider>
+    </MemoryRouter>
   );
 
   const buttonElement = screen.getAllByRole('button')[0];

--- a/client/src/components/Header/styles.tsx
+++ b/client/src/components/Header/styles.tsx
@@ -3,6 +3,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 
 import { Theme } from '@mui/material/styles';
+import lightTheme from '~/styles/theme';
 import makeStyles from '@mui/styles/makeStyles';
 
 export default makeStyles((theme: Theme) => ({
@@ -35,5 +36,9 @@ export default makeStyles((theme: Theme) => ({
   },
   version: {
     fontStyle: 'italic',
+  },
+  homeLink: {
+    color: lightTheme.palette.common.orangeDarker,
+    textDecoration: 'none',
   },
 }));

--- a/client/src/components/Header/styles.tsx
+++ b/client/src/components/Header/styles.tsx
@@ -30,7 +30,7 @@ export default makeStyles((theme: Theme) => ({
     paddingRight: '8px',
   },
   title: {
-    padding: '0 8px',
+    padding: '0 8px 0 20px',
     whiteSpace: 'nowrap',
     fontWeight: 600,
   },

--- a/client/src/components/TestSuite/TestSession.tsx
+++ b/client/src/components/TestSuite/TestSession.tsx
@@ -109,6 +109,7 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
   );
   const [testRun, setTestRun] = React.useState<TestRun | null>(null);
   const [showProgressBar, setShowProgressBar] = React.useState<boolean>(false);
+  const [testSessionPolling, setTestSessionPolling] = React.useState(true);
 
   const { test_suite, id } = testSession;
 
@@ -174,6 +175,15 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
     setWaitingTestId(waitingTestId);
   }, [resultsMap]);
 
+  // when on TestSession, we want to poll for job status and cancel polling when nav'ing away
+  useEffect(() => {
+    setTestSessionPolling(true);
+
+    return () => {
+      setTestSessionPolling(false);
+    };
+  }, []);
+
   const showInputsModal = (runnableType: RunnableType, runnableId: string, inputs: TestInput[]) => {
     setInputs(inputs);
     setRunnableType(runnableType);
@@ -209,7 +219,7 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
           const updatedMap = resultsToMap(testRunResults.results, resultsMap);
           setResultsMap(updatedMap);
         }
-        if (testRunResults && testRunIsInProgress(testRunResults)) {
+        if (testRunResults && testRunIsInProgress(testRunResults) && testSessionPolling) {
           setTimeout(() => pollTestRunResults(testRunResults), 500);
         }
       })

--- a/client/src/hooks/useTimeout.ts
+++ b/client/src/hooks/useTimeout.ts
@@ -1,0 +1,17 @@
+import { useEffect, useRef } from 'react';
+
+type Timer = NodeJS.Timeout | undefined;
+
+export const useTimeout = () => {
+  const timeout = useRef<Timer>();
+  useEffect(
+    () => () => {
+      if (timeout.current) {
+        clearTimeout(timeout.current);
+        timeout.current = undefined;
+      }
+    },
+    []
+  );
+  return timeout;
+};


### PR DESCRIPTION
# Summary

* The link cancels polling so that we have no network memory leak
* I used react-router's Link so that relative links would work
* This caused some CSS styling to be lost so I moved the color etc into a homeLink rule

# Testing Guidance

Start a test run, watch the status polling.  Click the home link.  The polling stops.  You navigate to the test suite selection screen.
