### PR TITLE
FI-2001: Make API link params optional

### DIFF
--- a/docs/api-docs/index.html
+++ b/docs/api-docs/index.html
@@ -64,7 +64,7 @@
 
       const queryString = window.location.search;
       const urlParams = new URLSearchParams(queryString);
-      const scheme = urlParams.get('scheme').replaceAll(':', '');
+      const scheme = urlParams.get('scheme')?.replaceAll(':', '');
       const host = urlParams.get('host');
 
       window.onload = () => {


### PR DESCRIPTION
# Summary

Fixes a bug where accessing the API without any query params would prevent the page from rendering

# Testing Guidance

Spin up an API docs instance and navigate to:
http://127.0.0.1:4000/inferno-core/api-docs/

Page should render where it didn't before.