### PR TITLE
FI-1907: Change tab on icon click

### DIFF
--- a/client/src/components/TestSuite/TestSession.tsx
+++ b/client/src/components/TestSuite/TestSession.tsx
@@ -386,10 +386,10 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
           classes={{ paper: styles.swipeableDrawerHeight }}
         >
           {/* Spacer to be updated with header height */}
-          <Toolbar sx={{ minHeight: `${headerHeight}px` }} />
+          <Toolbar sx={{ minHeight: `${headerHeight}px !important` }} />
           {renderDrawerContents()}
           {/* Spacer to be updated with footer height */}
-          <Toolbar sx={{ minHeight: `${footerHeight}px` }} />
+          <Toolbar sx={{ minHeight: `${footerHeight}px !important` }} />
         </SwipeableDrawer>
       ) : (
         <Drawer

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/ProblemBadge.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/ProblemBadge.tsx
@@ -31,7 +31,10 @@ const ProblemBadge: FC<ProblemBadgeProps> = ({
 
   const openPanel = () => {
     if (view !== 'report') {
-      if (setPanelIndex && panelIndex) setPanelIndex(panelIndex);
+      // panelIndex can be 0, which is falsy, so explicitly check against undefined
+      if (setPanelIndex && panelIndex !== undefined) {
+        setPanelIndex(panelIndex);
+      }
       if (setOpen) setOpen(true);
     }
   };
@@ -45,12 +48,12 @@ const ProblemBadge: FC<ProblemBadgeProps> = ({
       className={clsx([color, badgeStyle, styles.badgeBase])}
       onClick={(e) => {
         e.stopPropagation();
-        if (openPanel) openPanel();
+        openPanel();
       }}
       onKeyDown={(e) => {
         e.stopPropagation();
         if (e.key === 'Enter') {
-          if (openPanel) openPanel();
+          openPanel();
         }
       }}
     >
@@ -62,12 +65,12 @@ const ProblemBadge: FC<ProblemBadgeProps> = ({
           className={clsx([styles.badgeIcon, color])}
           onClick={(e) => {
             e.stopPropagation();
-            if (openPanel) openPanel();
+            openPanel();
           }}
           onKeyDown={(e) => {
             e.stopPropagation();
             if (e.key === 'Enter') {
-              if (openPanel) openPanel();
+              openPanel();
             }
           }}
         />

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
@@ -248,6 +248,7 @@ const TestListItem: FC<TestListItemProps> = ({
               test={test}
               tabs={tabs}
               currentTabIndex={tabIndex}
+              setTabIndex={setTabIndex}
               updateRequest={updateRequest}
             />
           )}

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestRunDetail.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestRunDetail.tsx
@@ -14,6 +14,7 @@ import remarkGfm from 'remark-gfm';
 interface TestRunDetailProps {
   test: Test;
   currentTabIndex: number;
+  setTabIndex: React.Dispatch<React.SetStateAction<number>>;
   updateRequest?: (requestId: string, resultId: string, request: Request) => void;
   tabs: TabProps[];
 }
@@ -23,9 +24,14 @@ export interface TabProps {
   value: Message[] | Request[] | TestInput[] | TestOutput[] | string | null | undefined;
 }
 
-const TestRunDetail: FC<TestRunDetailProps> = ({ test, currentTabIndex, tabs, updateRequest }) => {
+const TestRunDetail: FC<TestRunDetailProps> = ({
+  test,
+  currentTabIndex,
+  setTabIndex,
+  updateRequest,
+  tabs,
+}) => {
   const styles = useStyles();
-  const [tabIndex, setTabIndex] = React.useState(currentTabIndex);
 
   useEffect(() => {
     setTabIndex(currentTabIndex);
@@ -81,7 +87,7 @@ const TestRunDetail: FC<TestRunDetailProps> = ({ test, currentTabIndex, tabs, up
   return (
     <Card data-testid="test-run-detail">
       <Tabs
-        value={tabIndex}
+        value={currentTabIndex}
         variant="scrollable"
         className={styles.tabs}
         onChange={(e, newIndex: number) => {
@@ -91,10 +97,10 @@ const TestRunDetail: FC<TestRunDetailProps> = ({ test, currentTabIndex, tabs, up
         {tabs.map((tab, i) => renderTab(tab, i))}
       </Tabs>
       <Divider />
-      <TabPanel id={test.id} currentTabIndex={tabIndex} index={0}>
+      <TabPanel id={test.id} currentTabIndex={currentTabIndex} index={0}>
         <MessagesList messages={test.result?.messages || []} />
       </TabPanel>
-      <TabPanel id={test.id} currentTabIndex={tabIndex} index={1}>
+      <TabPanel id={test.id} currentTabIndex={currentTabIndex} index={1}>
         {updateRequest && (
           <RequestsList
             requests={test.result?.requests || []}
@@ -104,21 +110,21 @@ const TestRunDetail: FC<TestRunDetailProps> = ({ test, currentTabIndex, tabs, up
           />
         )}
       </TabPanel>
-      <TabPanel id={test.id} currentTabIndex={tabIndex} index={2}>
+      <TabPanel id={test.id} currentTabIndex={currentTabIndex} index={2}>
         <InputOutputsList
           inputOutputs={test.result?.inputs || []}
           noValuesMessage="No Inputs"
           headerName="Input"
         />
       </TabPanel>
-      <TabPanel id={test.id} currentTabIndex={tabIndex} index={3}>
+      <TabPanel id={test.id} currentTabIndex={currentTabIndex} index={3}>
         <InputOutputsList
           inputOutputs={test.result?.outputs || []}
           noValuesMessage="No Outputs"
           headerName="Output"
         />
       </TabPanel>
-      <TabPanel id={test.id} currentTabIndex={tabIndex} index={4}>
+      <TabPanel id={test.id} currentTabIndex={currentTabIndex} index={4}>
         {shouldShowDescription(test, testDescription) ? (
           testDescription
         ) : (

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestRunDetail.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestRunDetail.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, useEffect, useMemo } from 'react';
 import { Box, Card, Divider, Tab, Tabs, Tooltip, Typography } from '@mui/material';
 import { Message, Request, Test, TestInput, TestOutput } from '~/models/testSuiteModels';
 import { shouldShowDescription } from '~/components/TestSuite/TestSuiteUtilities';
@@ -26,6 +26,10 @@ export interface TabProps {
 const TestRunDetail: FC<TestRunDetailProps> = ({ test, currentTabIndex, tabs, updateRequest }) => {
   const styles = useStyles();
   const [tabIndex, setTabIndex] = React.useState(currentTabIndex);
+
+  useEffect(() => {
+    setTabIndex(currentTabIndex);
+  }, [currentTabIndex]);
 
   const testDescription: JSX.Element = (
     <Box mx={2}>

--- a/client/src/components/TestSuite/TestSuiteTree/TestSuiteTree.tsx
+++ b/client/src/components/TestSuite/TestSuiteTree/TestSuiteTree.tsx
@@ -109,6 +109,7 @@ const TestSuiteTreeComponent: FC<TestSuiteTreeProps> = ({
             </Typography>
           }
           icon={<NotificationsIcon />}
+          className={styles.treeItemTopBorder}
           // eslint-disable-next-line max-len
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
           ContentProps={{ testId: `${testSuite.id}/config` } as any}
@@ -118,6 +119,16 @@ const TestSuiteTreeComponent: FC<TestSuiteTreeProps> = ({
 
     return (
       <Box className={styles.testSuiteTreePanel}>
+        {presets && presets.length > 0 && testSessionId && getSessionData && (
+          <Box m={2}>
+            <PresetsSelector
+              presets={presets}
+              testSessionId={testSessionId}
+              getSessionData={getSessionData}
+            />
+          </Box>
+        )}
+        <Divider />
         <TreeView
           aria-label="navigation-panel"
           defaultCollapseIcon={<ExpandMoreIcon aria-hidden={false} tabIndex={0} />}
@@ -127,43 +138,28 @@ const TestSuiteTreeComponent: FC<TestSuiteTreeProps> = ({
           selected={selectedNode}
           className={styles.testSuiteTree}
         >
-          {presets && presets.length > 0 && testSessionId && getSessionData && (
-            <Box m={2}>
-              <PresetsSelector
-                presets={presets}
-                testSessionId={testSessionId}
-                getSessionData={getSessionData}
-              />
-            </Box>
-          )}
-          <Divider />
           <CustomTreeItem
             classes={{ content: styles.treeRoot }}
             nodeId={testSuite.id}
             label={<TreeItemLabel runnable={testSuite} />}
             icon={<ListAltIcon />}
+            className={styles.treeItemBottomBorder}
             // eslint-disable-next-line max-len
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
             ContentProps={{ testId: testSuite.id } as any}
           />
-          <Divider />
           {testGroupList}
-          <Divider />
           <CustomTreeItem
             nodeId={`${testSuite.id}/report`}
             label={<TreeItemLabel title={'Report'} />}
             icon={<FlagIcon />}
+            className={`${styles.treeItemTopBorder} ${styles.treeItemBottomBorder}`}
             // eslint-disable-next-line max-len
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
             ContentProps={{ testId: `${testSuite.id}/report` } as any}
           />
-          <Divider />
           <Box display="flex" alignItems="flex-end" flexGrow={1} mt={8}>
-            {/* Box is necessary to show dividers */}
-            <Box width="100%">
-              <Divider />
-              {renderConfigMessagesTreeItem()}
-            </Box>
+            <Box width="100%">{renderConfigMessagesTreeItem()}</Box>
           </Box>
         </TreeView>
       </Box>

--- a/client/src/components/TestSuite/TestSuiteTree/styles.tsx
+++ b/client/src/components/TestSuite/TestSuiteTree/styles.tsx
@@ -29,7 +29,7 @@ export default makeStyles((theme: Theme) => ({
     flexDirection: 'column',
     width: '300px',
     flexGrow: 1,
-    overflowY: 'hidden',
+    overflow: 'hidden',
   },
   testSuiteTree: {
     height: '100%',

--- a/client/src/components/TestSuite/TestSuiteTree/styles.tsx
+++ b/client/src/components/TestSuite/TestSuiteTree/styles.tsx
@@ -25,14 +25,17 @@ export default makeStyles((theme: Theme) => ({
     color: theme.palette.common.grayDarkest,
   },
   testSuiteTreePanel: {
+    display: 'flex',
+    flexDirection: 'column',
     width: '300px',
     flexGrow: 1,
-    overflowX: 'hidden',
+    overflowY: 'hidden',
   },
   testSuiteTree: {
     height: '100%',
     display: 'flex',
     flexDirection: 'column',
+    overflowY: 'auto',
   },
   treeRoot: {
     '& $labelText': {
@@ -40,5 +43,11 @@ export default makeStyles((theme: Theme) => ({
       fontWeight: 'bold',
     },
     padding: '8px 20px !important',
+  },
+  treeItemTopBorder: {
+    borderTop: `1px solid ${theme.palette.common.grayLighter}`,
+  },
+  treeItemBottomBorder: {
+    borderBottom: `1px solid ${theme.palette.common.grayLighter}`,
   },
 }));

--- a/client/src/components/TestSuite/styles.tsx
+++ b/client/src/components/TestSuite/styles.tsx
@@ -29,6 +29,7 @@ export default makeStyles((theme: Theme) => ({
   drawer: {
     display: 'flex',
     flexGrow: 1,
+    overflow: 'hidden',
     '@media print': {
       display: 'none',
     },


### PR DESCRIPTION
# Summary

Clicking on the request or messages icon will now also change the selected test list item tab. Also adds an a11y fix for tree view.

# Testing Guidance
Open a test list item with requests and messages, clicking the icons should change the open tab.
