### PR TITLE
FI-1877: feature/empty-options

### DIFF
--- a/client/src/api/RequestsApi.ts
+++ b/client/src/api/RequestsApi.ts
@@ -9,7 +9,7 @@ export function getRequestDetails(requestId: string): Promise<Request | null> {
       return result as Request;
     })
     .catch((e) => {
-      console.log(e);
+      console.error(e);
       return null;
     });
 }

--- a/client/src/api/TestRunsApi.ts
+++ b/client/src/api/TestRunsApi.ts
@@ -43,7 +43,7 @@ export function postTestRun(
       return result as TestRun;
     })
     .catch((e) => {
-      console.log(e);
+      console.error(e);
       return null;
     });
 }
@@ -51,7 +51,7 @@ export function postTestRun(
 export function deleteTestRun(testRunId: string): void {
   const endpoint = getApiEndpoint(`/test_runs/${testRunId}`);
   fetch(endpoint, { method: 'DELETE' }).catch((e) => {
-    console.log(e);
+    console.error(e);
     return null;
   });
 }
@@ -70,7 +70,7 @@ export function getTestRunWithResults(
       return testRun as TestRun;
     })
     .catch((e) => {
-      console.log(e);
+      console.error(e);
       return null;
     });
 }

--- a/client/src/api/TestSessionApi.ts
+++ b/client/src/api/TestSessionApi.ts
@@ -18,7 +18,7 @@ export function getLastTestRun(test_session_id: string): Promise<TestRun | null>
       return result as TestRun;
     })
     .catch((e) => {
-      console.log(e);
+      console.error(e);
       return null;
     });
 }
@@ -31,7 +31,7 @@ export function getTestSession(test_session_id: string): Promise<TestSession | n
       return addProperties(result as TestSession);
     })
     .catch((e) => {
-      console.log(e);
+      console.error(e);
       return null;
     });
 }
@@ -56,7 +56,7 @@ export function postTestSessions(
       return result as TestSession;
     })
     .catch((e) => {
-      console.log(e);
+      console.error(e);
       return null;
     });
 }
@@ -69,7 +69,7 @@ export function getCurrentTestSessionResults(test_session_id: string): Promise<R
       return result as Result[];
     })
     .catch((e) => {
-      console.log(e);
+      console.error(e);
       return null;
     });
 }
@@ -82,7 +82,7 @@ export function getTestSessionData(test_session_id: string): Promise<TestOutput[
       return result as TestOutput[];
     })
     .catch((e) => {
-      console.log(e);
+      console.error(e);
       return null;
     });
 }

--- a/client/src/api/TestSuitesApi.ts
+++ b/client/src/api/TestSuitesApi.ts
@@ -11,7 +11,7 @@ export function getTestSuites(): Promise<TestSuite[]> {
       return testSets;
     })
     .catch((e) => {
-      console.log(e);
+      console.error(e);
       return [];
     });
 }

--- a/client/src/api/VersionsApi.ts
+++ b/client/src/api/VersionsApi.ts
@@ -5,10 +5,10 @@ export function getCoreVersion(): Promise<string> {
   return fetch(endpoint)
     .then((response) => response.json())
     .then((result) => {
-      return 'version' in result ? (result.version as string) : ''; // eslint-disable-line 
+      return 'version' in result ? (result.version as string) : ''; // eslint-disable-line
     })
     .catch((e) => {
-      console.log(e);
+      console.error(e);
       return '';
     });
 }

--- a/client/src/components/App/App.tsx
+++ b/client/src/components/App/App.tsx
@@ -33,7 +33,7 @@ const App: FC<unknown> = () => {
         setTestSuites(testSuites);
       })
       .catch((e) => {
-        console.log(e);
+        console.error(e);
       });
   }, []);
 
@@ -46,7 +46,7 @@ const App: FC<unknown> = () => {
           }
         })
         .catch((e) => {
-          console.log(e);
+          console.error(e);
         });
     }
   }, [testSuites]);
@@ -81,7 +81,11 @@ const App: FC<unknown> = () => {
               <TestSessionWrapper />
             </Route>
             <Route path="/:test_suite_id">
-              {testSuites.length > 1 && <SuiteOptionsPage testSuites={testSuites} />}
+              {testSuites.length > 0 ? (
+                <SuiteOptionsPage testSuites={testSuites} />
+              ) : (
+                <LandingPage testSuites={testSuites} />
+              )}
             </Route>
           </Switch>
         </ThemeProvider>

--- a/client/src/components/LandingPage/LandingPage.tsx
+++ b/client/src/components/LandingPage/LandingPage.tsx
@@ -38,7 +38,7 @@ const LandingPage: FC<LandingPageProps> = ({ testSuites }) => {
           }
         })
         .catch((e) => {
-          console.log(e);
+          console.error(e);
         });
     }
   }

--- a/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
+++ b/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
@@ -37,7 +37,7 @@ const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuites }) => {
     // just grab the first to start
     // perhaps choices should be persisted in the URL to make it easy to share specific options
     id: option.id,
-    value: option && option.list_options && option.list_options[0].value,
+    value: option && option.list_options ? option.list_options[0].value : '',
   }));
   const [selectedSuiteOptions, setSelectedSuiteOptions] = React.useState<SuiteOption[]>(
     initialSelectedSuiteOptions || []
@@ -46,7 +46,7 @@ const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuites }) => {
   const selectionPanel = useRef<HTMLElement>(null);
 
   useEffect(() => {
-    // If no options, then just start a test session
+    // If no options, then start a test session
     if (testSuite && (!testSuite.suite_options || testSuite.suite_options.length === 0)) {
       postTestSessions(testSuite.id, null, null)
         .then((testSession: TestSession | null) => {

--- a/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
+++ b/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
@@ -46,6 +46,21 @@ const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuites }) => {
   const selectionPanel = useRef<HTMLElement>(null);
 
   useEffect(() => {
+    // If no options, then just start a test session
+    if (testSuite && (!testSuite.suite_options || testSuite.suite_options.length === 0)) {
+      postTestSessions(testSuite.id, null, null)
+        .then((testSession: TestSession | null) => {
+          if (testSession && testSession.test_suite) {
+            history.push('test_sessions/' + testSession.id);
+          }
+        })
+        .catch((e) => {
+          console.error(e);
+        });
+    }
+  }, []);
+
+  useEffect(() => {
     getDescriptionWidth();
   }, [windowIsSmall]);
 
@@ -72,7 +87,7 @@ const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuites }) => {
         }
       })
       .catch((e) => {
-        console.log(e);
+        console.error(e);
       });
   }
 

--- a/client/src/components/TestSuite/TestSession.tsx
+++ b/client/src/components/TestSuite/TestSession.tsx
@@ -226,7 +226,7 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
         }
       })
       .catch((e) => {
-        console.log(e);
+        console.error(e);
       });
   };
 
@@ -282,7 +282,7 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
         }
       })
       .catch((e) => {
-        console.log(e);
+        console.error(e);
       });
   };
 

--- a/client/src/components/TestSuite/TestSessionWrapper.tsx
+++ b/client/src/components/TestSuite/TestSessionWrapper.tsx
@@ -43,7 +43,7 @@ const TestSessionWrapper: FC<unknown> = () => {
         setCoreVersion(version);
       })
       .catch((e) => {
-        console.log(e);
+        console.error(e);
       });
   }, []);
 
@@ -53,10 +53,10 @@ const TestSessionWrapper: FC<unknown> = () => {
         if (retrievedTestSession) {
           setTestSession(retrievedTestSession);
         } else {
-          console.log('failed to load test session');
+          console.error('Failed to load test session');
         }
       })
-      .catch((e) => console.log(e))
+      .catch((e) => console.error(e))
       .finally(() => setAttemptedGetSession(true));
   }
 
@@ -69,7 +69,7 @@ const TestSessionWrapper: FC<unknown> = () => {
           setTestRun(null);
         }
       })
-      .catch((e) => console.log(e))
+      .catch((e) => console.error(e))
       .finally(() => setAttemptedGetRun(true));
   }
 
@@ -79,10 +79,10 @@ const TestSessionWrapper: FC<unknown> = () => {
         if (results) {
           setTestResults(results);
         } else {
-          console.log('failed to load test session results');
+          console.error('failed to load test session results');
         }
       })
-      .catch((e) => console.log(e))
+      .catch((e) => console.error(e))
       .finally(() => setAttemptedGetResults(true));
   }
 
@@ -97,10 +97,10 @@ const TestSessionWrapper: FC<unknown> = () => {
           });
           setSessionData(new Map(sessionData));
         } else {
-          console.log('failed to load session data');
+          console.error('failed to load session data');
         }
       })
-      .catch((e) => console.log(e))
+      .catch((e) => console.error(e))
       .finally(() => setAttemptedSessionData(true));
   }
 

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/RequestsList.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/RequestsList.tsx
@@ -42,11 +42,11 @@ const RequestsList: FC<RequestsListProps> = ({ requests, resultId, updateRequest
             setDetailedRequest(updatedRequest);
             setShowDetails(true);
           } else {
-            console.log('failed to update request');
+            console.error('Failed to update request');
           }
         })
         .catch((e) => {
-          console.log(e);
+          console.error(e);
         });
     } else {
       setDetailedRequest(request);


### PR DESCRIPTION
# Summary
Navigating to a test suite options page via URL starts a new test session if there are no actual options.

Also makes console.logs console errors instead for future conversion to actual error handling.

# Testing Guidance
http://localhost:4567/inferno/demo for local instances.


