### PR TITLE
FI-1851: Handle refresh without new token

### DIFF
--- a/lib/inferno/dsl/oauth_credentials.rb
+++ b/lib/inferno/dsl/oauth_credentials.rb
@@ -121,7 +121,7 @@ module Inferno
         expires_in = token_response_body['expires_in'].is_a?(Numeric) ? token_response_body['expires_in'] : nil
 
         self.access_token = token_response_body['access_token']
-        self.refresh_token = token_response_body['refresh_token']
+        self.refresh_token = token_response_body['refresh_token'] if token_response_body['refresh_token'].present?
         self.expires_in = expires_in
         self.token_retrieval_time = DateTime.now
 


### PR DESCRIPTION
See https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/377

This branch makes it so that the existing refresh token is maintained when a new refresh token is not received during an automatic token refresh.
