### PR TITLE
FI-1885: Make fhir models extension nil safe

### DIFF
--- a/lib/inferno/ext/fhir_models.rb
+++ b/lib/inferno/ext/fhir_models.rb
@@ -27,7 +27,7 @@ end
 module InfernoJson
   def from_json(json)
     resource = super(json)
-    resource.source_text = json
+    resource&.source_text = json
     resource
   end
 end
@@ -37,7 +37,7 @@ end
 module InfernoXml
   def from_xml(xml)
     resource = super(xml)
-    resource.source_text = xml
+    resource&.source_text = xml
     resource
   end
 end


### PR DESCRIPTION
When parsing fails, `from_json/xml` returns `nil`, so there was a nil safety issue in the FHIR models extension. See https://github.com/onc-healthit/onc-certification-g10-test-kit/issues/397