### PR TITLE
FI-1880: Misc. documentation

### DIFF
--- a/docs/advanced-test-features/configuration-checks.md
+++ b/docs/advanced-test-features/configuration-checks.md
@@ -1,0 +1,46 @@
+---
+title: Configuration Checks
+nav_order: 5
+parent: Advanced Features
+---
+# Configuration Checks
+{: .no_toc}
+
+## Table of Contents
+{: .no_toc .text-delta}
+
+1. TOC
+{:toc}
+---
+## Overview
+Test Suites can have a set of checks they perform on startup to ensure that
+their environment is correctly configured. These checks are performed the first
+time a session is created for the suite. The checks can be refreshed [using the
+JSON API](/inferno-core/api-docs/#/Test
+Suite/put_test_suites__test_suite_id__check_configuration).
+
+### Defining Configuration Checks
+The `check_configuration` method defines a check to be performed. It takes a
+block which returns an Array of message hashes.
+
+```ruby
+class MySuite < Inferno::TestSuite
+  check_configuration do
+    messages = []
+    
+    if validator_is_correct_version?
+      messages << { type: 'info', message: 'Correct validator version' }
+    else
+      messages << { type: 'error', message: 'Incorrect validator version' }
+    end
+    
+    if service_xyz_is_available?
+      messages << { type: 'info', message: 'Service XYZ is available' }
+    else
+      messages << { type: 'error', message: 'Service XYZ is unavailable' }
+    end
+    
+    messages
+  end
+end
+```

--- a/docs/advanced-test-features/scratch.md
+++ b/docs/advanced-test-features/scratch.md
@@ -1,0 +1,66 @@
+---
+title: Scratch
+nav_order: 4
+parent: Advanced Features
+---
+# Scratch
+{: .no_toc}
+
+## Table of Contents
+{: .no_toc .text-delta}
+
+1. TOC
+{:toc}
+---
+## Overview
+Scratch provides an alternative to inputs and outputs for passing information
+between tests. Inputs and outputs should be preferred over scratch when
+possible.
+
+| Inputs/Outputs | Scratch |
+| --- | --- |
+| Stored in the database | Stored in memory |
+| Strings | Any data type |
+| Persist through an entire test session | Lifetime limited to a single test run |
+| Input values only change if they are a test output | Any test can change scratch |
+
+The major advantage of scratch is that its contents are stored in memory. Inputs
+are loaded from the database at the start of each test. If tests require a large
+number of complex objects, scratch provides a way to avoid repeatedly loading,
+deserializing, and instantiating them. The major limitation of scratch is that
+it only persists through a single test run (i.e., a single click of the _Run
+Tests_ button).
+
+## Example
+`scratch` is just a plain Hash which is passed to each test.
+
+```ruby
+class MyGroup < Inferno::TestGroup
+  # Since scratch is lost at the end of a test run, by making this group run
+  # together, that ensures that the tests run together and the scratch will
+  # remain present.
+  run_as_group
+  
+  test do
+    run do
+      # retrieve a large number of FHIR resources
+      # ...
+      
+      scratch[:observations] = a_large_number_of_fhir_observations
+      scratch[:conditions] =  a_large_number_of_fhir_conditions
+    end
+  end
+  
+  test do
+    run do
+      perform_some_operation_on(scratch[:observations])
+    end
+  end
+  
+  test do
+    run do
+      perform_some_operation_on(scratch[:conditions])
+    end
+  end
+end
+```

--- a/docs/available-test-kits.md
+++ b/docs/available-test-kits.md
@@ -1,26 +1,49 @@
 ---
 title: Available Test Kits
-nav_order: 10
+nav_order: 7
 ---
 # Available Test Kits
 {: .no_toc}
 ---
 
-- **[US Core Test Kit](https://github.com/inferno-framework/us-core-test-kit)**: Tests for the [US Core Implementation Guide v3.1.1](http://hl7.org/fhir/us/core/STU3.1.1/)
+- **[US Core Test Kit](https://github.com/inferno-framework/us-core-test-kit)**:
+  Tests for the [US Core Implementation Guide](http://hl7.org/fhir/us/core)
 {: .my-4 .test-kit-links }
-- **[ONC Certification (g)(10) Test Kit](https://github.com/inferno-framework/onc-certification-g10-test-kit)**: Tests for the [Standardized API for Patient and Population Services criterion § 170.315(g)(10) in the 2015 Edition Cures Update](https://www.healthit.gov/test-method/standardized-api-patient-and-population-services#test_procedure). You can view this test kit in action [here](https://inferno.healthit.gov/onc-certification-g10-test-kit).
+- **[ONC Certification (g)(10) Test
+    Kit](https://github.com/inferno-framework/onc-certification-g10-test-kit)**:
+    Tests for the [Standardized API for Patient and Population Services
+    criterion § 170.315(g)(10) in the 2015 Edition Cures
+    Update](https://www.healthit.gov/test-method/standardized-api-patient-and-population-services#test_procedure).
+    You can view this test kit in action
+  [here](https://inferno.healthit.gov/onc-certification-g10-test-kit).
 {: .my-4 .test-kit-links }
-- **[SMART App Launch Framework Test Kit](https://github.com/inferno-framework/smart-app-launch-test-kit)**: Tests for the [SMART App Launch Framework](http://hl7.org/fhir/smart-app-launch/1.0.0/)
+- **[SMART App Launch Framework Test
+  Kit](https://github.com/inferno-framework/smart-app-launch-test-kit)**: Tests
+  for the [SMART App Launch Framework](http://hl7.org/fhir/smart-app-launch)
 {: .my-4 .test-kit-links }
-- **[International Patient Summary Test Kit](https://github.com/inferno-framework/ips-test-kit)**: Tests for the [International Patient Summary Implementation Guide](http://hl7.org/fhir/uv/ips/)
+- **[International Patient Summary Test
+  Kit](https://github.com/inferno-framework/ips-test-kit)**: Tests for the
+  [International Patient Summary Implementation
+  Guide](http://hl7.org/fhir/uv/ips/)
 {: .my-4 .test-kit-links }
-- **[International Patient Access Test Kit](https://github.com/inferno-framework/ipa-test-kit)**: Tests for the [International Patient Access Implementation Guide](http://build.fhir.org/ig/HL7/fhir-ipa/)
+- **[International Patient Access Test
+  Kit](https://github.com/inferno-framework/ipa-test-kit)**: Tests for the
+  [International Patient Access Implementation
+  Guide](http://build.fhir.org/ig/HL7/fhir-ipa/)
 {: .my-4 .test-kit-links }
-- **[SMART Health Cards: Vaccination & Testing Test Kit](https://github.com/inferno-framework/shc-vaccination-test-kit)**: Tests for the [SMART Health Cards: Vaccination & Testing Implemenation Guide](https://build.fhir.org/ig/HL7/fhir-shc-vaccination-ig/)
+- **[SMART Health Cards: Vaccination & Testing Test
+  Kit](https://github.com/inferno-framework/shc-vaccination-test-kit)**: Tests
+  for the [SMART Health Cards: Vaccination & Testing Implemenation
+  Guide](https://build.fhir.org/ig/HL7/fhir-shc-vaccination-ig/)
 {: .my-4 .test-kit-links }
-- **[FAST Security Test Kit](https://github.com/inferno-framework/fast-security-test-kit)**: Tests for the [Security for Scalable Registration, Authentication, and Authorization Implementation Guide](https://build.fhir.org/ig/HL7/fhir-udap-security-ig/index.html)
+- **[FAST Security Test
+  Kit](https://github.com/inferno-framework/fast-security-test-kit)**: Tests for
+  the [Security for Scalable Registration, Authentication, and Authorization
+  Implementation
+  Guide](https://build.fhir.org/ig/HL7/fhir-udap-security-ig/index.html)
 {: .my-4 .test-kit-links }
-- **[TLS Test Kit](https://github.com/inferno-framework/tls-test-kit)**: Tests for TLS connections
+- **[TLS Test Kit](https://github.com/inferno-framework/tls-test-kit)**: Tests
+  for TLS connections
 {: .my-4 .test-kit-links }
 
 

--- a/docs/deployment/host.md
+++ b/docs/deployment/host.md
@@ -12,6 +12,13 @@ parent: Deployment
 1. TOC
 {:toc}
 ---
+## Overview
+Inferno needs to know the URL where it is being hosted, and it determines this
+based on environment variables. These environment variables need to be set in
+both the web and worker processes. Some tests need to generate links to Inferno,
+so the worker process needs to know where Inferno is hosted even though it isn't
+serving those urls itself.
+
 ## Hostname Configuration
 Set the `INFERNO_HOST` environment variable in `.env` to tell Inferno what its
 host and scheme are. This allows Inferno to correctly construct things like

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -103,6 +103,8 @@ The advantages of using a local ruby installation are
   docker images. This must be done every time tests change.
 * It is possible to set breakpoints and access an interactive debugger inside of
   running tests, which makes test development much easier.
+* The Inferno Command Line Interface can be used. Run `inferno help` for
+  information.
 
 ### Development with Ruby
 
@@ -136,7 +138,7 @@ The advantages of using a local ruby installation are
 
 #### Interactive consoles
 A local ruby installation also allows you to use [pry](https://pry.github.io/),
-a powerful interactive console to explore and experiment with your tests with
+a powerful interactive console, to explore and experiment with your tests with
 `inferno console`:
 ```ruby
 ᐅ bundle exec inferno console

--- a/docs/writing-tests/assertions-and-results.md
+++ b/docs/writing-tests/assertions-and-results.md
@@ -31,7 +31,7 @@ test do
   end
 end
 ```
-Inferno also implements more specific assertion to handle common cases, such as:
+Inferno also implements more specific assertions to handle common cases, such as:
 - Verifying the http status code of a response.
 - Verifying that a string is valid JSON.
 - Validating a FHIR Resource.
@@ -58,7 +58,8 @@ Tests can have the following results in Inferno:
   This indicates a problem in a test kit or in Inferno itself. You should
   contact the test kit author or the Inferno team.
 - `wait` - A test is waiting to receive an incoming request, and will resume
-  once it is received.
+  once it is received (see [Waiting for an Incoming
+  Request](/inferno-core/advanced-test-features/waiting-for-requests.html)).
 - `cancel` (not yet implemented)
 
 ### Assigning specific results

--- a/docs/writing-tests/defining-tests.md
+++ b/docs/writing-tests/defining-tests.md
@@ -203,7 +203,7 @@ module USCoreTestKit
 end
 ```
 
-When importang a group, its optional children can be omitted:
+When importing a group, its optional children can be omitted:
 ```ruby
 group from: :us_core_patient, exclude_optional: true
 ```

--- a/docs/writing-tests/fhir-validation.md
+++ b/docs/writing-tests/fhir-validation.md
@@ -1,0 +1,129 @@
+---
+title: FHIR Validation
+nav_order: 6
+parent: Writing Tests
+---
+# FHIR Resource Validation
+{: .no_toc}
+
+## Table of Contents
+{: .no_toc .text-delta}
+
+1. TOC
+{:toc}
+---
+## Overview
+FHIR resource validation is performed by the [FHIR Validator Wrapper
+service](https://github.com/inferno-framework/fhir-validator-wrapper). When
+creating a test kit based on the template:
+
+* Place the `.tgz` IG packages for any profiles you need to validate against in
+  `lib/YOUR_TEST_KIT_NAME/igs`.
+* Make sure that the volume path in `docker-compose.background.yml` points to
+  the above directory.
+* Restart the validator service after adding/changing any IGs.
+
+### Defining Validators
+The test kit template defines a validator in the suite, and it is not necessary
+to alter it unless you need multiple validators or want to add extra validator
+behaviors. Validators are defined with `validator`:
+
+```ruby
+validator :optional_validator_name do
+  # Read the validator URL from an environment variable
+  url ENV.fetch('VALIDATOR_URL')
+end
+```
+
+[`validator` in the API
+docs](/inferno-core/docs/Inferno/DSL/FHIRValidation/ClassMethods.html#validator-instance_method)
+
+### Validating FHIR Resources
+The `resource_is_valid?` method will validate a FHIR resource and add any
+validation messages to the runnable.
+
+```ruby
+test do
+  fhir_read :patient, '123'
+  
+  # Validate the resource from the last request
+  if resource_is_valid?
+  end
+  
+  # Validate some other resource
+  if resource_is_valid?(resource: some_other_resource)
+  end
+  
+  # Validate against a particular profile
+  if resource_is_valid?(profile_url: 'http://example.com/fhir_profile_url')
+  end
+  
+  # Validate using a particular named validator
+  if resource_is_valid?(validator: :my_customized_validator)
+  end
+end
+```
+
+[`resource_is_valid?` in the API
+docs](/inferno-core/docs/Inferno/DSL/FHIRValidation.html#resource_is_valid%3F-instance_method)
+
+`assert_valid_resource` will validate the resource, add any validation messages
+to the runnable, and fail the test if the resource is invalid.
+
+```ruby
+test do
+  fhir_read :patient, '123'
+  
+  # Use the resource from the last request
+  assert_valid_resource
+  
+  # Validate some other resource
+  assert_valid_resource(resource: some_other_resource)
+  
+  # Validate against a particular profile
+  assert_valid_resource(profile_url: 'http://example.com/fhir_profile_url')
+  
+  # Validate using a particular named validator
+  assert_valid_resource(validator: :my_customized_validator)
+end
+```
+
+[`assert_valid_resource` in the API
+docs](/inferno-core/docs/Inferno/DSL/Assertions.html#assert_valid_resource-instance_method)
+
+### Filtering Validation Messages
+If you need to ignore certain validation messages in your test kit, this can be
+done using the `exclude_message` method in the validator definition.
+
+```ruby
+validator do
+  url ENV.fetch('VALIDATOR_URL')
+  # Messages will be excluded if the block evaluates to a truthy value
+  exclude_message do |message|
+    message.type == 'info' ||
+      message.message.include?('message to ignore') ||
+      message.message.match?(/regex_filter/)
+  end
+end
+```
+
+### Performing Additional Validation
+Additional resource validation can be done using the
+`perform_additional_validation` method in the validator definition. This method
+can be used multiple times in a single validator definition to add multiple
+additional validation steps. To add additional validation messages, the block in
+this method must return a single Hash with a `type` and `message`, or an Array
+of Hashes with those keys. If the block returns `nil`, no new messages are
+added. The resource is considered invalid if any messages with a `type` of
+`error` are present.
+
+```ruby
+validator do
+  url ENV.fetch('VALIDATOR_URL')
+  perform_additional_validation do |resource, profile_url|
+    if something_is_wrong
+      { type: 'error', message: 'something is wrong'}
+    end
+  end
+end
+```

--- a/docs/writing-tests/making-requests.md
+++ b/docs/writing-tests/making-requests.md
@@ -54,7 +54,7 @@ test do
     
     ...
     
-    assert_response_status(200, responce: some_other_response)
+    assert_response_status(200, response: some_other_response)
     assert_resource_type(:patient, resource: some_other_resource)
     assert_valid_resource(resource: some_other_resource)
   end
@@ -146,10 +146,13 @@ end
 
 ### Available FHIR Request Methods
 The following methods are currently available for making FHIR requests:
+- `fhir_create`
+- `fhir_delete`
 - `fhir_get_capability_statement`
+- `fhir_operation`
 - `fhir_read`
 - `fhir_search`
-- `fhir_operation`
+- `fhir_transaction`
 For more details on these methods, see the [FHIR Client API
 documentation](/inferno-core/docs/Inferno/DSL/FHIRClient.html). If you need to
 make other types of FHIR requests, [contact the Inferno
@@ -241,6 +244,8 @@ end
 The following methods are currently available for making http requests:
 - `get`
 - `post`
+- `delete`
+- `stream` - used to stream the response from a GET request
 
 For more details on these methods, see the [HTTP Client API
 documentation](/inferno-core/docs/Inferno/DSL/HTTPClient.html). If you need to

--- a/docs/writing-tests/making-requests.md
+++ b/docs/writing-tests/making-requests.md
@@ -132,13 +132,13 @@ end
 ```
 
 If you need direct access to the FHIR client in a test, it is available via
-`client`. The client is reinstantiated in each test, so changes made to a client
-within a test do not carry over into other tests.
+`fhir_client`. The client is reinstantiated in each test, so changes made to a
+client within a test do not carry over into other tests.
 
 ```ruby
 test do
   run do
-    client # this returns the FHIR client
+    fhir_client # this returns the FHIR client
   end
 end
 ```
@@ -174,6 +174,36 @@ group do
       fhir_read(:patient, '123', client: :client_a)
       
       fhir_read(:patient, '456', client: :client_b)
+    end
+  end
+end
+```
+
+### OAuth Credentials
+When making requests to FHIR servers using OAuth2-based (such as the SMART App
+Launch workflow) authorization, OAuth credentials support an access token and
+optionally a refresh token as well as all of the information needed to perform a
+token refresh (refresh token, token endpoint, client ID, client secret). If all
+of this information is available, the FHIR client will automatically refresh the
+access token if it will expire in under a minute. If no information on the
+access token duration is available, the token will be refreshed prior to each
+FHIR request.
+
+```ruby
+group do
+  input :credentials, type: :oauth_credentials
+  
+  fhir_client do
+    url 'https://example.com/fhir'
+    oauth_credentials :credentials
+  end
+  
+  test do
+    run do
+      sleep 3600
+      
+      # The access token will automatically refresh if it has expired
+      fhir_read(:patient, '123') 
     end
   end
 end

--- a/docs/writing-tests/test-inputs-outputs.md
+++ b/docs/writing-tests/test-inputs-outputs.md
@@ -60,7 +60,8 @@ docs](/inferno-core/docs/Inferno/DSL/Runnable.html#input-instance_method)
 
 ### Defining Multiple Inputs
 It is possible to define multiple inputs in a single `input` call, but not with
-any of the additional properties listed above.
+any of the additional properties listed above. This can be useful when a test
+uses inputs which have been more completely defined in a parent or sibling.
 
 ```ruby
 test do
@@ -107,8 +108,8 @@ end
 
 ## Defining Outputs
 The `output` method defines an output. It is used in a test's definition block
-to define which outputs a test uses, and within a test's `run` block to assign a
-value to an output. Multiple outputs can be defined/assigned at once.
+to define which outputs a test provides, and within a test's `run` block to
+assign a value to an output. Multiple outputs can be defined/assigned at once.
 
 ```ruby
 test do

--- a/lib/inferno/dsl/assertions.rb
+++ b/lib/inferno/dsl/assertions.rb
@@ -61,8 +61,10 @@ module Inferno
       # @param resource [FHIR::Model]
       # @param profile_url [String] url of the profile to validate against,
       #   defaults to validating against the base FHIR resource
-      def assert_valid_resource(resource: self.resource, profile_url: nil)
-        assert resource_is_valid?(resource:, profile_url:),
+      # @param validator [Symbol] the name of the validator to use
+      # @return [void]
+      def assert_valid_resource(resource: self.resource, profile_url: nil, validator: :default)
+        assert resource_is_valid?(resource:, profile_url:, validator:),
                invalid_resource_message(profile_url)
       end
 


### PR DESCRIPTION
# Summary
This branch adds documentation for some small remaining features and fixes typos/cleans up remaining docs.

# Testing Guidance
`bundle exec jekyll s` in docs, then go to `localhost:4000/inferno-core`.