### PR TITLE
FI-1975: fix flex model

### DIFF
--- a/client/src/components/LandingPage/LandingPage.tsx
+++ b/client/src/components/LandingPage/LandingPage.tsx
@@ -91,7 +91,6 @@ const LandingPage: FC<LandingPageProps> = ({ testSuites }) => {
         justifyContent="center"
         alignItems="center"
         overflow="initial"
-        height="100%"
         minHeight="400px"
         pb={windowIsSmall ? 0 : 10}
       >

--- a/client/src/components/LandingPage/LandingPage.tsx
+++ b/client/src/components/LandingPage/LandingPage.tsx
@@ -90,7 +90,7 @@ const LandingPage: FC<LandingPageProps> = ({ testSuites }) => {
         flexDirection="column"
         justifyContent="center"
         alignItems="center"
-        overflow="auto"
+        overflow="initial"
         height="100%"
         minHeight="400px"
         pb={windowIsSmall ? 0 : 10}
@@ -134,7 +134,7 @@ const LandingPage: FC<LandingPageProps> = ({ testSuites }) => {
           >
             Test Suites
           </Typography>
-          <Box overflow="auto">
+          <Box>
             <List>
               {testSuites ? (
                 testSuites

--- a/client/src/components/LandingPage/styles.tsx
+++ b/client/src/components/LandingPage/styles.tsx
@@ -20,6 +20,5 @@ export default makeStyles()((theme: Theme) => ({
     margin: '20px',
     padding: '16px',
     borderRadius: '16px',
-    overflow: 'auto',
   },
 }));

--- a/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
+++ b/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
@@ -174,6 +174,27 @@ const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuite }) => {
         width="100%"
         sx={windowIsSmall ? { overflow: 'auto' } : { mt: 4, pb: 8, overflow: 'hidden' }}
       >
+        {/* Description */}
+        <Box
+          maxWidth={descriptionWidth}
+          maxHeight={windowIsSmall ? 'none' : '100%'}
+          overflow="auto"
+          my={3}
+        >
+          <Typography
+            variant="h6"
+            component="h2"
+            pr={2}
+            pl={5}
+            sx={{
+              wordBreak: 'break-word',
+            }}
+          >
+            <ReactMarkdown>
+              {testSuite?.suite_summary || testSuite?.description || ''}
+            </ReactMarkdown>
+          </Typography>
+        </Box>
         {/* Selection panel */}
         <Box display="flex" justifyContent="center" maxHeight="100%" ref={selectionPanel} p={3}>
           <Paper
@@ -226,27 +247,6 @@ const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuite }) => {
               </Button>
             </Box>
           </Paper>
-        </Box>
-        {/* Description */}
-        <Box
-          maxWidth={descriptionWidth}
-          maxHeight={windowIsSmall ? 'none' : '100%'}
-          overflow="auto"
-          my={3}
-        >
-          <Typography
-            variant="h6"
-            component="h2"
-            pr={2}
-            pl={5}
-            sx={{
-              wordBreak: 'break-word',
-            }}
-          >
-            <ReactMarkdown>
-              {testSuite?.suite_summary || testSuite?.description || ''}
-            </ReactMarkdown>
-          </Typography>
         </Box>
       </Box>
     </Box>

--- a/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
+++ b/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
@@ -174,36 +174,8 @@ const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuite }) => {
         width="100%"
         sx={windowIsSmall ? { overflow: 'auto' } : { mt: 4, pb: 8, overflow: 'hidden' }}
       >
-        {/* Description */}
-        <Box
-          maxWidth={descriptionWidth}
-          maxHeight={windowIsSmall ? 'none' : '100%'}
-          overflow="auto"
-          my={3}
-        >
-          <Typography
-            variant="h6"
-            component="h2"
-            pr={2}
-            pl={5}
-            sx={{
-              wordBreak: 'break-word',
-            }}
-          >
-            <ReactMarkdown>
-              {testSuite?.suite_summary || testSuite?.description || ''}
-            </ReactMarkdown>
-          </Typography>
-        </Box>
         {/* Selection panel */}
-        <Box
-          display="flex"
-          justifyContent="center"
-          maxHeight="100%"
-          overflow="auto"
-          ref={selectionPanel}
-          p={3}
-        >
+        <Box display="flex" justifyContent="center" maxHeight="100%" ref={selectionPanel} p={3}>
           <Paper
             elevation={4}
             className={classes.optionsList}
@@ -230,7 +202,7 @@ const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuite }) => {
               {testSuites.length > 1 && <Box minWidth="45px" />}
             </Box>
 
-            <Box overflow="auto" px={4} pt={2}>
+            <Box px={4} pt={2}>
               {testSuite?.suite_options ? (
                 testSuite?.suite_options.map((suiteOption: SuiteOption, i) =>
                   renderOption(suiteOption, i)
@@ -254,6 +226,27 @@ const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuite }) => {
               </Button>
             </Box>
           </Paper>
+        </Box>
+        {/* Description */}
+        <Box
+          maxWidth={descriptionWidth}
+          maxHeight={windowIsSmall ? 'none' : '100%'}
+          overflow="auto"
+          my={3}
+        >
+          <Typography
+            variant="h6"
+            component="h2"
+            pr={2}
+            pl={5}
+            sx={{
+              wordBreak: 'break-word',
+            }}
+          >
+            <ReactMarkdown>
+              {testSuite?.suite_summary || testSuite?.description || ''}
+            </ReactMarkdown>
+          </Typography>
         </Box>
       </Box>
     </Box>

--- a/client/src/components/SuiteOptionsPage/styles.tsx
+++ b/client/src/components/SuiteOptionsPage/styles.tsx
@@ -16,6 +16,5 @@ export default makeStyles()((theme: Theme) => ({
     flexDirection: 'column',
     padding: '16px 0',
     borderRadius: '16px',
-    overflow: 'auto',
   },
 }));


### PR DESCRIPTION
# Summary

Removes scrolling overflow in favor of automatic sizing.
<img width="688" alt="Screenshot 2023-05-05 at 10 56 24 AM" src="https://user-images.githubusercontent.com/11209247/236493764-6795ee80-44fc-42c9-818a-d764391b5f0b.png">

# Testing Guidance

Shrink browser height, selection card should not scroll.