### PR TITLE
FI-1924: short ID links

### DIFF
--- a/client/src/components/TestSuite/TestSession.tsx
+++ b/client/src/components/TestSuite/TestSession.tsx
@@ -121,6 +121,21 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
   const { test_suite, id } = testSession;
 
   const runnableMap = React.useMemo(() => mapRunnableToId(test_suite), [test_suite]);
+  console.log(useLocation());
+  const runnableToShortId = () => {
+    const runnableArray = Array.from(runnableMap);
+    return runnableArray.filter(([key, value]) => {
+      (isTestSuite(value) || isTestGroup(value)) && value.short_id && value.short_id === '1.1';
+    });
+    // return Object.values(runnableObject);
+
+    // .filter((runnable) => !!runnable.short_id)
+    // .map((runnable) => {
+    //   Object.values(runnable).map((r) => r.short_id);
+    // });
+  };
+  console.log(runnableToShortId());
+
   const [suiteName, view] = useLocation().hash.replace('#', '').split('/');
   const selectedRunnable = runnableMap.get(suiteName) ? suiteName : testSession.test_suite.id;
 

--- a/client/src/components/TestSuite/TestSuiteUtilities.tsx
+++ b/client/src/components/TestSuite/TestSuiteUtilities.tsx
@@ -1,4 +1,42 @@
-import { Runnable } from '~/models/testSuiteModels';
+import { Result, Runnable, Test, TestGroup, TestSuite } from '~/models/testSuiteModels';
+
+const mapRunnableRecursive = (testGroup: TestGroup, map: Map<string, Runnable>) => {
+  map.set(testGroup.id, testGroup);
+  testGroup.test_groups.forEach((subGroup: TestGroup) => {
+    mapRunnableRecursive(subGroup, map);
+  });
+  testGroup.tests.forEach((test: Test) => {
+    map.set(test.id, test);
+  });
+};
+
+export const mapRunnableToId = (testSuite: TestSuite): Map<string, Runnable> => {
+  const map = new Map<string, Runnable>();
+  map.set(testSuite.id, testSuite);
+  testSuite?.test_groups?.forEach((testGroup: TestGroup) => {
+    mapRunnableRecursive(testGroup, map);
+  });
+  return map;
+};
+
+export const resultsToMap = (results: Result[], map?: Map<string, Result>): Map<string, Result> => {
+  let resultsMap: Map<string, Result>;
+  if (map === undefined) {
+    resultsMap = new Map<string, Result>();
+  } else {
+    resultsMap = map;
+  }
+  results.forEach((result: Result) => {
+    if (result.test_suite_id) {
+      resultsMap.set(result.test_suite_id, result);
+    } else if (result.test_group_id) {
+      resultsMap.set(result.test_group_id, result);
+    } else if (result.test_id) {
+      resultsMap.set(result.test_id, result);
+    }
+  });
+  return new Map(resultsMap);
+};
 
 export const shouldShowDescription = (
   runnable: Runnable,

--- a/client/src/components/TestSuite/TestSuiteUtilities.tsx
+++ b/client/src/components/TestSuite/TestSuiteUtilities.tsx
@@ -1,4 +1,12 @@
-import { Result, Runnable, Test, TestGroup, TestSuite } from '~/models/testSuiteModels';
+import {
+  isTestGroup,
+  isTestSuite,
+  Result,
+  Runnable,
+  Test,
+  TestGroup,
+  TestSuite,
+} from '~/models/testSuiteModels';
 
 const mapRunnableRecursive = (testGroup: TestGroup, map: Map<string, Runnable>) => {
   map.set(testGroup.id, testGroup);
@@ -36,6 +44,20 @@ export const resultsToMap = (results: Result[], map?: Map<string, Result>): Map<
     }
   });
   return new Map(resultsMap);
+};
+
+// Recursive function to set the `is_running` field for all children of a runnable
+export const setIsRunning = (runnable: Runnable, value: boolean) => {
+  if (runnable) {
+    runnable.is_running = value;
+    if (isTestGroup(runnable)) {
+      runnable.tests?.forEach((test: Test) => (test.is_running = value));
+      runnable.test_groups?.forEach((testGroup: TestGroup) => setIsRunning(testGroup, value));
+    }
+    if (isTestSuite(runnable)) {
+      runnable.test_groups?.forEach((testGroup: TestGroup) => setIsRunning(testGroup, value));
+    }
+  }
 };
 
 export const shouldShowDescription = (

--- a/client/src/models/testSuiteModels.ts
+++ b/client/src/models/testSuiteModels.ts
@@ -1,14 +1,31 @@
+export type FooterLink = {
+  label: string;
+  url: string;
+};
+
+export interface InputOption {
+  label: string;
+  value: string;
+}
+
 export type Message = {
   message: string;
   type: 'error' | 'warning' | 'info';
 };
 
-export type ViewType = 'run' | 'report' | 'config';
+export interface OAuthCredentials {
+  access_token: string;
+  refresh_token?: string;
+  expires_in?: string;
+  client_id?: string;
+  client_secret?: string;
+  token_url?: string;
+}
 
-export type RequestHeader = {
-  name: string;
-  value: string;
-};
+export interface PresetSummary {
+  id: string;
+  title: string;
+}
 
 export type Request = {
   direction: string;
@@ -23,6 +40,11 @@ export type Request = {
   request_body?: string | null;
   response_body?: string | null;
   result_id: string;
+};
+
+export type RequestHeader = {
+  name: string;
+  value: string;
 };
 
 export interface Result {
@@ -43,6 +65,20 @@ export interface Result {
   optional?: boolean;
 }
 
+export interface SuiteOption {
+  id: string;
+  title?: string;
+  description?: string;
+  list_options?: SuiteOptionChoice[];
+  value?: string;
+}
+
+export interface SuiteOptionChoice {
+  label: string;
+  id: string;
+  value: string;
+}
+
 export interface TestInput {
   name: string;
   title?: string;
@@ -57,14 +93,39 @@ export interface TestInput {
   };
 }
 
-export interface InputOption {
-  label: string;
-  value: string;
-}
-
 export interface TestOutput {
   name: string;
   value: string | undefined;
+}
+
+export interface TestRun {
+  id: string;
+  inputs?: TestInput[] | null;
+  results?: Result[] | null;
+  status?: 'queued' | 'running' | 'waiting' | 'cancelling' | 'done';
+  test_count?: number;
+  test_group_id?: string;
+  test_suite_id?: string;
+  test_id?: string;
+}
+
+export interface TestSession {
+  id: string;
+  test_suite: TestSuite;
+  test_suite_id: string;
+  suite_options?: SuiteOption[];
+}
+
+export type ViewType = 'run' | 'report' | 'config';
+
+// ==========================================
+// RUNNABLES
+// ==========================================
+
+export enum RunnableType {
+  TestSuite,
+  TestGroup,
+  Test,
 }
 
 export type Runnable = {
@@ -110,68 +171,15 @@ export type TestSuite = Runnable & {
   suite_summary?: string;
 };
 
-export interface TestSession {
-  id: string;
-  test_suite: TestSuite;
-  test_suite_id: string;
-  suite_options?: SuiteOption[];
-}
-
-export enum RunnableType {
-  TestSuite,
-  TestGroup,
-  Test,
-}
-
-export interface TestRun {
-  id: string;
-  inputs?: TestInput[] | null;
-  results?: Result[] | null;
-  status?: 'queued' | 'running' | 'waiting' | 'cancelling' | 'done';
-  test_count?: number;
-  test_group_id?: string;
-  test_suite_id?: string;
-  test_id?: string;
-}
-
-export interface OAuthCredentials {
-  access_token: string;
-  refresh_token?: string;
-  expires_in?: string;
-  client_id?: string;
-  client_secret?: string;
-  token_url?: string;
-}
-
-export interface PresetSummary {
-  id: string;
-  title: string;
-}
-
-export interface SuiteOption {
-  id: string;
-  title?: string;
-  description?: string;
-  list_options?: SuiteOptionChoice[];
-  value?: string;
-}
-
-export interface SuiteOptionChoice {
-  label: string;
-  id: string;
-  value: string;
-}
-
-export type FooterLink = {
-  label: string;
-  url: string;
-};
-
 // Custom type guards to determine type of Runnable
-export const isTestSuite = (object: Runnable): object is TestSuite => {
-  return 'test_groups' in object && !('tests' in object);
+export const isTest = (object: Runnable): object is Test => {
+  return !('test_groups' in object);
 };
 
 export const isTestGroup = (object: Runnable): object is TestGroup => {
   return 'test_groups' in object && 'tests' in object;
+};
+
+export const isTestSuite = (object: Runnable): object is TestSuite => {
+  return 'test_groups' in object && !('tests' in object);
 };


### PR DESCRIPTION
# Summary

Allows link aliasing to short IDs, so for example:

localhost:4567/inferno/demo/<id>#demo-Group01-Group01

and 

localhost:4567/inferno/demo/<id>#1.1

access the same test group.

Also refactors some files to alphabetize/move methods to util files.

# Testing Guidance
Test the behavior above; if a short ID is not present the URL should direct to the base suite page (e.g. localhost:4567/inferno/demo/<id>) but the URL will still show the short ID.
