### PR TITLE
Draft: FI-1905: Single suite new session

### DIFF
--- a/client/src/api/TestSuitesApi.ts
+++ b/client/src/api/TestSuitesApi.ts
@@ -8,7 +8,7 @@ export function getTestSuites(): Promise<TestSuite[]> {
     .then((response) => response.json())
     .then((result) => {
       testSets = result as TestSuite[];
-      return [testSets[0]] || [];
+      return [testSets[2]] || [];
     })
     .catch(() => {
       return [];

--- a/client/src/api/TestSuitesApi.ts
+++ b/client/src/api/TestSuitesApi.ts
@@ -8,7 +8,7 @@ export function getTestSuites(): Promise<TestSuite[]> {
     .then((response) => response.json())
     .then((result) => {
       testSets = result as TestSuite[];
-      return testSets;
+      return [testSets[0]] || [];
     })
     .catch(() => {
       return [];

--- a/client/src/api/TestSuitesApi.ts
+++ b/client/src/api/TestSuitesApi.ts
@@ -8,7 +8,7 @@ export function getTestSuites(): Promise<TestSuite[]> {
     .then((response) => response.json())
     .then((result) => {
       testSets = result as TestSuite[];
-      return [testSets[2]] || [];
+      return [testSets[0]] || [];
     })
     .catch(() => {
       return [];

--- a/client/src/api/TestSuitesApi.ts
+++ b/client/src/api/TestSuitesApi.ts
@@ -8,7 +8,7 @@ export function getTestSuites(): Promise<TestSuite[]> {
     .then((response) => response.json())
     .then((result) => {
       testSets = result as TestSuite[];
-      return [testSets[0]] || [];
+      return testSets || [];
     })
     .catch(() => {
       return [];

--- a/client/src/components/App/App.tsx
+++ b/client/src/components/App/App.tsx
@@ -1,21 +1,16 @@
 import React, { FC, useEffect } from 'react';
 import { RouterProvider } from 'react-router-dom';
 import { StyledEngineProvider } from '@mui/material/styles';
-import { useSnackbar } from 'notistack';
-import { postTestSessions } from '~/api/TestSessionApi';
 import { getTestSuites } from '~/api/TestSuitesApi';
 import { router } from '~/components/App/Router';
 import ThemeProvider from '~/components/ThemeProvider';
-import { TestSession, TestSuite } from '~/models/testSuiteModels';
+import { TestSuite } from '~/models/testSuiteModels';
 import { useAppStore } from '~/store/app';
 
 const App: FC<unknown> = () => {
-  const { enqueueSnackbar } = useSnackbar();
   const setFooterHeight = useAppStore((state) => state.setFooterHeight);
   const testSuites = useAppStore((state) => state.testSuites);
   const setTestSuites = useAppStore((state) => state.setTestSuites);
-  const testSession = useAppStore((state) => state.testSession);
-  const setTestSession = useAppStore((state) => state.setTestSession);
   const smallWindowThreshold = useAppStore((state) => state.smallWindowThreshold);
   const setWindowIsSmall = useAppStore((state) => state.setWindowIsSmall);
 
@@ -35,20 +30,6 @@ const App: FC<unknown> = () => {
       });
   }, []);
 
-  useEffect(() => {
-    if (testSuites && testSuites.length === 1) {
-      postTestSessions(testSuites[0].id, null, null)
-        .then((testSession: TestSession | null) => {
-          if (testSession && testSession.test_suite) {
-            setTestSession(testSession);
-          }
-        })
-        .catch((e: Error) => {
-          enqueueSnackbar(`Error while creating test session: ${e.message}`, { variant: 'error' });
-        });
-    }
-  }, [testSuites]);
-
   const handleResize = () => {
     if (window.innerWidth < smallWindowThreshold) {
       setWindowIsSmall(true);
@@ -59,14 +40,14 @@ const App: FC<unknown> = () => {
     }
   };
 
-  if (!testSuites || (testSuites.length === 1 && !testSession)) {
+  if (!testSuites || testSuites.length === 0) {
     return <></>;
   }
 
   return (
     <StyledEngineProvider injectFirst>
       <ThemeProvider>
-        <RouterProvider router={router(testSuites, testSession)} />
+        <RouterProvider router={router(testSuites)} />
       </ThemeProvider>
     </StyledEngineProvider>
   );

--- a/client/src/components/App/Router.tsx
+++ b/client/src/components/App/Router.tsx
@@ -14,7 +14,7 @@ export const router = (testSuites: TestSuite[], testSession?: TestSession) => {
         path: '/',
         element:
           testSuites.length === 1 && testSession ? (
-            <Navigate to={`/test_sessions/${testSession.id}`} />
+            <Navigate to={`/${testSuites[0].id}/${testSession.id}`} />
           ) : (
             <Page title={`Inferno Test Suites`}>
               <LandingPage testSuites={testSuites} />

--- a/client/src/components/App/Router.tsx
+++ b/client/src/components/App/Router.tsx
@@ -1,25 +1,22 @@
 import React from 'react';
-import { createBrowserRouter, Navigate } from 'react-router-dom';
+import { createBrowserRouter } from 'react-router-dom';
 import LandingPage from '~/components/LandingPage';
 import SuiteOptionsPage from '~/components/SuiteOptionsPage';
 import TestSessionWrapper from '~/components/TestSuite/TestSessionWrapper';
 import { basePath } from '~/api/infernoApiService';
 import Page from '~/components/App/Page';
-import { TestSession, TestSuite } from '~/models/testSuiteModels';
+import { TestSuite } from '~/models/testSuiteModels';
 
-export const router = (testSuites: TestSuite[], testSession?: TestSession) => {
+export const router = (testSuites: TestSuite[]) => {
   return createBrowserRouter(
     [
       {
         path: '/',
-        element:
-          testSuites.length === 1 && testSession ? (
-            <Navigate to={`/${testSuites[0].id}/${testSession.id}`} />
-          ) : (
-            <Page title={`Inferno Test Suites`}>
-              <LandingPage testSuites={testSuites} />
-            </Page>
-          ),
+        element: (
+          <Page title={`Inferno Test Suites`}>
+            <LandingPage testSuites={testSuites} />
+          </Page>
+        ),
       },
       {
         path: ':test_suite_id',

--- a/client/src/components/App/__tests__/App.test.tsx
+++ b/client/src/components/App/__tests__/App.test.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { SnackbarProvider } from 'notistack';
 
 import App from '../App';
 import * as testSuitesApi from '~/api/TestSuitesApi';
-import * as testSessionApi from '~/api/TestSessionApi';
-import { testSuites, singleTestSuite, testSession } from '../__mocked_data__/mockData';
+import { testSuites } from '../__mocked_data__/mockData';
 
 import { vi } from 'vitest';
 
@@ -33,26 +32,5 @@ describe('The App Root Component', () => {
     );
 
     expect(getTestSuites).toBeCalledTimes(1);
-  });
-
-  it('sets the Test Session if there is a single Test Suite', async () => {
-    const getTestSuites = vi.spyOn(testSuitesApi, 'getTestSuites');
-    getTestSuites.mockResolvedValue(singleTestSuite);
-
-    const postTestSessions = vi.spyOn(testSessionApi, 'postTestSessions');
-    postTestSessions.mockResolvedValue(testSession);
-    postTestSessions.mockRejectedValue(new Error('Error while creating test session'));
-
-    render(
-      <SnackbarProvider>
-        <App />
-      </SnackbarProvider>
-    );
-
-    // We have to wait for something to load so we don't get act()
-    // warnings.  The only thing rendered by App is children components.
-    // So await for those to be done with side effects (hooks).
-    await screen.findByText('Suite One');
-    expect(postTestSessions).toBeCalledTimes(1);
   });
 });

--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -3,12 +3,11 @@ import { AppBar, Avatar, Box, Button, IconButton, Toolbar, Typography } from '@m
 import { Link, useNavigate } from 'react-router-dom';
 import { Menu, NoteAdd } from '@mui/icons-material';
 import { getStaticPath } from '~/api/infernoApiService';
-import { SuiteOptionChoice, TestSession } from '~/models/testSuiteModels';
+import { SuiteOptionChoice } from '~/models/testSuiteModels';
 import { useAppStore } from '~/store/app';
 import useStyles from './styles';
 import icon from '~/images/inferno_icon.png';
 import lightTheme from '~/styles/theme';
-import { postTestSessions } from '~/api/TestSessionApi';
 
 export interface HeaderProps {
   suiteId?: string;
@@ -31,23 +30,9 @@ const Header: FC<HeaderProps> = ({
   const navigate = useNavigate();
   const headerHeight = useAppStore((state) => state.headerHeight);
   const windowIsSmall = useAppStore((state) => state.windowIsSmall);
-  const setTestSession = useAppStore((state) => state.setTestSession);
 
   const startNewSession = () => {
-    if (!suiteId) {
-      navigate('/');
-    } else {
-      postTestSessions(suiteId, null, null)
-        .then((testSession: TestSession | null) => {
-          if (testSession && testSession.test_suite) {
-            navigate(`/${suiteId}/${testSession.id}`);
-            setTestSession(testSession);
-          }
-        })
-        .catch(() => {
-          navigate('/');
-        });
-    }
+    navigate('/');
   };
 
   const suiteOptionsString =

--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -39,10 +39,9 @@ const Header: FC<HeaderProps> = ({
     } else {
       postTestSessions(suiteId, null, null)
         .then((testSession: TestSession | null) => {
-          // navigate('/');
-
           if (testSession && testSession.test_suite) {
             setTestSession(testSession);
+            navigate(`/${suiteId}/${testSession.id}`);
           }
         })
         .catch(() => {
@@ -78,7 +77,7 @@ const Header: FC<HeaderProps> = ({
             <Menu fontSize="inherit" />
           </IconButton>
         ) : (
-          <Link to="/" aria-label="Inferno Home" onClick={() => setTestSession(undefined)}>
+          <Link to="/" aria-label="Inferno Home">
             <img src={getStaticPath(icon as string)} alt="Inferno logo" className={styles.logo} />
           </Link>
         )}

--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -40,8 +40,8 @@ const Header: FC<HeaderProps> = ({
       postTestSessions(suiteId, null, null)
         .then((testSession: TestSession | null) => {
           if (testSession && testSession.test_suite) {
-            setTestSession(testSession);
             navigate(`/${suiteId}/${testSession.id}`);
+            setTestSession(testSession);
           }
         })
         .catch(() => {

--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -3,11 +3,12 @@ import { AppBar, Avatar, Box, Button, IconButton, Toolbar, Typography } from '@m
 import { Link, useHistory } from 'react-router-dom';
 import { Menu, NoteAdd } from '@mui/icons-material';
 import { getStaticPath } from '~/api/infernoApiService';
-import { SuiteOptionChoice } from '~/models/testSuiteModels';
+import { SuiteOptionChoice, TestSession } from '~/models/testSuiteModels';
 import { useAppStore } from '~/store/app';
 import useStyles from './styles';
 import icon from '~/images/inferno_icon.png';
 import lightTheme from '~/styles/theme';
+import { postTestSessions } from '~/api/TestSessionApi';
 
 export interface HeaderProps {
   suiteId?: string;
@@ -30,9 +31,29 @@ const Header: FC<HeaderProps> = ({
   const history = useHistory();
   const headerHeight = useAppStore((state) => state.headerHeight);
   const windowIsSmall = useAppStore((state) => state.windowIsSmall);
+  const setTestSession = useAppStore((state) => state.setTestSession);
 
+<<<<<<< Updated upstream
   const returnHome = () => {
     history.push('/');
+=======
+  const startNewSession = () => {
+    if (!suiteId) {
+      navigate('/');
+    } else {
+      postTestSessions(suiteId, null, null)
+        .then((testSession: TestSession | null) => {
+          navigate('/');
+
+          if (testSession && testSession.test_suite) {
+            setTestSession(testSession);
+          }
+        })
+        .catch(() => {
+          navigate('/');
+        });
+    }
+>>>>>>> Stashed changes
   };
 
   const suiteOptionsString =
@@ -62,7 +83,7 @@ const Header: FC<HeaderProps> = ({
             <Menu fontSize="inherit" />
           </IconButton>
         ) : (
-          <Link to="/" aria-label="Inferno Home">
+          <Link to="/" aria-label="Inferno Home" onClick={() => setTestSession(undefined)}>
             <img src={getStaticPath(icon as string)} alt="Inferno logo" className={styles.logo} />
           </Link>
         )}
@@ -109,7 +130,7 @@ const Header: FC<HeaderProps> = ({
           style={windowIsSmall ? { marginRight: '-16px' } : {}}
         >
           {windowIsSmall ? (
-            <IconButton color="secondary" aria-label="New Session" onClick={returnHome}>
+            <IconButton color="secondary" aria-label="New Session" onClick={startNewSession}>
               <Avatar sx={{ width: 32, height: 32, bgcolor: lightTheme.palette.secondary.main }}>
                 <NoteAdd fontSize="small" />
               </Avatar>
@@ -121,7 +142,7 @@ const Header: FC<HeaderProps> = ({
               size="small"
               variant="contained"
               startIcon={<NoteAdd />}
-              onClick={returnHome}
+              onClick={startNewSession}
             >
               New Session
             </Button>

--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -39,7 +39,7 @@ const Header: FC<HeaderProps> = ({
     } else {
       postTestSessions(suiteId, null, null)
         .then((testSession: TestSession | null) => {
-          navigate('/');
+          // navigate('/');
 
           if (testSession && testSession.test_suite) {
             setTestSession(testSession);

--- a/client/src/components/LandingPage/__tests__/LandingPage.test.tsx
+++ b/client/src/components/LandingPage/__tests__/LandingPage.test.tsx
@@ -2,10 +2,13 @@ import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
 import { SnackbarProvider } from 'notistack';
-import ThemeProvider from 'components/ThemeProvider';
-import LandingPage from '../LandingPage';
+import * as testSessionApi from '~/api/TestSessionApi';
+import ThemeProvider from '~/components/ThemeProvider';
+import LandingPage from '~/components/LandingPage/LandingPage';
 import { mockedTestSuitesReturnValue } from '../__mocked_data__/mockData';
+import { singleTestSuite, testSession } from '~/components/App/__mocked_data__/mockData';
 
 test('renders Inferno Landing Page', () => {
   const testSuites = mockedTestSuitesReturnValue;
@@ -60,4 +63,20 @@ test('should enable Start Testing when test suite is selected', () => {
   userEvent.click(testSuiteElement);
   expect(testSuiteElement).toHaveFocus();
   expect(buttonElement).toBeEnabled();
+});
+
+test('sets the Test Session if there is a single Test Suite', () => {
+  const postTestSessions = vi.spyOn(testSessionApi, 'postTestSessions');
+  postTestSessions.mockResolvedValue(testSession);
+
+  render(
+    <BrowserRouter>
+      <ThemeProvider>
+        <SnackbarProvider>
+          <LandingPage testSuites={singleTestSuite} />
+        </SnackbarProvider>
+      </ThemeProvider>
+    </BrowserRouter>
+  );
+  expect(postTestSessions).toBeCalledTimes(1);
 });

--- a/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
+++ b/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
@@ -29,6 +29,7 @@ export interface SuiteOptionsPageProps {
 
 const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuite }) => {
   const { enqueueSnackbar } = useSnackbar();
+  const testSuites = useAppStore((state) => state.testSuites);
   const windowIsSmall = useAppStore((state) => state.windowIsSmall);
   const smallWindowThreshold = useAppStore((state) => state.smallWindowThreshold);
   const styles = useStyles();
@@ -208,8 +209,13 @@ const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuite }) => {
             className={styles.optionsList}
             sx={{ width: windowIsSmall ? 'auto' : '400px', maxWidth: '400px' }}
           >
-            <Box display="flex" alignItems="center" justifyContent="space-between" mx={1}>
-              {renderBackButton()}
+            <Box
+              display="flex"
+              alignItems="center"
+              justifyContent={testSuites.length > 1 ? 'space-between' : 'center'}
+              mx={1}
+            >
+              {testSuites.length > 1 && renderBackButton()}
               <Typography
                 variant="h4"
                 component="h2"
@@ -221,7 +227,7 @@ const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuite }) => {
                 Options
               </Typography>
               {/* Spacer to center title with button */}
-              <Box minWidth="45px" />
+              {testSuites.length > 1 && <Box minWidth="45px" />}
             </Box>
 
             <Box overflow="auto" px={4} pt={2}>


### PR DESCRIPTION
# Summary
Updates behavior when a single suite is loaded so that the test session header navigation buttons start a new session when redirected to the landing page.

To be merged after the router migration from v5 to v6.

# Testing Guidance

Behavior when a single test suite is loaded should be as follows: 

- Initially loading the Landing Page should redirect to a different page. If there are suite options, the Suite Options Page will render, else a new Test Session will be populated and loaded.
- Clicking the logo or the `New Session` button in the header redirects to the Landing Page, which should automatically redirect as above.
- Clicking the header title should redirect to the suite options page or start a new session if there are no options.

No behavior should change when multiple test suites are loaded.