### PR TITLE
FI-1879: Fix suite describe

### DIFF
--- a/lib/inferno/config/boot/suites.rb
+++ b/lib/inferno/config/boot/suites.rb
@@ -2,6 +2,10 @@ Inferno::Application.boot(:suites) do
   init do
     use :logging
 
+    require 'inferno/entities/test'
+    require 'inferno/entities/test_group'
+    require 'inferno/entities/test_suite'
+
     files_to_load = Dir.glob(File.join(Dir.pwd, 'lib', '*.rb'))
 
     if ENV['LOAD_DEV_SUITES'].present?


### PR DESCRIPTION
When running in a test kit repo, the Test entity would not be loaded: `uninitialized constant Inferno::Test (NameError)`. This branch updates the suite loading to make sure that the Test entities are loaded prior to loading the suites.