### PR TITLE
FI-1876: Document routes

### DIFF
--- a/docs/advanced-test-features/index.md
+++ b/docs/advanced-test-features/index.md
@@ -1,6 +1,6 @@
 ---
 title: Advanced Features
-nav_order: 5
+nav_order: 6
 has_children: true
 ---
 # Advanced Features

--- a/docs/advanced-test-features/index.md
+++ b/docs/advanced-test-features/index.md
@@ -1,0 +1,8 @@
+---
+title: Advanced Features
+nav_order: 5
+has_children: true
+---
+# Advanced Features
+{: .no_toc}
+---

--- a/docs/advanced-test-features/serving-http-requests.md
+++ b/docs/advanced-test-features/serving-http-requests.md
@@ -1,0 +1,77 @@
+---
+title: Serving HTTP Requests
+nav_order: 2
+parent: Advanced Features
+---
+# Serving HTTP Requests
+{: .no_toc}
+
+## Table of Contents
+{: .no_toc .text-delta}
+
+1. TOC
+{:toc}
+---
+## Overview
+Some testing scenarios require that Inferno respond to incoming HTTP requests.
+For these cases, it is possible for a suite to define custom routes which will
+be served by Inferno. For example, authorization workflows based on asymmetric
+client credentials require that public keys are served at an accessible
+location, so Inferno needs to be able to serve these keys in order to support
+these workflows.
+  
+To prevent conflicts between routes defined by different test suites,
+suite-defined routes are served at
+`INFERNO_BASE/custom/SUITE_ID/CUSTOM_ROUTE_PATH`.
+
+## Defining Custom Routes
+Custom routes are defined using the
+[`route`](/inferno-core/docs/Inferno/DSL/Runnable.html#route-instance_method)
+method.
+
+```ruby
+class MyTestSuite < Inferno::TestSuite
+  route(:get, 'my_custom_route', my_route_handler)
+end
+```
+
+`route` takes three arguments, a symbol for the HTTP verb served by the route
+(`:get`, `:post`, etc., or `:all`), a String for the route path, and a route
+handler. The route handler is any Rack-compatible object.
+
+[`route` in the API
+docs](/inferno-core/docs/Inferno/DSL/Runnable.html#route-instance_method)
+
+### Route Handlers
+[Rack](https://github.com/rack/rack) is a standard interface for handling HTTP
+requests in ruby. Route handlers must be a Rack-compatible object, which could
+be something as simple as a Proc/Lambda, or an entire web application built in
+something like [Sinatra](https://sinatrarb.com/).
+
+The requirements for a Rack-compatible route handler are as follows:
+
+* It must respond to the `call` method which takes one argument ([the Rack
+  environment](https://github.com/rack/rack/blob/main/SPEC.rdoc#the-environment-)).
+* It must return a three element array consisting of:
+  * The HTTP status code (integer)
+  * The response headers (Hash)
+  * The response body (Array of Strings)
+
+Some simple route handlers could look like this:
+```ruby
+class MyTestSuite < Inferno::TestSuite
+  id :my_test_suite
+  
+  my_html = File.read(File.join(__dir__, 'my_html.html'))
+  my_html_route_handler = proc { [200, { 'Content-Type' => 'text/html' }, [html]] }
+  
+  # Serve an html page at INFERNO_PATH/my_test_suite/custom/my_html_page
+  route :get, '/my_html_page', my_html_route_handler
+  
+  my_jwks = File.read(File.join(__dir__, 'my_jwks.json'))
+  my_jwks_route_handler = proc { [200, { 'Content-Type' => 'application/json' }, [my_jwks]] }
+  
+  # Serve a JSON file at INFERNO_PATH/my_test_suite/custom/.well-known/jwks.json
+  route :get, '/.well-known/jwks.json', my_jwks_route_handler
+end
+```

--- a/docs/advanced-test-features/test-configuration.md
+++ b/docs/advanced-test-features/test-configuration.md
@@ -1,7 +1,7 @@
 ---
 title: Suite/Group/Test Configuration
-nav_order: 6
-parent: Writing Tests
+nav_order: 1
+parent: Advanced Features
 ---
 # Suite/Group/Test Configuration
 {: .no_toc}

--- a/docs/advanced-test-features/waiting-for-requests.md
+++ b/docs/advanced-test-features/waiting-for-requests.md
@@ -1,0 +1,134 @@
+---
+title: Waiting for an Incoming Request
+nav_order: 3
+parent: Advanced Features
+---
+# Waiting for an Incoming Request
+{: .no_toc}
+
+## Table of Contents
+{: .no_toc .text-delta}
+
+1. TOC
+{:toc}
+---
+## Overview
+Some testing workflows required testing to pause until an incoming request is
+received. For example, the OAuth2 workflow used by the SMART App Launch IG
+involves redirecting the user to an authorization server, which then redirects
+the user back to the application which requested authorization (Inferno). In
+order to handle a workflow like this, Inferno must be able to handle the
+incoming request and associate it with a particular testing session. Inferno
+accomplishes this with the `wait` status and special routes for resuming tests.
+
+### Making a Test Wait
+A test is instructed to wait for an incoming request using the
+[`wait`](/inferno-core/docs/Inferno/DSL/Results.html#wait-instance_method)
+method. `wait` takes three arguments:
+* `identifier` - An identifier which can uniquely identify the current test
+  session. It must be possible for this identifier to be reconstructed based on
+  the incoming request.
+* `message` - A markdown string which will be displayed to the user while the
+  test is waiting.
+* `timeout` - The number of seconds the test will wait.
+
+[`wait` in the API
+docs](/inferno-core/docs/Inferno/DSL/Results.html#wait-instance_method)
+
+### Handling the Incoming Request
+The route to make a test resume execution is created with
+[`resume_test_route`](/inferno-core/docs/Inferno/DSL/Runnable.html#resume_test_route-instance_method),
+which takes three arguments:
+* `method` - A symbol for the HTTP verb for the incoming request (`:get`,
+  `:post`, etc.)
+* `path` - A string for the route path. The route will be served at
+  `INFERNO_BASE/custom/SUITE_ID/CUSTOM_ROUTE_PATH`.
+* A block which extracts `identifier` from the incoming request and returns it.
+  In this block, `request` can be used to access a [`Request`
+  object](/inferno-core/docs/Inferno/Entities/Request.html) which contains the
+  details of the incoming request.
+  
+If it is necessary to inspect the incoming request in a test, the incoming
+request can be assigned a name using `receives_request :my_request_name` (see
+[Reusing
+Requests](/inferno-core/writing-tests/making-requests.html#reusing-requests)).
+
+[`resume_test_route` in the API
+docs](/inferno-core/docs/Inferno/DSL/Runnable.html#resume_test_route-instance_method)
+
+[`receives_request` in the API
+docs](/inferno-core/docs/Inferno/DSL/RequestStorage/ClassMethods.html#receives_request-instance_method)
+
+## Example
+This example will show how to implement the redirect flow in the [SMART App
+Launch Standalone Launch
+Sequence](http://hl7.org/fhir/smart-app-launch/1.0.0/#standalone-launch-sequence).
+It will be necessary to:
+* Redirect the user to the system under test's authorize endpoint.
+  * The client (Inferno) generates a random `state` value which the
+    authorization server sends back, so `state` can be used as the `identifier`.
+* Wait for the user to be redirected back to Inferno.
+  * Extract `state` from the incoming request to match the current test session.
+* Check that the incoming request contained a `code` parameter.
+
+```ruby
+class SMARTAppLaunchSuite < Inferno::TestSuite
+  id :smart_app_launch
+  
+  # This route will be served at INFERNO_BASE/custom/smart_app_launch/redirect
+  # Since the `state` query parameter is what uniquely links the incoming request
+  # to the current test session, return that from the block.
+  resume_test_route :get, '/redirect' do |request|
+    request.query_parameters['state']
+  end
+  
+  group do
+    id :standalone_launch
+    
+    test do
+      id :smart_redirect
+      
+      # Assign a name to the incoming request so that it can be inspected by
+      # other tests.
+      receives_request :redirect
+      
+      run do
+        # Generate a random unique state value which uniquely identifies this
+        # authorization request.
+        state = SecureRandom.uuid
+        
+        # Build authorization url based on information from discovery, app
+        # registration, and state.
+        authorization_url = ...
+        
+        # Make this test wait.
+        wait(
+          identifier: state,
+          message: %(
+            [Follow this link to authorize with the SMART server](#{authorization_url}).
+
+            Tests will resume once Inferno receives a request at
+            `#{Inferno::Application['base_url']}/custom/smart_app_launch/redirect`
+            with a state of `#{state}`.
+          )
+        )
+      end
+    end
+    
+    # Execution will resume with this test once the incoming request is
+    # received.
+    test do
+      id :redirect_contains_code
+      
+      # Make the incoming request from the previous test available here.
+      uses_request :redirect
+      
+      run do
+        code = request.query_parameters['code']
+        
+        assert code.present?, 'No `code` parameter received'
+      end
+    end
+  end
+end
+```

--- a/docs/available-test-kits.md
+++ b/docs/available-test-kits.md
@@ -1,6 +1,6 @@
 ---
 title: Available Test Kits
-nav_order: 9
+nav_order: 10
 ---
 # Available Test Kits
 {: .no_toc}

--- a/docs/available-test-kits.md
+++ b/docs/available-test-kits.md
@@ -1,6 +1,6 @@
 ---
 title: Available Test Kits
-nav_order: 7
+nav_order: 9
 ---
 # Available Test Kits
 {: .no_toc}

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -1,6 +1,6 @@
 ---
 title: Deployment
-nav_order: 6
+nav_order: 8
 has_children: true
 ---
 # Deploying Inferno

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -1,6 +1,6 @@
 ---
 title: Deployment
-nav_order: 8
+nav_order: 9
 has_children: true
 ---
 # Deploying Inferno

--- a/docs/distributing-tests.md
+++ b/docs/distributing-tests.md
@@ -1,6 +1,6 @@
 ---
 title: Distributing Tests
-nav_order: 7
+nav_order: 8
 ---
 # Distributing Tests
 {: .no_toc}

--- a/docs/distributing-tests.md
+++ b/docs/distributing-tests.md
@@ -1,6 +1,6 @@
 ---
 title: Distributing Tests
-nav_order: 6
+nav_order: 7
 ---
 # Distributing Tests
 {: .no_toc}

--- a/docs/repo-layout-and-organization.md
+++ b/docs/repo-layout-and-organization.md
@@ -1,6 +1,6 @@
 ---
 title: Test Kit Repository Layout and Organization
-nav_order: 5
+nav_order: 6
 ---
 # Test Kit Repository Layout and Organization
 {: .no_toc}

--- a/docs/repo-layout-and-organization.md
+++ b/docs/repo-layout-and-organization.md
@@ -1,6 +1,6 @@
 ---
 title: Test Kit Repository Layout and Organization
-nav_order: 6
+nav_order: 7
 ---
 # Test Kit Repository Layout and Organization
 {: .no_toc}


### PR DESCRIPTION
# Summary
This branch adds documentation for serving custom routes and using wait tests.

# Testing Guidance
`bundle exec jekyll s` in docs, then go to `localhost:4000/inferno-core`.
