### PR TITLE
FI-1883: Update yard docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Template Repository](https://github.com/inferno-framework/inferno-template).
 
 ## Contributing to Inferno Core
 Developers interested in contributing to the Inferno Core gem must have [Ruby
-2.7+](https://www.ruby-lang.org/en/) and [Node.js and
+3.1+](https://www.ruby-lang.org/en/) and [Node.js and
 NPM](https://www.npmjs.com/get-npm) installed.
 
 ## Using Inferno Core to author tests
@@ -31,7 +31,7 @@ bundle install
 gem install foreman
 
 # Set up database
-bundle exec bin/inferno migrate
+bin/inferno migrate
 
 # Start Inferno background services (validator, redis, nginx)
 bin/inferno services start
@@ -93,10 +93,15 @@ GET http://localhost:4567/inferno/api/test_sessions/TEST_SESSION_ID/results
 To get to an interactive console, run `bundle exec bin/inferno console`
 
 ## Customizable Banner
-Inferno Core allows you to add your own customizable banner. It loads the banner from the `config/banner.html.erb` file and renders it above the application. The size and appearance of the banner can be controlled by using the inline style attribute. 
+Inferno Core allows you to add your own customizable banner. It loads the banner
+from the `config/banner.html.erb` file and renders it above the application. The
+size and appearance of the banner can be controlled by using the inline style
+attribute.
 
 ## Documentation
-Inferno documentation source code is located in the `docs/` directory. This documentation is rendered using Jekyll, which creates a site that can be built and served with: 
+Inferno documentation source code is located in the `docs/` directory. This
+documentation is rendered using Jekyll, which creates a site that can be built
+and served with:
 
 ```sh
 cd docs/
@@ -107,7 +112,7 @@ By default the site will be served at `http://localhost:4000/inferno-core/`
 
 
 ## License
-Copyright 2022 The MITRE Corporation
+Copyright 2023 The MITRE Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License. You may obtain a copy of the

--- a/lib/inferno/dsl/assertions.rb
+++ b/lib/inferno/dsl/assertions.rb
@@ -12,6 +12,7 @@ module Inferno
       # @param test a value whose truthiness will determine whether the
       #   assertion passes or fails
       # @param message [String] failure message
+      # @return [void]
       def assert(test, message = '')
         raise Exceptions::AssertionException, message unless test
       end
@@ -26,6 +27,7 @@ module Inferno
       # @param status [Integer, Array<Integer>] a single integer or an array of
       #   integer status codes
       # @param response [Hash]
+      # @return [void]
       def assert_response_status(status, response: self.response)
         assert Array.wrap(status).include?(response[:status]), bad_response_status_message(status, response[:status])
       end
@@ -44,6 +46,7 @@ module Inferno
       #   assert_resource_type(:capability_statement)
       #   assert_resource_type('CapabilityStatement')
       #   assert_resource_type(FHIR::CapabilityStatement)
+      # @return [void]
       def assert_resource_type(resource_type, resource: self.resource)
         resource_type_name = normalize_resource_type(resource_type)
 
@@ -95,6 +98,7 @@ module Inferno
       #       'Condition': nil
       #     }
       #   )
+      # @return [void]
       def assert_valid_bundle_entries(bundle: resource, resource_types: {})
         assert_resource_type('Bundle', resource: bundle)
 
@@ -150,6 +154,7 @@ module Inferno
       #
       # @param maybe_json_string [String]
       # @param message [String] extra failure message
+      # @return [void]
       def assert_valid_json(maybe_json_string, message = '')
         assert JSON.parse(maybe_json_string)
       rescue JSON::ParserError
@@ -160,6 +165,7 @@ module Inferno
       #
       # @param uri [String]
       # @param message [String] custom failure message
+      # @return [void]
       def assert_valid_http_uri(uri, message = '')
         error_message = message.presence || "\"#{uri}\" is not a valid URI"
         assert uri =~ /\A#{URI::DEFAULT_PARSER.make_regexp(['http', 'https'])}\z/, error_message
@@ -169,6 +175,7 @@ module Inferno
       #
       # @param type [String]
       # @param request [Inferno::Entities::Request]
+      # @return [void]
       def assert_response_content_type(type, request: self.request)
         header = request.response_header('Content-Type')
         assert header.present?, no_content_type_message

--- a/lib/inferno/dsl/configurable.rb
+++ b/lib/inferno/dsl/configurable.rb
@@ -6,6 +6,7 @@ module Inferno
     # configuration provides a way to modify test behavior at boot time.
     #
     # The main features enabled by configuration are:
+    #
     # - Modifying the properties of a runnable's inputs. This could include
     #   locking a particular input, making a particular input optional/required,
     #   or changing an input's value.
@@ -81,6 +82,7 @@ module Inferno
       # will be applied to the runnable and all of its children.
       #
       # @param new_configuration [Hash]
+      # @return [Inferno::DSL::Configurable::Configuration]
       def config(new_configuration = {})
         @config ||= Configuration.new
 

--- a/lib/inferno/dsl/fhir_client.rb
+++ b/lib/inferno/dsl/fhir_client.rb
@@ -243,6 +243,7 @@ module Inferno
         # @param block a block to configure the client
         # @see Inferno::FHIRClientBuilder Documentation for the client
         #   configuration DSL
+        # @return [void]
         def fhir_client(name = :default, &block)
           fhir_client_definitions[name] = block
         end

--- a/lib/inferno/dsl/fhir_validation.rb
+++ b/lib/inferno/dsl/fhir_validation.rb
@@ -99,7 +99,8 @@ module Inferno
             .select { |message| message.is_a? Hash }
         end
 
-        # Filter out unwanted validation messages
+        # Filter out unwanted validation messages. Any messages for which the
+        # block evalutates to a truthy value will be excluded.
         #
         # @example
         #   validator do

--- a/lib/inferno/dsl/http_client.rb
+++ b/lib/inferno/dsl/http_client.rb
@@ -198,6 +198,7 @@ module Inferno
         # @param block a block to configure the client
         # @see Inferno::HTTPClientBuilder Documentation for the client
         #   configuration DSL
+        # @return [void]
         def http_client(name = :default, &block)
           http_client_definitions[name] = block
         end

--- a/lib/inferno/dsl/input_output_handling.rb
+++ b/lib/inferno/dsl/input_output_handling.rb
@@ -47,7 +47,7 @@ module Inferno
       # @param identifier [Symbol] identifier for the output
       # @param other_identifiers [Symbol] array of symbols if specifying multiple outputs
       # @param output_definition [Hash] options for output
-      # @option output_definition [String] :type text | textarea | oauth_credentials
+      # @option output_definition [String] :type text, textarea, or oauth_credentials
       # @return [void]
       # @example
       #   output :patient_id, :condition_id, :observation_id

--- a/lib/inferno/dsl/request_storage.rb
+++ b/lib/inferno/dsl/request_storage.rb
@@ -89,6 +89,7 @@ module Inferno
         # Specify the named requests made by a test
         #
         # @param identifiers [Symbol] one or more request identifiers
+        # @return [void]
         def makes_request(*identifiers)
           named_requests_made.concat(identifiers).uniq!
           identifiers.each do |identifier|
@@ -99,6 +100,7 @@ module Inferno
         # Specify the name for a request received by a test
         #
         # @param identifier [Symbol]
+        # @return [void]
         def receives_request(identifier)
           config.add_request(identifier)
           @incoming_request_name = identifier
@@ -112,6 +114,7 @@ module Inferno
         # Specify the named requests used by a test
         #
         # @param identifiers [Symbol] one or more request identifiers
+        # @return [void]
         def uses_request(*identifiers)
           named_requests_used.concat(identifiers).uniq!
           identifiers.each do |identifier|

--- a/lib/inferno/dsl/results.rb
+++ b/lib/inferno/dsl/results.rb
@@ -5,6 +5,7 @@ module Inferno
       # Halt execution of the current test and mark it as passed.
       #
       # @param message [String]
+      # @return [void]
       def pass(message = '')
         raise Exceptions::PassException, message
       end
@@ -14,6 +15,7 @@ module Inferno
       #
       # @param test [Boolean]
       # @param message [String]
+      # @return [void]
       def pass_if(test, message = '')
         raise Exceptions::PassException, message if test
       end
@@ -21,6 +23,7 @@ module Inferno
       # Halt execution of the current test and mark it as skipped.
       #
       # @param message [String]
+      # @return [void]
       def skip(message = '')
         raise Exceptions::SkipException, message
       end
@@ -30,6 +33,7 @@ module Inferno
       #
       # @param test [Boolean]
       # @param message [String]
+      # @return [void]
       def skip_if(test, message = '')
         raise Exceptions::SkipException, message if test
       end
@@ -37,6 +41,7 @@ module Inferno
       # Halt execution of the current test and mark it as omitted.
       #
       # @param message [String]
+      # @return [void]
       def omit(message = '')
         raise Exceptions::OmitException, message
       end
@@ -46,6 +51,7 @@ module Inferno
       #
       # @param test [Boolean]
       # @param message [String]
+      # @return [void]
       def omit_if(test, message = '')
         raise Exceptions::OmitException, message if test
       end
@@ -75,6 +81,7 @@ module Inferno
       # @param message [String]
       # @param timeout [Integer] Number of seconds to wait for an incoming
       #   request
+      # @return [void]
       def wait(identifier:, message: '', timeout: 300)
         identifier(identifier)
         wait_timeout(timeout)

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -268,7 +268,6 @@ module Inferno
       #
       # @param optional [Boolean]
       # @return [void]
-      #
       def optional(optional = true) # rubocop:disable Style/OptionalBooleanParameter
         @optional = optional
       end
@@ -347,6 +346,7 @@ module Inferno
       #   route. The block has access to the `request` method which returns a
       #   {Inferno::Entities::Request} object with the information for the
       #   incoming request.
+      # @return [void]
       def resume_test_route(method, path, &block)
         route_class = Class.new(ResumeTestRoute) do |klass|
           klass.singleton_class.instance_variable_set(:@test_run_identifier_block, block)
@@ -368,6 +368,7 @@ module Inferno
       #   compatible object (e.g. a `Proc` object, a [Sinatra
       #   app](http://sinatrarb.com/)) as described in the [Hanami Router
       #   documentation.](https://github.com/hanami/router/tree/f41001d4c3ee9e2d2c7bb142f74b43f8e1d3a265#mount-rack-applications)
+      # @return [void]
       def route(method, path, handler)
         Inferno.routes << { method:, path:, handler:, suite: }
       end
@@ -414,6 +415,7 @@ module Inferno
       #   group from: :ig_v2_group do
       #     required_suite_options ig_version: 'ig_v2'
       #   end
+      # @return [void]
       def required_suite_options(suite_option_requirements)
         @suite_option_requirements =
           suite_option_requirements.map do |key, value|
@@ -436,6 +438,7 @@ module Inferno
         end
       end
 
+      # @private
       def inspect
         non_dynamic_ancestor = ancestors.find { |ancestor| !ancestor.to_s.start_with? '#' }
         "#<#{non_dynamic_ancestor}".tap do |inspect_string|

--- a/lib/inferno/entities/request.rb
+++ b/lib/inferno/entities/request.rb
@@ -58,29 +58,29 @@ module Inferno
       # Find a response header
       #
       # @param name [String] the header name
-      # @return [Inferno::Entities::RequestHeader, nil]
+      # @return [Inferno::Entities::Header, nil]
       def response_header(name)
         response_headers.find { |header| header.name.casecmp(name).zero? }
       end
 
       # Find a request header
       #
-      # @param name [String] the header name
-      # @return [Inferno::Entities::RequestHeader, nil]
+      # @param name [String] the header name.
+      # @return [Inferno::Entities::Header, nil]
       def request_header(name)
         request_headers.find { |header| header.name.casecmp(name).zero? }
       end
 
       # All of the request headers
       #
-      # @return [Array<Inferno::Entities::RequestHeader>]
+      # @return [Array<Inferno::Entities::Header>]
       def request_headers
         headers.select(&:request?)
       end
 
       # All of the response headers
       #
-      # @return [Array<Inferno::Entities::RequestHeader>]
+      # @return [Array<Inferno::Entities::Header>]
       def response_headers
         headers.select(&:response?)
       end
@@ -131,7 +131,7 @@ module Inferno
 
       # Return the FHIR resource from the response body.
       #
-      # @return [FHIR::Model]
+      # @return [FHIR::Model, nil]
       def resource
         FHIR.from_contents(response_body)
       end

--- a/lib/inferno/entities/test.rb
+++ b/lib/inferno/entities/test.rb
@@ -28,6 +28,11 @@ module Inferno
         @messages ||= []
       end
 
+      # Add a message to the result.
+      #
+      # @param type [String] error, warning, or info
+      # @param message [String]
+      # @return [void]
       def add_message(type, message)
         messages << { type: type.to_s, message: format_markdown(message) }
       end
@@ -40,7 +45,6 @@ module Inferno
       # @example
       #   output(patient_id: '5', bearer_token: 'ABC')
       def output(outputs)
-        # TODO: update to track outputs that need to be updated
         outputs.each do |key, value|
           send("#{key}=", value)
           outputs_to_persist[key] = value
@@ -158,6 +162,7 @@ module Inferno
           end
         end
 
+        # @private
         def repository
           Inferno::Repositories::Tests.new
         end

--- a/lib/inferno/entities/test_group.rb
+++ b/lib/inferno/entities/test_group.rb
@@ -28,6 +28,7 @@ module Inferno
       end
 
       class << self
+        # @private
         def repository
           Inferno::Repositories::TestGroups.new
         end
@@ -53,12 +54,14 @@ module Inferno
         # Methods to configure Inferno::DSL::Runnable
 
         # Add a child group
+        # @return [void]
         def group(...)
           child_metadata(group_metadata)
           define_child(...)
         end
 
         # Add a test
+        # @return [void]
         def test(...)
           child_metadata(test_metadata)
           define_child(...)
@@ -108,6 +111,7 @@ module Inferno
         # UI, and this group must be run as a group.
         #
         # @param value [Boolean]
+        # @return [void]
         def run_as_group(value = true) # rubocop:disable Style/OptionalBooleanParameter
           @run_as_group = value
         end

--- a/lib/inferno/entities/test_suite.rb
+++ b/lib/inferno/entities/test_suite.rb
@@ -28,6 +28,7 @@ module Inferno
           @default_group
         end
 
+        # @private
         def repository
           Inferno::Repositories::TestSuites.new
         end
@@ -44,6 +45,7 @@ module Inferno
         # Methods to configure Inferno::DSL::Runnable
 
         # Add a child group
+        # @return [void]
         def group(...)
           child_metadata(group_metadata)
           define_child(...)
@@ -93,6 +95,7 @@ module Inferno
         # @yieldreturn [Array<Hash>] An array of message hashes containing the
         #   keys `:type` and `:message`. Type options are `info`, `warning`, and
         #   `error`.
+        # @return [void]
         def check_configuration(&block)
           @check_configuration_block = block
         end
@@ -134,6 +137,7 @@ module Inferno
         #   group from: :ig_v2_group do
         #     required_suite_options ig_version: 'ig_v2'
         #   end
+        # @return [void]
         def suite_option(identifier, **option_params)
           suite_options << DSL::SuiteOption.new(option_params.merge(id: identifier))
         end


### PR DESCRIPTION
# Summary
Minor updates to yard docs. Mainly marking methods I don't want to expose as private and marking methods whose return values should not be used as returning void.

# Testing Guidance
Run `bin/docs` to regenerate the yard docs, then `open docs/docs/index.html` to see the changes.
