### PR TITLE
FI-1939: Handle unknown inputs in preset

### DIFF
--- a/lib/inferno/utils/preset_processor.rb
+++ b/lib/inferno/utils/preset_processor.rb
@@ -19,11 +19,17 @@ module Inferno
       def processed_inputs
         preset.inputs
           .map { |input| input_for_options(input) }
+          .compact
       end
 
       private
 
       def input_for_options(input)
+        if suite_inputs[input[:name].to_sym].nil?
+          Inferno::Application['logger'].warn("Unknown input #{input[:name]} in preset #{preset.id}")
+          return
+        end
+
         {
           name: input[:name],
           value: value(input),

--- a/spec/inferno/utils/preset_processor_spec.rb
+++ b/spec/inferno/utils/preset_processor_spec.rb
@@ -22,6 +22,17 @@ RSpec.describe Inferno::Utils::PresetProcessor do
       end
     end
 
+    context 'with an unknown input' do
+      it 'skips the unknown input' do
+        bad_input = { name: 'bad_input', value: 'bad_value' }
+        base_preset.inputs << bad_input
+
+        processed_inputs = described_class.new(base_preset, session).processed_inputs
+
+        expect(processed_inputs.length).to eq(base_preset.inputs.length - 1)
+      end
+    end
+
     context 'with options' do
       let(:preset_with_options) do
         base_preset.tap do |preset|


### PR DESCRIPTION
# Summary
This branch prevents an exception when a preset contains an unknown input (see #337). A warning will be displayed for unknown inputs:
```
WARN -- : Unknown input patient_idxx in preset demo_preset
```

# Testing Guidance
In addition to the unit test, you can add a bad input to a preset and see the warning in the logs.