### PR TITLE
FI-1854: Log error and warning level config messages

### DIFF
--- a/lib/inferno/entities/test_suite.rb
+++ b/lib/inferno/entities/test_suite.rb
@@ -97,7 +97,16 @@ module Inferno
         #   `error`.
         # @return [void]
         def check_configuration(&block)
-          @check_configuration_block = block
+          @check_configuration_block = lambda do
+            block.call&.each do |configuration_message|
+              case configuration_message[:type]
+              when 'warning'
+                Application[:logger].warn(configuration_message[:message])
+              when 'error'
+                Application[:logger].error(configuration_message[:message])
+              end
+            end
+          end
         end
 
         # @private


### PR DESCRIPTION
# Summary
Log error and warning level config messages whenever configuration is checked.

# Testing Guidance
Use a test kit which does configuration checks, and deliberately set your environment up to fail at least one of those checks (e.g. run the g(10) test kit without the validator running). Check the logs and you should see the same errors and warnings that are shown in the UI.