### PR TITLE
FI-1927 inferno start --watch command

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -122,6 +122,8 @@ The advantages of using a local ruby installation are
 1. Run `gem install inferno_core` to install inferno.
 1. Run `gem install foreman` to install foreman, which will be used to run the
    Inferno web and worker processes.
+1. Run `gem install rerun` to install rerun, which will be used to enable
+   `watch` functionality to reload Inferno when a test has been updated.
 1. Run `bundle exec inferno migrate` to set up the database.
 
 #### Running Inferno
@@ -129,8 +131,9 @@ The advantages of using a local ruby installation are
    default, these include nginx, redis, the FHIR validator service, and the FHIR
    validator UI. Background services can be added/removed/edited in
    `docker-compose.background.yml`.
-1. Run `inferno start` to start Inferno. You will need to stop and re-run this
-   whenever you make changes to your tests.
+1. Run `inferno start --watch` to start Inferno and to reload any time a file
+   changes.  Remove the `watch` flag if you would prefer to manually restart
+   Inferno.
 1. Navigate to `http://localhost:4567` to access Inferno, where your test suite
    will be available. To access the FHIR resource validator, navigate to
    `http://localhost/validator`.

--- a/lib/inferno/apps/cli/main.rb
+++ b/lib/inferno/apps/cli/main.rb
@@ -33,7 +33,7 @@ module Inferno
             puts "You must install 'rerun' with 'gem install rerun' to restart on file changes."
           end
 
-          command = "rerun \"#{command}\""
+          command = "rerun \"#{command}\" --background"
         end
 
         system command

--- a/lib/inferno/apps/cli/main.rb
+++ b/lib/inferno/apps/cli/main.rb
@@ -26,6 +26,18 @@ module Inferno
         system 'foreman start --env=/dev/null'
       end
 
+      desc 'watch', 'Start Inferno and watch for file changes'
+      def watch
+        if `gem list -i foreman`.chomp == 'false'
+          puts "You must install foreman with 'gem install foreman' prior to running inferno."
+        end
+        if `gem list -i rerun`.chomp == 'false'
+          puts "You must install rerun with 'gem install rerun' prior to running inferno while watching for file changes."
+        end
+
+        system 'rerun "foreman start --env=/dev/null"'
+      end
+
       desc 'suites', 'List available test suites'
       def suites
         Suites.new.run

--- a/lib/inferno/apps/cli/main.rb
+++ b/lib/inferno/apps/cli/main.rb
@@ -18,24 +18,26 @@ module Inferno
       end
 
       desc 'start', 'Start Inferno'
+      option :watch,
+              default: false,
+              type: :boolean,
+              desc: 'Automatically restart Inferno when a file is changed.'
       def start
+
+        command = 'foreman start --env=/dev/null'
         if `gem list -i foreman`.chomp == 'false'
-          puts "You must install foreman with 'gem install foreman' prior to running inferno."
+          puts "You must install foreman with 'gem install foreman' prior to running Inferno."
         end
 
-        system 'foreman start --env=/dev/null'
-      end
+        if options[:watch]
+          if `gem list -i rerun`.chomp == 'false'
+            puts "You must install 'rerun' with 'gem install rerun' to restart on file changes."
+          end
 
-      desc 'watch', 'Start Inferno and watch for file changes'
-      def watch
-        if `gem list -i foreman`.chomp == 'false'
-          puts "You must install foreman with 'gem install foreman' prior to running inferno."
-        end
-        if `gem list -i rerun`.chomp == 'false'
-          puts "You must install rerun with 'gem install rerun' prior to running inferno while watching for file changes."
+          command = "rerun \"#{command}\""
         end
 
-        system 'rerun "foreman start --env=/dev/null"'
+        system command
       end
 
       desc 'suites', 'List available test suites'

--- a/lib/inferno/apps/cli/main.rb
+++ b/lib/inferno/apps/cli/main.rb
@@ -19,11 +19,10 @@ module Inferno
 
       desc 'start', 'Start Inferno'
       option :watch,
-              default: false,
-              type: :boolean,
-              desc: 'Automatically restart Inferno when a file is changed.'
+             default: false,
+             type: :boolean,
+             desc: 'Automatically restart Inferno when a file is changed.'
       def start
-
         command = 'foreman start --env=/dev/null'
         if `gem list -i foreman`.chomp == 'false'
           puts "You must install foreman with 'gem install foreman' prior to running Inferno."


### PR DESCRIPTION
# Summary
Adds a `--watch` flag to `inferno start` that uses [rerun](https://github.com/alexch/rerun) to wrap the existing command that runs Inferno.  This is a pretty simple solution compared to a much more complex 'hot-reload' type functionality.  However, it saves test writers the need to do several commands to stop and restart every time a file changes and has the exact same result as that method of reloading Inferno.

I have it reload on the default `rerun` watch targets, which is almost all file types that we deal with, but not quite everything.  It won't restart when the Gemfile is changed, for example.  It also doesn't affect the `services`... it might make sense to add `--watch` to services when the IG `package.tgz` is updated, but that solution may look a little different than this and probably warrants a separate ticket.

I used the same pattern as we did for foreman, where you need to install the gem separately, and the CLI will alert you if you haven't installed it but try to use the `watch` command.  I don't love this solution, but since we are already doing it for foreman I don't see any harm in being consistent with the pattern.

I updated the documentation to tell the user to install `rerun` and add the `--watch` flag in the quickstart section.  I didn't see any other references to `inferno start` in our docs.

Update: I added the `--background` flag to `rerun` to avoid a strange `tty` message when exiting.  I think it is because we are wrapping this in a system call.

# Testing Guidance

You can test in this repo simply by running `bin/inferno start --watch`, and you can see the server restarting.  For a more realistic test, in a separate test kit like g10, you can run something like `../inferno-core/bin/inferno start --watch` (assuming that is the path to this copy of inferno-core).    If you change a test, it should automatically fully restart Inferno after a second or two max.

It should be tolerant to bad changes -- eg. invalid Ruby... the service won't start and will give a stack trace, but by fixing the error and resaving the file it should automatically restart again.

It shouldn't consume a lot of resources if you do this for awhile.  I haven't really checked this but didn't notice anything unusual.

I haven't tried this on Windows.  I believe it should work fine on WSL2, but there is always the chance that something funny is happening with file change watches/signals in that kind of environment.  If it doesn't work properly in Windows, I don't think we should block this though regardless... we should be sure to try it out later.
