### PR TITLE
FI-1881: Improve session routes

### DIFF
--- a/client/src/components/App/App.tsx
+++ b/client/src/components/App/App.tsx
@@ -86,7 +86,7 @@ const App: FC<unknown> = () => {
               Title for TestSessionWrapper is set in the component 
               because testSession is not set at the time of render 
             */}
-            <Route path="/test_sessions/:test_suite_id/:test_session_id">
+            <Route path="/:test_suite_id/:test_session_id">
               <TestSessionWrapper />
             </Route>
             <Route

--- a/client/src/components/App/App.tsx
+++ b/client/src/components/App/App.tsx
@@ -86,7 +86,7 @@ const App: FC<unknown> = () => {
               Title for TestSessionWrapper is set in the component 
               because testSession is not set at the time of render 
             */}
-            <Route path="/test_sessions/:test_session_id">
+            <Route path="/test_sessions/:test_suite_id/:test_session_id">
               <TestSessionWrapper />
             </Route>
             <Route

--- a/client/src/components/LandingPage/LandingPage.tsx
+++ b/client/src/components/LandingPage/LandingPage.tsx
@@ -36,7 +36,7 @@ const LandingPage: FC<LandingPageProps> = ({ testSuites }) => {
       postTestSessions(testSuiteChosen, null, null)
         .then((testSession: TestSession | null) => {
           if (testSession && testSession.test_suite) {
-            history.push('test_sessions/' + testSession.id);
+            history.push('test_sessions/' + testSession.test_suite_id + '/' + testSession.id);
           }
         })
         .catch((e: Error) => {

--- a/client/src/components/LandingPage/LandingPage.tsx
+++ b/client/src/components/LandingPage/LandingPage.tsx
@@ -36,7 +36,7 @@ const LandingPage: FC<LandingPageProps> = ({ testSuites }) => {
       postTestSessions(testSuiteChosen, null, null)
         .then((testSession: TestSession | null) => {
           if (testSession && testSession.test_suite) {
-            history.push('test_sessions/' + testSession.test_suite_id + '/' + testSession.id);
+            history.push(testSession.test_suite_id + '/' + testSession.id);
           }
         })
         .catch((e: Error) => {

--- a/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
+++ b/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
@@ -78,7 +78,7 @@ const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuite }) => {
     postTestSessions(id, null, options)
       .then((testSession: TestSession | null) => {
         if (testSession && testSession.test_suite) {
-          history.push('test_sessions/' + testSession.test_suite_id + '/' + testSession.id);
+          history.push(testSession.test_suite_id + '/' + testSession.id);
         }
       })
       .catch((e: Error) => {

--- a/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
+++ b/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
@@ -78,7 +78,7 @@ const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuite }) => {
     postTestSessions(id, null, options)
       .then((testSession: TestSession | null) => {
         if (testSession && testSession.test_suite) {
-          history.push('test_sessions/' + testSession.id);
+          history.push('test_sessions/' + testSession.test_suite_id + '/' + testSession.id);
         }
       })
       .catch((e: Error) => {

--- a/lib/inferno/apps/web/controllers/test_sessions/client_show.rb
+++ b/lib/inferno/apps/web/controllers/test_sessions/client_show.rb
@@ -24,7 +24,7 @@ module Inferno
             if test_suite_id.blank? || test_suite_id != test_session.test_suite_id
               test_suite_id = test_session.test_suite_id
 
-              res.redirect_to "#{Inferno::Application['base_url']}/test_sessions/#{test_suite_id}/#{test_session_id}"
+              res.redirect_to "#{Inferno::Application['base_url']}/#{test_suite_id}/#{test_session_id}"
             end
 
             test_suite = Inferno::Repositories::TestSuites.new.find(test_suite_id)

--- a/lib/inferno/apps/web/controllers/test_sessions/client_show.rb
+++ b/lib/inferno/apps/web/controllers/test_sessions/client_show.rb
@@ -1,0 +1,40 @@
+module Inferno
+  module Web
+    module Controllers
+      module TestSessions
+        class ClientShow < Controller
+          config.default_response_format = :html
+
+          CLIENT_PAGE =
+            ERB.new(
+              File.read(
+                File.join(
+                  Inferno::Application.root, 'lib', 'inferno', 'apps', 'web', 'index.html.erb'
+                )
+              )
+            ).result.freeze
+
+          def handle(req, res)
+            test_session_id = req.params[:id]
+            test_suite_id = req.params[:test_suite_id]
+
+            test_session = repo.find(test_session_id)
+            halt 404 if test_session.nil?
+
+            if test_suite_id.blank? || test_suite_id != test_session.test_suite_id
+              test_suite_id = test_session.test_suite_id
+
+              res.redirect_to "#{Inferno::Application['base_url']}/test_sessions/#{test_suite_id}/#{test_session_id}"
+            end
+
+            test_suite = Inferno::Repositories::TestSuites.new.find(test_suite_id)
+
+            halt 404 if test_suite.nil?
+
+            res.body = CLIENT_PAGE
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/inferno/apps/web/router.rb
+++ b/lib/inferno/apps/web/router.rb
@@ -53,7 +53,8 @@ module Inferno
       # Should not need Content-Type header but GitHub Codespaces will not work without them.
       # This could be investigated and likely removed if addressed properly elsewhere.
       get '/', to: ->(_env) { [200, { 'Content-Type' => 'text/html' }, [client_page]] }
-      get '/test_sessions/:id', to: ->(_env) { [200, { 'Content-Type' => 'text/html' }, [client_page]] }
+      get '/test_sessions/:test_suite_id/:id', to: Inferno::Web::Controllers::TestSessions::ClientShow
+      get '/test_sessions/:id', to: Inferno::Web::Controllers::TestSessions::ClientShow
 
       Inferno.routes.each do |route|
         cleaned_id = route[:suite].id.gsub(/[^a-zA-Z\d\-._~]/, '_')
@@ -70,6 +71,7 @@ module Inferno
         Application['logger'].info("Registering suite route: #{suite_path}")
         get suite_path, to: ->(_env) { [200, {}, [client_page]] }
       end
+      Inferno::Application['logger'].info("*** Registering updated client routes ***")
     end
 
     Router = # rubocop:disable Naming/ConstantName

--- a/lib/inferno/apps/web/router.rb
+++ b/lib/inferno/apps/web/router.rb
@@ -53,8 +53,6 @@ module Inferno
       # Should not need Content-Type header but GitHub Codespaces will not work without them.
       # This could be investigated and likely removed if addressed properly elsewhere.
       get '/', to: ->(_env) { [200, { 'Content-Type' => 'text/html' }, [client_page]] }
-      get '/test_sessions/:test_suite_id/:id', to: Inferno::Web::Controllers::TestSessions::ClientShow
-      get '/test_sessions/:id', to: Inferno::Web::Controllers::TestSessions::ClientShow
 
       Inferno.routes.each do |route|
         cleaned_id = route[:suite].id.gsub(/[^a-zA-Z\d\-._~]/, '_')
@@ -71,7 +69,9 @@ module Inferno
         Application['logger'].info("Registering suite route: #{suite_path}")
         get suite_path, to: ->(_env) { [200, {}, [client_page]] }
       end
-      Inferno::Application['logger'].info("*** Registering updated client routes ***")
+
+      get '/test_sessions/:id', to: Inferno::Web::Controllers::TestSessions::ClientShow
+      get '/:test_suite_id/:id', to: Inferno::Web::Controllers::TestSessions::ClientShow
     end
 
     Router = # rubocop:disable Naming/ConstantName

--- a/lib/inferno/apps/web/router.rb
+++ b/lib/inferno/apps/web/router.rb
@@ -70,8 +70,8 @@ module Inferno
         get suite_path, to: ->(_env) { [200, {}, [client_page]] }
       end
 
-      get '/test_sessions/:id', to: Inferno::Web::Controllers::TestSessions::ClientShow
-      get '/:test_suite_id/:id', to: Inferno::Web::Controllers::TestSessions::ClientShow
+      get '/test_sessions/:id', to: Inferno::Web::Controllers::TestSessions::ClientShow, as: :client_session_show
+      get '/:test_suite_id/:id', to: Inferno::Web::Controllers::TestSessions::ClientShow, as: :client_suite_session_show
     end
 
     Router = # rubocop:disable Naming/ConstantName

--- a/lib/inferno/entities/test_session.rb
+++ b/lib/inferno/entities/test_session.rb
@@ -40,7 +40,7 @@ module Inferno
 
         self.suite_options ||= []
 
-        test_suite.suite_options&.each do |option|
+        test_suite&.suite_options&.each do |option|
           if suite_options.none? { |selected_option| selected_option.id == option.id }
             suite_options << DSL::SuiteOption.new(id: option.id, value: option.list_options.first[:value])
           end

--- a/spec/requests/client_requests_spec.rb
+++ b/spec/requests/client_requests_spec.rb
@@ -2,11 +2,6 @@ require 'request_helper'
 
 RSpec.describe 'client requests' do
   let(:router) { Inferno::Web::Router }
-  # let(:response_fields) { ['id', 'inputs', 'results', 'status', 'test_group_id'] }
-  # let(:test_group_id) { BasicTestSuite::Suite.groups.first.id }
-  # let(:test_run) { repo_create(:test_run, runnable: { test_group_id: }) }
-  # let(:result) { repo_create(:result, test_run:) }
-  # let(:request) { repo_create(:request, result:) }
 
   describe 'GET /test_sessions/:id' do
     it 'returns a 404 if no session is found' do
@@ -35,7 +30,11 @@ RSpec.describe 'client requests' do
     end
 
     it 'returns a 404 if no suite is found' do
-      get router.path(:client_suite_session_show, id: SecureRandom.uuid, test_suite_id: 'bad_suite')
+      session = repo_create(:test_session)
+
+      allow_any_instance_of(Inferno::Entities::TestSession).to receive(:test_suite_id).and_return('bad_suite')
+
+      get router.path(:client_suite_session_show, id: session.id, test_suite_id: 'bad_suite')
 
       expect(last_response.status).to eq(404)
     end

--- a/spec/requests/client_requests_spec.rb
+++ b/spec/requests/client_requests_spec.rb
@@ -1,0 +1,61 @@
+require 'request_helper'
+
+RSpec.describe 'client requests' do
+  let(:router) { Inferno::Web::Router }
+  # let(:response_fields) { ['id', 'inputs', 'results', 'status', 'test_group_id'] }
+  # let(:test_group_id) { BasicTestSuite::Suite.groups.first.id }
+  # let(:test_run) { repo_create(:test_run, runnable: { test_group_id: }) }
+  # let(:result) { repo_create(:result, test_run:) }
+  # let(:request) { repo_create(:request, result:) }
+
+  describe 'GET /test_sessions/:id' do
+    it 'returns a 404 if no session is found' do
+      get router.path(:client_session_show, id: SecureRandom.uuid)
+
+      expect(last_response.status).to eq(404)
+    end
+
+    it 'redirects to /:test_suite_id/:id if the session is found' do
+      session = repo_create(:test_session)
+      get router.path(:client_session_show, id: session.id)
+
+      expected_path = Inferno::Application['inferno_host'] +
+                      router.path(:client_suite_session_show, id: session.id, test_suite_id: session.test_suite_id)
+
+      expect(last_response.status).to eq(302)
+      expect(last_response.headers['Location']).to eq(expected_path)
+    end
+  end
+
+  describe 'GET /:test_suite_id/:id' do
+    it 'returns a 404 if no session is found' do
+      get router.path(:client_suite_session_show, id: SecureRandom.uuid, test_suite_id: 'basic')
+
+      expect(last_response.status).to eq(404)
+    end
+
+    it 'returns a 404 if no suite is found' do
+      get router.path(:client_suite_session_show, id: SecureRandom.uuid, test_suite_id: 'bad_suite')
+
+      expect(last_response.status).to eq(404)
+    end
+
+    it 'redirects to the sessions suite if the wrong suite id is used' do
+      session = repo_create(:test_session)
+      get router.path(:client_suite_session_show, id: session.id, test_suite_id: 'demo')
+
+      expected_path = Inferno::Application['inferno_host'] +
+                      router.path(:client_suite_session_show, id: session.id, test_suite_id: session.test_suite_id)
+
+      expect(last_response.status).to eq(302)
+      expect(last_response.headers['Location']).to eq(expected_path)
+    end
+
+    it 'returns a 200 if the session and suite are found' do
+      session = repo_create(:test_session)
+      get router.path(:client_suite_session_show, id: session.id, test_suite_id: session.test_suite_id)
+
+      expect(last_response.status).to eq(200)
+    end
+  end
+end


### PR DESCRIPTION
# Summary
Update routes for sessions so they look like `BASE_PATH/:test_suite_id/:id` instead of `BASE_PATH/test_sessions/:id`. Old routes redirect to new routes.

# Testing Guidance
Start sessions for the various suites and they should work. Replace the suite id in the url with `test_sessions` and you should be redirected to the original url.