### PR TITLE
FI-1978: Fix headers call syntax in yard docs

### DIFF
--- a/lib/inferno/dsl/fhir_client.rb
+++ b/lib/inferno/dsl/fhir_client.rb
@@ -16,7 +16,7 @@ module Inferno
     #     # create a named client for a group
     #     fhir_client :with_custom_header do
     #       url 'https://example.com/fhir'
-    #       headers { 'X-my-custom-header': 'ABC123' }
+    #       headers 'X-my-custom-header': 'ABC123'
     #     end
     #
     #     test :some_test do


### PR DESCRIPTION
This change fixes this header call syntax in the yard docs. It was wrong because the curly braces are interpreted as a block rather than a Hash.