### PR TITLE
FI-1899: Fix validation error message when no profile is given

### DIFF
--- a/lib/inferno/dsl/assertions.rb
+++ b/lib/inferno/dsl/assertions.rb
@@ -57,8 +57,10 @@ module Inferno
       end
 
       # @private
-      def invalid_resource_message(profile_url)
-        "Resource does not conform to the profile: #{profile_url}"
+      def invalid_resource_message(resource, profile_url)
+        return "Resource does not conform to the profile: #{profile_url}" if profile_url.present?
+
+        "Resource does not conform to the base #{resource&.resourceType} profile."
       end
 
       # Validate a FHIR resource
@@ -70,7 +72,7 @@ module Inferno
       # @return [void]
       def assert_valid_resource(resource: self.resource, profile_url: nil, validator: :default)
         assert resource_is_valid?(resource:, profile_url:, validator:),
-               invalid_resource_message(profile_url)
+               invalid_resource_message(resource, profile_url)
       end
 
       # Validate each entry of a Bundle

--- a/spec/inferno/dsl/assertions_spec.rb
+++ b/spec/inferno/dsl/assertions_spec.rb
@@ -172,6 +172,17 @@ RSpec.describe Inferno::DSL::Assertions do
 
         expect(validation_request).to have_been_made.once
       end
+
+      it 'uses an appropriate error message' do
+        stub_request(:post, validation_url)
+          .with(query: { profile: FHIR::Definitions.resource_definition('Patient').url })
+          .with(body: patient_resource.source_contents)
+          .to_return(status: 200, body: error_outcome.to_json)
+
+        expect { klass.assert_valid_resource(resource: patient_resource) }.to(
+          raise_error(assertion_exception, 'Resource does not conform to the base Patient profile.')
+        )
+      end
     end
 
     context 'when a profile_url is provided' do
@@ -196,7 +207,7 @@ RSpec.describe Inferno::DSL::Assertions do
           .to_return(status: 200, body: error_outcome.to_json)
 
         expect { klass.assert_valid_resource(resource: patient_resource, profile_url:) }.to(
-          raise_error(assertion_exception, klass.invalid_resource_message(profile_url))
+          raise_error(assertion_exception, klass.invalid_resource_message(patient_resource, profile_url))
         )
       end
 
@@ -207,7 +218,7 @@ RSpec.describe Inferno::DSL::Assertions do
           .to_return(status: 200, body: error_outcome.to_json)
 
         expect { klass.assert_valid_resource(resource: patient_resource, profile_url:) }.to(
-          raise_error(assertion_exception, klass.invalid_resource_message(profile_url))
+          raise_error(assertion_exception, klass.invalid_resource_message(patient_resource, profile_url))
         )
 
         error_message = klass.messages.find { |message| message[:type] == 'error' }


### PR DESCRIPTION
# Summary
Use a different error message when no profile is given to avoid the error message looking like: `Resource does not conform to the profile:`