### PR TITLE
FI-1819: Make headers unique

### DIFF
--- a/lib/inferno/db/migrations/009_make_headers_unique.rb
+++ b/lib/inferno/db/migrations/009_make_headers_unique.rb
@@ -1,0 +1,40 @@
+Sequel.migration do
+  change do
+    create_table :unique_headers do
+      column :id, String, primary_key: true, null: false, size: 36
+      column :type, String, size: 10 # request / response
+      column :name, String, size: 255
+      column :value, String, text: true
+
+      index [:type, :name, :value], unique: true
+    end
+
+    create_table :requests_unique_headers do
+      foreign_key :unique_headers_id, :unique_headers, index: true, type: String, null: false, size: 36, key: [:id]
+      foreign_key :requests_id, :requests, index: true, type: Integer, null: false, size: 36, key: [:index]
+      index [:requests_id, :unique_headers_id], unique: true
+    end
+
+    headers_table = self[:headers]
+    unique_headers_table = self[:unique_headers]
+    join_table = self[:requests_unique_headers]
+
+    headers_table.order(:id).paged_each do |header|
+      type = header[:type]
+      name = header[:name]
+      value = header[:value]
+      request_id = header[:request_id]
+
+      unique_header_id = unique_headers_table.where(type:, name:, value:).get(:id)
+
+      if unique_header_id.blank?
+        unique_header_id = SecureRandom.uuid
+        unique_headers_table.insert(id: unique_header_id, type:, name:, value:)
+      end
+
+      join_table.insert(requests_id: request_id, unique_headers_id: unique_header_id)
+    end
+
+    drop_table :headers
+  end
+end

--- a/lib/inferno/db/schema.rb
+++ b/lib/inferno/db/schema.rb
@@ -14,6 +14,17 @@ Sequel.migration do
       primary_key [:id]
     end
     
+    create_table(:unique_headers, :ignore_index_errors=>true) do
+      String :id, :size=>36, :null=>false
+      String :type, :size=>10
+      String :name, :size=>255
+      String :value, :text=>true
+      
+      primary_key [:id]
+      
+      index [:type, :name, :value], :unique=>true
+    end
+    
     create_table(:session_data, :ignore_index_errors=>true) do
       String :id, :size=>255, :null=>false
       foreign_key :test_session_id, :test_sessions, :type=>String, :size=>36, :null=>false, :key=>[:id]
@@ -103,23 +114,21 @@ Sequel.migration do
       index [:test_session_id, :name]
     end
     
-    create_table(:headers, :ignore_index_errors=>true) do
-      String :id, :size=>36, :null=>false
-      foreign_key :request_id, :requests, :null=>false, :key=>[:index]
-      String :type, :size=>255, :null=>false
-      String :name, :size=>255, :null=>false
-      String :value, :text=>true
-      
-      index [:id]
-      index [:request_id]
-    end
-    
     create_table(:requests_results, :ignore_index_errors=>true) do
       foreign_key :results_id, :results, :type=>String, :size=>36, :null=>false, :key=>[:id]
       foreign_key :requests_id, :requests, :null=>false, :key=>[:index]
       
       index [:requests_id]
       index [:results_id]
+    end
+    
+    create_table(:requests_unique_headers, :ignore_index_errors=>true) do
+      foreign_key :unique_headers_id, :unique_headers, :type=>String, :size=>36, :null=>false, :key=>[:id]
+      foreign_key :requests_id, :requests, :null=>false, :key=>[:index]
+      
+      index [:requests_id]
+      index [:requests_id, :unique_headers_id], :unique=>true
+      index [:unique_headers_id]
     end
   end
 end

--- a/lib/inferno/repositories/headers.rb
+++ b/lib/inferno/repositories/headers.rb
@@ -1,17 +1,20 @@
 module Inferno
   module Repositories
     class Headers < Repository
+      def self.table_name
+        :unique_headers
+      end
+
       class Model < Sequel::Model(db)
-        many_to_one :request, class: 'Inferno::Repositories::Requests::Model', key: :request_id
+        many_to_many :request,
+                     class: 'Inferno::Repositories::Requests::Model',
+                     join_table: :requests_unique_headers,
+                     left_key: :unique_headers_id,
+                     right_key: :requests_id
 
         def before_create
           self.id = SecureRandom.uuid
           super
-        end
-
-        def validate
-          super
-          errors.add(:request_id, 'must be present') if request_id.blank?
         end
       end
     end

--- a/spec/inferno/repositories/requests_spec.rb
+++ b/spec/inferno/repositories/requests_spec.rb
@@ -43,6 +43,20 @@ RSpec.describe Inferno::Repositories::Requests do
       expect(response_header.name).to eq('RESPONSE_HEADER_NAME')
       expect(response_header.value).to eq('RESPONSE_HEADER_VALUE')
     end
+
+    it 'does not create duplicate headers' do
+      repo.create(request_params)
+      repo.create(request_params)
+
+      expect(described_class.new.db.count).to eq(2)
+      expect(Inferno::Repositories::Headers.new.db.count).to eq(3)
+
+      persisted_header_values = Inferno::Repositories::Headers.new.db.all.map do |hash|
+        hash[:value]
+      end
+
+      expect(persisted_header_values).to match_array(['REQUEST_HEADER_VALUE', 'RESPONSE_HEADER_VALUE'])
+    end
   end
 
   describe '#find' do


### PR DESCRIPTION
# Summary
This branch alters the headers table so that unique headers are only stored once.

# Testing Guidance
- Copy `data/inferno_development.db` somewhere in case you want to restore it after testing the migration
- Run `bundle exec inferno migrate`
- Everything should work as normal
