### PR TITLE
Feature/FI-1831-header-footer

### DIFF
--- a/client/src/components/App/App.tsx
+++ b/client/src/components/App/App.tsx
@@ -13,6 +13,7 @@ import { basePath } from '~/api/infernoApiService';
 import { useAppStore } from '~/store/app';
 
 const App: FC<unknown> = () => {
+  const setFooterHeight = useAppStore((state) => state.setFooterHeight);
   const testSuites = useAppStore((state) => state.testSuites);
   const setTestSuites = useAppStore((state) => state.setTestSuites);
   const testSession = useAppStore((state) => state.testSession);
@@ -51,7 +52,13 @@ const App: FC<unknown> = () => {
   }, [testSuites]);
 
   const handleResize = () => {
-    setWindowIsSmall(window.innerWidth < smallWindowThreshold);
+    if (window.innerWidth < smallWindowThreshold) {
+      setWindowIsSmall(true);
+      setFooterHeight(36);
+    } else {
+      setWindowIsSmall(false);
+      setFooterHeight(56);
+    }
   };
 
   if (!testSuites || (testSuites.length === 1 && !testSession)) {

--- a/client/src/components/Footer/Footer.tsx
+++ b/client/src/components/Footer/Footer.tsx
@@ -18,105 +18,75 @@ const Footer: FC<FooterProps> = ({ version, linkList }) => {
   const [showMenu, setShowMenu] = React.useState<boolean>(false);
   const styles = useStyles();
 
-  if (windowIsSmall) {
+  const renderLogoText = () => {
+    if (!version) return <></>;
     return (
-      <footer className={styles.mobileFooter}>
-        <Box display="flex" flexDirection="row" justifyContent="space-between" overflow="auto">
-          <Box display="flex" alignItems="center" px={2}>
-            <Link
-              href="https://inferno-framework.github.io/inferno-core"
-              target="_blank"
-              rel="noreferrer"
-              aria-label="Inferno"
-            >
-              <img
-                src={getStaticPath(logo as string)}
-                alt="Inferno logo - documentation"
-                className={styles.mobileLogo}
-              />
-            </Link>
-            {version && (
-              <Typography className={styles.logoText} style={{ fontSize: '0.7rem' }}>
-                {`v.${version}`}
-              </Typography>
-            )}
-          </Box>
-          <Box display="flex" alignItems="center" data-testid="footer-links">
-            <IconButton
-              aria-label="links"
-              size="small"
-              color="secondary"
-              onClick={(e) => {
-                setAnchorEl(!anchorEl ? e.currentTarget : null);
-                setShowMenu(!showMenu);
+      <Box display="flex" flexDirection="column">
+        {!windowIsSmall && (
+          <Typography className={styles.logoText} style={{ fontSize: '0.7rem' }}>
+            Built with
+          </Typography>
+        )}
+        <Typography
+          className={styles.logoText}
+          style={{ fontSize: windowIsSmall ? '0.7rem' : '0.9rem' }}
+        >
+          {`v.${version}`}
+        </Typography>
+      </Box>
+    );
+  };
+
+  const renderLinks = () => {
+    if (windowIsSmall) {
+      return (
+        <Box display="flex" alignItems="center" data-testid="footer-links">
+          <IconButton
+            aria-label="links"
+            size="small"
+            color="secondary"
+            onClick={(e) => {
+              setAnchorEl(!anchorEl ? e.currentTarget : null);
+              setShowMenu(!showMenu);
+            }}
+          >
+            <Help fontSize="inherit" />
+          </IconButton>
+
+          {linkList && showMenu && (
+            <Menu
+              anchorEl={anchorEl}
+              open={showMenu}
+              MenuListProps={{ dense: true }}
+              onClose={() => {
+                setShowMenu(false);
+                setAnchorEl(null);
               }}
             >
-              <Help fontSize="inherit" />
-            </IconButton>
-
-            {linkList && showMenu && (
-              <Menu
-                anchorEl={anchorEl}
-                open={showMenu}
-                MenuListProps={{ dense: true }}
-                onClose={() => {
-                  setShowMenu(false);
-                  setAnchorEl(null);
-                }}
-              >
-                {linkList.map((link) => {
-                  return (
-                    <MenuItem key={link.url}>
-                      <Link
-                        href={link.url}
-                        target="_blank"
-                        rel="noreferrer"
-                        underline="hover"
-                        className={styles.linkText}
-                        style={{
-                          fontSize: '0.8rem',
-                        }}
-                      >
-                        {link.label}
-                      </Link>
-                    </MenuItem>
-                  );
-                })}
-              </Menu>
-            )}
-          </Box>
-        </Box>
-      </footer>
-    );
-  }
-
-  return (
-    <footer className={styles.footer}>
-      <Box display="flex" flexDirection="row" justifyContent="space-between" overflow="auto">
-        <Box display="flex" alignItems="center" px={2}>
-          <Link
-            href="https://inferno-framework.github.io/inferno-core"
-            target="_blank"
-            rel="noreferrer"
-            aria-label="Inferno"
-          >
-            <img
-              src={getStaticPath(logo as string)}
-              alt="Inferno logo - documentation"
-              className={styles.logo}
-            />
-          </Link>
-          {version && (
-            <Box display="flex" flexDirection="column">
-              <Typography className={styles.logoText} style={{ fontSize: '0.7rem' }}>
-                Built with
-              </Typography>
-              <Typography className={styles.logoText} style={{ fontSize: '0.9rem' }}>
-                {`v.${version}`}
-              </Typography>
-            </Box>
+              {linkList.map((link) => {
+                return (
+                  <MenuItem key={link.url}>
+                    <Link
+                      href={link.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      underline="hover"
+                      className={styles.linkText}
+                      style={{
+                        fontSize: '0.8rem',
+                      }}
+                    >
+                      {link.label}
+                    </Link>
+                  </MenuItem>
+                );
+              })}
+            </Menu>
           )}
         </Box>
+      );
+    } else {
+      return (
         <Box display="flex" alignItems="center" p={2} data-testid="footer-links">
           {linkList &&
             linkList.map((link, i) => {
@@ -140,6 +110,39 @@ const Footer: FC<FooterProps> = ({ version, linkList }) => {
               );
             })}
         </Box>
+      );
+    }
+  };
+
+  return (
+    <footer
+      className={styles.footer}
+      style={
+        windowIsSmall
+          ? {
+              minHeight: '36px',
+              maxHeight: '36px',
+            }
+          : {}
+      }
+    >
+      <Box display="flex" flexDirection="row" justifyContent="space-between" overflow="auto">
+        <Box display="flex" alignItems="center" px={2}>
+          <Link
+            href="https://inferno-framework.github.io/inferno-core"
+            target="_blank"
+            rel="noreferrer"
+            aria-label="Inferno"
+          >
+            <img
+              src={getStaticPath(logo as string)}
+              alt="Inferno logo - documentation"
+              className={windowIsSmall ? styles.mobileLogo : styles.logo}
+            />
+          </Link>
+          {renderLogoText()}
+        </Box>
+        {renderLinks()}
       </Box>
     </footer>
   );

--- a/client/src/components/Footer/Footer.tsx
+++ b/client/src/components/Footer/Footer.tsx
@@ -118,7 +118,10 @@ const Footer: FC<FooterProps> = ({ version, linkList }) => {
   return (
     <footer
       className={styles.footer}
-      style={{ minHeight: `${footerHeight}px`, maxHeight: `${footerHeight}px` }}
+      style={{
+        minHeight: `${footerHeight}px`,
+        maxHeight: `${footerHeight}px`,
+      }}
     >
       <Box display="flex" flexDirection="row" justifyContent="space-between" overflow="auto">
         <Box display="flex" alignItems="center" px={2}>

--- a/client/src/components/Footer/Footer.tsx
+++ b/client/src/components/Footer/Footer.tsx
@@ -1,9 +1,11 @@
 import React, { FC } from 'react';
 import useStyles from './styles';
-import { Box, Link, Typography, Divider } from '@mui/material';
+import { Box, Link, Typography, Divider, IconButton, MenuItem, Menu } from '@mui/material';
 import logo from '~/images/inferno_logo.png';
 import { getStaticPath } from '~/api/infernoApiService';
 import { FooterLink } from '~/models/testSuiteModels';
+import { useAppStore } from '~/store/app';
+import { Help } from '@mui/icons-material';
 
 interface FooterProps {
   version: string;
@@ -11,7 +13,82 @@ interface FooterProps {
 }
 
 const Footer: FC<FooterProps> = ({ version, linkList }) => {
+  const windowIsSmall = useAppStore((state) => state.windowIsSmall);
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const [showMenu, setShowMenu] = React.useState<boolean>(false);
   const styles = useStyles();
+
+  if (windowIsSmall) {
+    return (
+      <footer className={styles.mobileFooter}>
+        <Box display="flex" flexDirection="row" justifyContent="space-between" overflow="auto">
+          <Box display="flex" alignItems="center" px={2}>
+            <Link
+              href="https://inferno-framework.github.io/inferno-core"
+              target="_blank"
+              rel="noreferrer"
+              aria-label="Inferno"
+            >
+              <img
+                src={getStaticPath(logo as string)}
+                alt="Inferno logo - documentation"
+                className={styles.mobileLogo}
+              />
+            </Link>
+            {version && (
+              <Typography className={styles.logoText} style={{ fontSize: '0.7rem' }}>
+                {`v.${version}`}
+              </Typography>
+            )}
+          </Box>
+          <Box display="flex" alignItems="center" data-testid="footer-links">
+            <IconButton
+              aria-label="links"
+              size="small"
+              color="secondary"
+              onClick={(e) => {
+                setAnchorEl(!anchorEl ? e.currentTarget : null);
+                setShowMenu(!showMenu);
+              }}
+            >
+              <Help fontSize="inherit" />
+            </IconButton>
+
+            {linkList && showMenu && (
+              <Menu
+                anchorEl={anchorEl}
+                open={showMenu}
+                MenuListProps={{ dense: true }}
+                onClose={() => {
+                  setShowMenu(false);
+                  setAnchorEl(null);
+                }}
+              >
+                {linkList.map((link) => {
+                  return (
+                    <MenuItem key={link.url}>
+                      <Link
+                        href={link.url}
+                        target="_blank"
+                        rel="noreferrer"
+                        underline="hover"
+                        className={styles.linkText}
+                        style={{
+                          fontSize: '0.8rem',
+                        }}
+                      >
+                        {link.label}
+                      </Link>
+                    </MenuItem>
+                  );
+                })}
+              </Menu>
+            )}
+          </Box>
+        </Box>
+      </footer>
+    );
+  }
 
   return (
     <footer className={styles.footer}>
@@ -51,6 +128,10 @@ const Footer: FC<FooterProps> = ({ version, linkList }) => {
                     rel="noreferrer"
                     underline="hover"
                     className={styles.linkText}
+                    style={{
+                      fontSize: '1.1rem',
+                      margin: '0 16px',
+                    }}
                   >
                     {link.label}
                   </Link>

--- a/client/src/components/Footer/Footer.tsx
+++ b/client/src/components/Footer/Footer.tsx
@@ -13,6 +13,7 @@ interface FooterProps {
 }
 
 const Footer: FC<FooterProps> = ({ version, linkList }) => {
+  const footerHeight = useAppStore((state) => state.footerHeight);
   const windowIsSmall = useAppStore((state) => state.windowIsSmall);
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const [showMenu, setShowMenu] = React.useState<boolean>(false);
@@ -37,61 +38,34 @@ const Footer: FC<FooterProps> = ({ version, linkList }) => {
     );
   };
 
-  const renderLinks = () => {
-    if (windowIsSmall) {
-      return (
-        <Box display="flex" alignItems="center" data-testid="footer-links">
-          <IconButton
-            aria-label="links"
-            size="small"
-            color="secondary"
-            onClick={(e) => {
-              setAnchorEl(!anchorEl ? e.currentTarget : null);
-              setShowMenu(!showMenu);
+  const renderLinksMenu = () => {
+    return (
+      <Box display="flex" alignItems="center" data-testid="footer-links">
+        <IconButton
+          aria-label="links"
+          size="small"
+          color="secondary"
+          onClick={(e) => {
+            setAnchorEl(!anchorEl ? e.currentTarget : null);
+            setShowMenu(!showMenu);
+          }}
+        >
+          <Help fontSize="inherit" />
+        </IconButton>
+
+        {linkList && showMenu && (
+          <Menu
+            anchorEl={anchorEl}
+            open={showMenu}
+            MenuListProps={{ dense: true }}
+            onClose={() => {
+              setShowMenu(false);
+              setAnchorEl(null);
             }}
           >
-            <Help fontSize="inherit" />
-          </IconButton>
-
-          {linkList && showMenu && (
-            <Menu
-              anchorEl={anchorEl}
-              open={showMenu}
-              MenuListProps={{ dense: true }}
-              onClose={() => {
-                setShowMenu(false);
-                setAnchorEl(null);
-              }}
-            >
-              {linkList.map((link) => {
-                return (
-                  <MenuItem key={link.url}>
-                    <Link
-                      href={link.url}
-                      target="_blank"
-                      rel="noreferrer"
-                      underline="hover"
-                      className={styles.linkText}
-                      style={{
-                        fontSize: '0.8rem',
-                      }}
-                    >
-                      {link.label}
-                    </Link>
-                  </MenuItem>
-                );
-              })}
-            </Menu>
-          )}
-        </Box>
-      );
-    } else {
-      return (
-        <Box display="flex" alignItems="center" p={2} data-testid="footer-links">
-          {linkList &&
-            linkList.map((link, i) => {
+            {linkList.map((link) => {
               return (
-                <React.Fragment key={link.url}>
+                <MenuItem key={link.url}>
                   <Link
                     href={link.url}
                     target="_blank"
@@ -99,32 +73,52 @@ const Footer: FC<FooterProps> = ({ version, linkList }) => {
                     underline="hover"
                     className={styles.linkText}
                     style={{
-                      fontSize: '1.1rem',
-                      margin: '0 16px',
+                      fontSize: '0.8rem',
                     }}
                   >
                     {link.label}
                   </Link>
-                  {i !== linkList.length - 1 && <Divider orientation="vertical" flexItem />}
-                </React.Fragment>
+                </MenuItem>
               );
             })}
-        </Box>
-      );
-    }
+          </Menu>
+        )}
+      </Box>
+    );
+  };
+
+  const renderLinks = () => {
+    return (
+      <Box display="flex" alignItems="center" p={2} data-testid="footer-links">
+        {linkList &&
+          linkList.map((link, i) => {
+            return (
+              <React.Fragment key={link.url}>
+                <Link
+                  href={link.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  underline="hover"
+                  className={styles.linkText}
+                  style={{
+                    fontSize: '1.1rem',
+                    margin: '0 16px',
+                  }}
+                >
+                  {link.label}
+                </Link>
+                {i !== linkList.length - 1 && <Divider orientation="vertical" flexItem />}
+              </React.Fragment>
+            );
+          })}
+      </Box>
+    );
   };
 
   return (
     <footer
       className={styles.footer}
-      style={
-        windowIsSmall
-          ? {
-              minHeight: '36px',
-              maxHeight: '36px',
-            }
-          : {}
-      }
+      style={{ minHeight: `${footerHeight}px`, maxHeight: `${footerHeight}px` }}
     >
       <Box display="flex" flexDirection="row" justifyContent="space-between" overflow="auto">
         <Box display="flex" alignItems="center" px={2}>
@@ -142,7 +136,7 @@ const Footer: FC<FooterProps> = ({ version, linkList }) => {
           </Link>
           {renderLogoText()}
         </Box>
-        {renderLinks()}
+        {windowIsSmall ? renderLinksMenu() : renderLinks()}
       </Box>
     </footer>
   );

--- a/client/src/components/Footer/styles.tsx
+++ b/client/src/components/Footer/styles.tsx
@@ -9,21 +9,6 @@ export default makeStyles((theme: Theme) => ({
   footer: {
     width: '100%',
     overflow: 'auto',
-    minHeight: '56px', // For responsive screens
-    maxHeight: '56px', // For responsive screens
-    zIndex: `${theme.zIndex.drawer + 1} !important` as any,
-    backgroundColor: theme.palette.common.orangeLightest,
-    borderTop: `1px ${theme.palette.common.grayLighter} solid`,
-    bottom: 0,
-    '@media print': {
-      display: 'none',
-    },
-  },
-  mobileFooter: {
-    width: '100%',
-    overflow: 'auto',
-    minHeight: '36px', // For responsive screens
-    maxHeight: '36px', // For responsive screens
     zIndex: `${theme.zIndex.drawer + 1} !important` as any,
     backgroundColor: theme.palette.common.orangeLightest,
     borderTop: `1px ${theme.palette.common.grayLighter} solid`,

--- a/client/src/components/Footer/styles.tsx
+++ b/client/src/components/Footer/styles.tsx
@@ -14,7 +14,19 @@ export default makeStyles((theme: Theme) => ({
     zIndex: `${theme.zIndex.drawer + 1} !important` as any,
     backgroundColor: theme.palette.common.orangeLightest,
     borderTop: `1px ${theme.palette.common.grayLighter} solid`,
-    position: 'sticky',
+    bottom: 0,
+    '@media print': {
+      display: 'none',
+    },
+  },
+  mobileFooter: {
+    width: '100%',
+    overflow: 'auto',
+    minHeight: '36px', // For responsive screens
+    maxHeight: '36px', // For responsive screens
+    zIndex: `${theme.zIndex.drawer + 1} !important` as any,
+    backgroundColor: theme.palette.common.orangeLightest,
+    borderTop: `1px ${theme.palette.common.grayLighter} solid`,
     bottom: 0,
     '@media print': {
       display: 'none',
@@ -23,6 +35,11 @@ export default makeStyles((theme: Theme) => ({
   logo: {
     objectFit: 'contain',
     height: '2.5em',
+    padding: '0 8px 0 0',
+  },
+  mobileLogo: {
+    objectFit: 'contain',
+    height: '1.7em',
     padding: '4px 8px 0 0',
   },
   logoText: {
@@ -32,8 +49,6 @@ export default makeStyles((theme: Theme) => ({
   },
   linkText: {
     fontWeight: 'bolder',
-    fontSize: '1.1rem',
-    margin: '0 16px',
     color: theme.palette.common.grayDark,
     width: 'max-content',
   },

--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -48,6 +48,7 @@ const Header: FC<HeaderProps> = ({
       }}
     >
       <Toolbar className={styles.toolbar}>
+        {/* Home button */}
         {windowIsSmall ? (
           <IconButton
             size="large"
@@ -63,6 +64,8 @@ const Header: FC<HeaderProps> = ({
             <img src={getStaticPath(icon as string)} alt="Inferno logo" className={styles.logo} />
           </Link>
         )}
+
+        {/* Header Text */}
         <Box
           display="flex"
           flexDirection="column"
@@ -96,6 +99,7 @@ const Header: FC<HeaderProps> = ({
           )}
         </Box>
 
+        {/* New Session button */}
         <Box
           display="flex"
           minWidth="fit-content"

--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { AppBar, Box, Button, IconButton, Toolbar, Typography } from '@mui/material';
+import { AppBar, Avatar, Box, Button, IconButton, Toolbar, Typography } from '@mui/material';
 import { useHistory } from 'react-router-dom';
 import { Menu, NoteAdd } from '@mui/icons-material';
 import { getStaticPath } from '~/api/infernoApiService';
@@ -26,6 +26,7 @@ const Header: FC<HeaderProps> = ({
 }) => {
   const styles = useStyles();
   const history = useHistory();
+  const headerHeight = useAppStore((state) => state.headerHeight);
   const windowIsSmall = useAppStore((state) => state.windowIsSmall);
 
   const returnHome = () => {
@@ -38,7 +39,14 @@ const Header: FC<HeaderProps> = ({
       : '';
 
   return suiteTitle ? (
-    <AppBar color="default" className={styles.appbar}>
+    <AppBar
+      color="default"
+      className={styles.appbar}
+      style={{
+        minHeight: `${headerHeight}px`, // For responsive screens
+        maxHeight: `${headerHeight}px`, // For responsive screens
+      }}
+    >
       <Toolbar className={styles.toolbar}>
         {windowIsSmall ? (
           <IconButton
@@ -90,16 +98,24 @@ const Header: FC<HeaderProps> = ({
         </Box>
 
         <Box display="flex" minWidth="fit-content" pl={2}>
-          <Button
-            disableElevation
-            color="secondary"
-            size="small"
-            variant="contained"
-            startIcon={<NoteAdd />}
-            onClick={returnHome}
-          >
-            New Session
-          </Button>
+          {windowIsSmall ? (
+            <IconButton color="secondary" onClick={returnHome}>
+              <Avatar sx={{ width: 32, height: 32, bgcolor: lightTheme.palette.secondary.main }}>
+                <NoteAdd fontSize="small" />
+              </Avatar>
+            </IconButton>
+          ) : (
+            <Button
+              disableElevation
+              color="secondary"
+              size="small"
+              variant="contained"
+              startIcon={<NoteAdd />}
+              onClick={returnHome}
+            >
+              New Session
+            </Button>
+          )}
         </Box>
       </Toolbar>
     </AppBar>

--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -99,7 +99,7 @@ const Header: FC<HeaderProps> = ({
 
         <Box display="flex" minWidth="fit-content" pl={2}>
           {windowIsSmall ? (
-            <IconButton color="secondary" onClick={returnHome}>
+            <IconButton color="secondary" aria-label="New Session" onClick={returnHome}>
               <Avatar sx={{ width: 32, height: 32, bgcolor: lightTheme.palette.secondary.main }}>
                 <NoteAdd fontSize="small" />
               </Avatar>

--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -96,7 +96,12 @@ const Header: FC<HeaderProps> = ({
           )}
         </Box>
 
-        <Box display="flex" minWidth="fit-content" pl={2}>
+        <Box
+          display="flex"
+          minWidth="fit-content"
+          pl={1}
+          style={windowIsSmall ? { marginRight: '-16px' } : {}}
+        >
           {windowIsSmall ? (
             <IconButton color="secondary" aria-label="New Session" onClick={returnHome}>
               <Avatar sx={{ width: 32, height: 32, bgcolor: lightTheme.palette.secondary.main }}>

--- a/client/src/components/Header/styles.tsx
+++ b/client/src/components/Header/styles.tsx
@@ -7,8 +7,6 @@ import makeStyles from '@mui/styles/makeStyles';
 
 export default makeStyles((theme: Theme) => ({
   appbar: {
-    minHeight: '64px', // For responsive screens
-    maxHeight: '64px', // For responsive screens
     zIndex: `${theme.zIndex.drawer + 1} !important` as any,
     position: 'sticky',
     '@media print': {

--- a/client/src/components/TestSuite/TestRunButton/TestRunButton.tsx
+++ b/client/src/components/TestSuite/TestRunButton/TestRunButton.tsx
@@ -5,6 +5,7 @@ import PlayCircleIcon from '@mui/icons-material/PlayCircle';
 import { TestGroup, Runnable, RunnableType } from '~/models/testSuiteModels';
 import lightTheme from '~/styles/theme';
 
+import { useAppStore } from '~/store/app';
 import { useTestSessionStore } from '~/store/testSession';
 
 export interface TestRunButtonProps {
@@ -20,69 +21,70 @@ const TestRunButton: FC<TestRunButtonProps> = ({
   runnableType,
   buttonText,
 }) => {
+  const windowIsSmall = useAppStore((state) => state.windowIsSmall);
   const testRunInProgress = useTestSessionStore((state) => state.testRunInProgress);
   /* Need to explicitly check against false because undefined needs to be treated
    * as true. */
   const showRunButton = (runnable as TestGroup).user_runnable !== false;
 
-  return (
-    <>
-      {showRunButton &&
-        (buttonText ? (
-          <Button
-            variant="contained"
-            disabled={testRunInProgress}
-            color="secondary"
-            size="small"
-            disableElevation
-            onClick={() => {
-              runTests(runnableType, runnable.id);
-            }}
-            endIcon={<PlayArrowIcon />}
-            data-testid={`runButton-${runnable.id}`}
-          >
-            {buttonText}
-          </Button>
-        ) : (
-          // Custom icon button to resolve nested interactive control error
-          <Tooltip describeChild title={`Run ${runnable.title}`}>
-            <PlayCircleIcon
-              aria-label={`Run ${runnable.title}${
-                testRunInProgress ? ' Disabled - Test Run in Progress' : ''
-              }`}
-              aria-hidden={false}
-              tabIndex={0}
-              color={testRunInProgress ? 'disabled' : 'secondary'}
-              data-testid={`runButton-${runnable.id}`}
-              onClick={() => {
-                if (!testRunInProgress) runTests(runnableType, runnable.id);
-              }}
-              onKeyDown={(e) => {
-                e.stopPropagation();
-                if (e.key === 'Enter' && !testRunInProgress) {
-                  runTests(runnableType, runnable.id);
-                }
-              }}
-              sx={
-                testRunInProgress
-                  ? {
-                      margin: '0 8px',
-                      padding: '0.25em 0.25em',
-                    }
-                  : {
-                      margin: '0 8px',
-                      padding: '0.25em 0.25em',
-                      ':hover': {
-                        background: lightTheme.palette.common.grayLightest,
-                        borderRadius: '50%',
-                      },
-                    }
-              }
-            />
-          </Tooltip>
-        ))}
-    </>
+  const textButton = (
+    <Button
+      variant="contained"
+      disabled={testRunInProgress}
+      color="secondary"
+      size="small"
+      disableElevation
+      onClick={() => {
+        runTests(runnableType, runnable.id);
+      }}
+      endIcon={<PlayArrowIcon />}
+      data-testid={`runButton-${runnable.id}`}
+    >
+      {buttonText}
+    </Button>
   );
+
+  // Custom icon button to resolve nested interactive control error
+  const iconButton = (
+    <Tooltip describeChild title={`Run ${runnable.title}`}>
+      <PlayCircleIcon
+        aria-label={`Run ${runnable.title}${
+          testRunInProgress ? ' Disabled - Test Run in Progress' : ''
+        }`}
+        aria-hidden={false}
+        tabIndex={0}
+        color={testRunInProgress ? 'disabled' : 'secondary'}
+        data-testid={`runButton-${runnable.id}`}
+        onClick={() => {
+          if (!testRunInProgress) runTests(runnableType, runnable.id);
+        }}
+        onKeyDown={(e) => {
+          e.stopPropagation();
+          if (e.key === 'Enter' && !testRunInProgress) {
+            runTests(runnableType, runnable.id);
+          }
+        }}
+        sx={{
+          margin: '0 8px',
+          padding: '0.25em 0.25em',
+          ':hover': testRunInProgress
+            ? {}
+            : {
+                background: lightTheme.palette.common.grayLightest,
+                borderRadius: '50%',
+              },
+        }}
+      />
+    </Tooltip>
+  );
+
+  if (!showRunButton) {
+    return <></>;
+  } else if (!windowIsSmall && !!buttonText) {
+    return textButton;
+  } else {
+    return iconButton;
+  }
 };
 
 export default TestRunButton;

--- a/client/src/components/TestSuite/TestSession.tsx
+++ b/client/src/components/TestSuite/TestSession.tsx
@@ -93,6 +93,8 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
   toggleDrawer,
 }) => {
   const styles = useStyles();
+  const footerHeight = useAppStore((state) => state.footerHeight);
+  const headerHeight = useAppStore((state) => state.headerHeight);
   const windowIsSmall = useAppStore((state) => state.windowIsSmall);
   const runnableId = useTestSessionStore((state) => state.runnableId);
   const testRunInProgress = useTestSessionStore((state) => state.testRunInProgress);
@@ -364,10 +366,10 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
           classes={{ paper: styles.swipeableDrawerHeight }}
         >
           {/* Spacer to be updated with header height */}
-          <Toolbar sx={{ minHeight: '64px' }} />
+          <Toolbar sx={{ minHeight: `${headerHeight}px` }} />
           {renderDrawerContents()}
           {/* Spacer to be updated with footer height */}
-          <Toolbar />
+          <Toolbar sx={{ minHeight: `${footerHeight}px` }} />
         </SwipeableDrawer>
       ) : (
         <Drawer

--- a/client/src/components/TestSuite/TestSession.tsx
+++ b/client/src/components/TestSuite/TestSession.tsx
@@ -397,7 +397,7 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
           width: '100%',
         }}
       >
-        <Box className={styles.contentContainer}>
+        <Box className={styles.contentContainer} p={windowIsSmall ? 1 : 4}>
           {renderView((view as ViewType) || 'run')}
           {inputModalVisible && (
             <InputsModal

--- a/client/src/components/TestSuite/TestSuiteDetails/TestSuiteReport.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestSuiteReport.tsx
@@ -3,10 +3,22 @@ import TestGroupCard from '~/components/TestSuite/TestSuiteDetails/TestGroupCard
 import { TestGroup, Test, TestSuite, SuiteOptionChoice, Request } from '~/models/testSuiteModels';
 import TestGroupListItem from './TestGroupListItem/TestGroupListItem';
 import TestListItem from './TestListItem/TestListItem';
-import { Box, Button, Card, FormControlLabel, FormGroup, Switch, Typography } from '@mui/material';
+import {
+  Avatar,
+  Box,
+  Button,
+  Card,
+  FormControlLabel,
+  FormGroup,
+  IconButton,
+  Switch,
+  Typography,
+} from '@mui/material';
 import PrintIcon from '@mui/icons-material/Print';
 import useStyles from './styles';
 import TestSuiteMessages from './TestSuiteMessages';
+import { useAppStore } from '~/store/app';
+import lightTheme from '~/styles/theme';
 
 interface TestSuiteReportProps {
   testSuite: TestSuite;
@@ -15,13 +27,14 @@ interface TestSuiteReportProps {
 }
 
 const TestSuiteReport: FC<TestSuiteReportProps> = ({ testSuite, suiteOptions, updateRequest }) => {
-  const styles = useStyles();
+  const windowIsSmall = useAppStore((state) => state.windowIsSmall);
   const [showDetails, setShowDetails] = React.useState(false);
   const location = window?.location?.href?.split('#')?.[0];
   const suiteOptionsString =
     suiteOptions && suiteOptions.length > 0
       ? ` - ${suiteOptions.map((option) => option.label).join(', ')}`
       : '';
+  const styles = useStyles();
 
   const header = (
     <Card variant="outlined" sx={{ mb: 3 }}>
@@ -49,18 +62,24 @@ const TestSuiteReport: FC<TestSuiteReportProps> = ({ testSuite, suiteOptions, up
           </FormGroup>
         </span>
         <span className={styles.testGroupCardHeaderButton}>
-          <Button
-            variant="contained"
-            color="secondary"
-            size="small"
-            disableElevation
-            startIcon={<PrintIcon />}
-            onClick={() => {
-              window.print();
-            }}
-          >
-            Print
-          </Button>
+          {windowIsSmall ? (
+            <IconButton color="secondary" aria-label="Print Report" onClick={() => window.print()}>
+              <Avatar sx={{ width: 32, height: 32, bgcolor: lightTheme.palette.secondary.main }}>
+                <PrintIcon fontSize="small" />
+              </Avatar>
+            </IconButton>
+          ) : (
+            <Button
+              variant="contained"
+              color="secondary"
+              size="small"
+              disableElevation
+              startIcon={<PrintIcon />}
+              onClick={() => window.print()}
+            >
+              Print
+            </Button>
+          )}
         </span>
       </Box>
       <Box p={1}>

--- a/client/src/components/TestSuite/styles.tsx
+++ b/client/src/components/TestSuite/styles.tsx
@@ -16,8 +16,6 @@ export default makeStyles((theme: Theme) => ({
     backgroundColor: theme.palette.background.paper,
   },
   contentContainer: {
-    flexGrow: 1,
-    padding: '24px 48px',
     overflowX: 'hidden',
     overflow: 'auto',
     '@media print': {

--- a/client/src/components/TestSuite/styles.tsx
+++ b/client/src/components/TestSuite/styles.tsx
@@ -39,7 +39,7 @@ export default makeStyles((theme: Theme) => ({
     display: 'flex',
     flexGrow: 1,
     overflow: 'hidden',
-    maxHeight: `calc(100vh - 64px - 56px - ${bannerHeight()}px)`,
+    maxHeight: `calc(100vh - ${bannerHeight()}px)`,
     '@media print': {
       maxHeight: 'unset',
     },

--- a/client/src/store/app.ts
+++ b/client/src/store/app.ts
@@ -10,6 +10,7 @@ type AppStore = {
   testSession: TestSession | undefined;
   smallWindowThreshold: number;
   windowIsSmall: boolean | undefined;
+  setFooterHeight: (footerHeight: number) => void;
   setTestSuites: (testSuites: TestSuite[]) => void;
   setTestSession: (testSession: TestSession | undefined) => void;
   setWindowIsSmall: (windowIsSmall: boolean) => void;
@@ -19,12 +20,13 @@ type AppStore = {
 // other stores can be attached to child components
 export const useAppStore = create<AppStore>(
   devtoolsInDev((set, _get) => ({
-    footerHeight: 36,
+    footerHeight: 56, // default height, small window height is 36
     headerHeight: 64,
     testSuites: [] as TestSuite[],
     testSession: undefined,
     smallWindowThreshold: 1000,
     windowIsSmall: undefined,
+    setFooterHeight: (footerHeight: number) => set({ footerHeight: footerHeight }),
     setTestSuites: (testSuites: TestSuite[]) => set({ testSuites: testSuites }),
     setTestSession: (testSession: TestSession | undefined) => set({ testSession: testSession }),
     setWindowIsSmall: (windowIsSmall: boolean | undefined) => set({ windowIsSmall: windowIsSmall }),

--- a/client/src/store/app.ts
+++ b/client/src/store/app.ts
@@ -4,6 +4,8 @@ import { devtoolsInDev } from './devtools';
 import { TestSuite, TestSession } from '~/models/testSuiteModels';
 
 type AppStore = {
+  footerHeight: number;
+  headerHeight: number;
   testSuites: TestSuite[];
   testSession: TestSession | undefined;
   smallWindowThreshold: number;
@@ -17,6 +19,8 @@ type AppStore = {
 // other stores can be attached to child components
 export const useAppStore = create<AppStore>(
   devtoolsInDev((set, _get) => ({
+    footerHeight: 36,
+    headerHeight: 64,
     testSuites: [] as TestSuite[],
     testSession: undefined,
     smallWindowThreshold: 1000,


### PR DESCRIPTION
# Summary
Condenses components/text where possible to minimize header/footer real estate on mobile.\

<img width="375" alt="Screen Shot 2022-12-13 at 4 13 25 PM" src="https://user-images.githubusercontent.com/11209247/207445446-1b1ae9ba-8ff5-4854-81d5-1d45ab45577a.png">

# Testing Guidance

Just try it out, let me know if you have any other ideas for things to shrink.

