### PR TITLE
FI-1935: Fix test run results route

### DIFF
--- a/lib/inferno/apps/web/controllers/test_runs/results/index.rb
+++ b/lib/inferno/apps/web/controllers/test_runs/results/index.rb
@@ -7,7 +7,7 @@ module Inferno
             include Import[test_runs_repo: 'inferno.repositories.test_runs']
 
             def handle(req, res)
-              results = test_runs_repo.results_for_test_run(req.params[:test_run_id])
+              results = test_runs_repo.results_for_test_run(req.params[:id])
               res.body = serialize(results)
             end
           end

--- a/lib/inferno/apps/web/router.rb
+++ b/lib/inferno/apps/web/router.rb
@@ -16,7 +16,7 @@ module Inferno
           get '/:id', to: Inferno::Web::Controllers::TestRuns::Show, as: :show
           delete '/:id', to: Inferno::Web::Controllers::TestRuns::Destroy, as: :destroy
 
-          get '/results', to: Inferno::Web::Controllers::TestRuns::Results::Index, as: :results
+          get ':id/results', to: Inferno::Web::Controllers::TestRuns::Results::Index, as: :results
         end
 
         scope 'test_sessions' do

--- a/spec/requests/results_spec.rb
+++ b/spec/requests/results_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe '/(test_sessions/test_runs)/:id/results' do
 
   describe '/test_runs/:test_run_id/results' do
     it 'renders the results json for a test_run' do
-      get router.path(:api_test_runs_results, test_run_id: test_run.id)
+      get router.path(:api_test_runs_results, id: test_run.id)
 
       expect(last_response.status).to eq(200)
       expect(parsed_body.length).to eq(1)
@@ -45,7 +45,7 @@ RSpec.describe '/(test_sessions/test_runs)/:id/results' do
     end
 
     it 'includes the indices for request summaries' do
-      get router.path(:api_test_runs_results, test_run_id: test_run.id)
+      get router.path(:api_test_runs_results, id: test_run.id)
 
       expect(last_response.status).to eq(200)
       expect(parsed_body.length).to eq(1)
@@ -57,7 +57,7 @@ RSpec.describe '/(test_sessions/test_runs)/:id/results' do
     end
 
     it 'sorts the request summaries' do
-      get router.path(:api_test_runs_results, test_run_id: test_run.id)
+      get router.path(:api_test_runs_results, id: test_run.id)
 
       expect(last_response.status).to eq(200)
       expect(parsed_body.length).to eq(1)

--- a/spec/requests/test_runs_spec.rb
+++ b/spec/requests/test_runs_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe '/test_runs' do
     let(:messages) { result.messages }
 
     it 'renders the results json' do
-      get router.path(:api_test_runs_results, test_run_id: result.test_run_id)
+      get router.path(:api_test_runs_results, id: result.test_run_id)
 
       expect(last_response.status).to eq(200)
       expect(parsed_body).to all(include('id', 'result', 'test_run_id', 'test_session_id', 'messages'))


### PR DESCRIPTION
# Summary
The `/test_runs/:test_run_id/results` route was broken when the router was updated as part of the ruby 3 update. See #333.

# Testing Guidance
After running some tests, the above query should once again work.