### PR TITLE
FI-2040: Fix JSON parse error for OAuth inputs

### DIFF
--- a/client/src/components/Footer/Footer.tsx
+++ b/client/src/components/Footer/Footer.tsx
@@ -152,7 +152,13 @@ const Footer: FC<FooterProps> = ({ version, linkList }) => {
         maxHeight: `${footerHeight}px`,
       }}
     >
-      <Box display="flex" flexDirection="row" justifyContent="space-between" overflow="auto">
+      <Box
+        display="flex"
+        flexDirection="row"
+        justifyContent="space-between"
+        overflow="auto"
+        width="100%"
+      >
         <Box display="flex" alignItems="center" px={2}>
           <Link
             href="https://inferno-framework.github.io/inferno-core"

--- a/client/src/components/InputsModal/InputOAuthCredentials.tsx
+++ b/client/src/components/InputsModal/InputOAuthCredentials.tsx
@@ -35,19 +35,23 @@ const InputOAuthCredentials: FC<InputOAuthCredentialsProps> = ({
   setInputsMap,
 }) => {
   const { classes } = useStyles();
-  const template = {
-    access_token: '',
-    refresh_token: '',
-    expires_in: '',
-    client_id: '',
-    client_secret: '',
-    token_url: '',
-  };
+
+  // Convert OAuth string to Object
+  // OAuth should be an Object while in this component but should be converted to a string
+  // before being updated in the inputs map
   const oAuthCredentials = (
     inputsMap.get(requirement.name)
       ? JSON.parse(inputsMap.get(requirement.name) as string)
-      : template
+      : {
+          access_token: '',
+          refresh_token: '',
+          expires_in: '',
+          client_id: '',
+          client_secret: '',
+          token_url: '',
+        }
   ) as OAuthCredentials;
+
   const showRefreshDetails = !!oAuthCredentials.refresh_token;
 
   const oAuthFields: InputOAuthField[] = [

--- a/client/src/components/InputsModal/InputsModal.tsx
+++ b/client/src/components/InputsModal/InputsModal.tsx
@@ -64,11 +64,6 @@ const InputsModal: FC<InputsModalProps> = ({
   const [invalidInput, setInvalidInput] = React.useState<boolean>(false);
 
   const missingRequiredInput = inputs.some((input: TestInput) => {
-    // Handle JSON/YAML validation separately
-    if (inputType !== 'Field') {
-      return false;
-    }
-
     // radio inputs will always be required and have a default value
     if (input.type === 'radio') return false;
 

--- a/client/src/components/InputsModal/InputsModal.tsx
+++ b/client/src/components/InputsModal/InputsModal.tsx
@@ -64,6 +64,11 @@ const InputsModal: FC<InputsModalProps> = ({
   const [invalidInput, setInvalidInput] = React.useState<boolean>(false);
 
   const missingRequiredInput = inputs.some((input: TestInput) => {
+    // Handle JSON/YAML validation separately
+    if (inputType !== 'Field') {
+      return false;
+    }
+
     // radio inputs will always be required and have a default value
     if (input.type === 'radio') return false;
 
@@ -79,6 +84,7 @@ const InputsModal: FC<InputsModalProps> = ({
         enqueueSnackbar(`Checkbox input incorrectly formatted: ${errorMessage}`, {
           variant: 'error',
         });
+        return true;
       }
     }
 
@@ -87,7 +93,8 @@ const InputsModal: FC<InputsModalProps> = ({
     if (input.type === 'oauth_credentials') {
       try {
         const oAuthJSON = JSON.parse(
-          (inputsMap.get(input.name) as string) || '{}'
+          // JSON.stringify(inputsMap.get(input.name) || {})
+          (inputsMap.get(input.name) as string) || '{ "access_token": null }'
         ) as OAuthCredentials;
         const accessTokenIsEmpty = oAuthJSON.access_token === '';
         const refreshIsEmpty =
@@ -99,48 +106,12 @@ const InputsModal: FC<InputsModalProps> = ({
         enqueueSnackbar(`OAuth credentials incorrectly formatted: ${errorMessage}`, {
           variant: 'error',
         });
+        return true;
       }
     }
 
     return (!input.optional && !inputsMap.get(input.name)) || oAuthMissingRequiredInput;
   });
-
-  useEffect(() => {
-    inputsMap.clear();
-    inputs.forEach((requirement: TestInput) => {
-      inputsMap.set(
-        requirement.name,
-        sessionData.get(requirement.name) || (requirement.default as string) || ''
-      );
-    });
-    setInputsMap(new Map(inputsMap));
-  }, [inputs, sessionData]);
-
-  useEffect(() => {
-    setInvalidInput(false);
-    setBaseInput(serializeMap(inputsMap));
-  }, [inputType, open]);
-
-  const handleSubmitKeydown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (
-      open &&
-      e.key === 'Enter' &&
-      (e.metaKey || e.ctrlKey) &&
-      !missingRequiredInput &&
-      !invalidInput
-    ) {
-      submitClicked();
-    }
-  };
-
-  const submitClicked = () => {
-    const inputs_with_values: TestInput[] = [];
-    inputsMap.forEach((input_value, input_name) => {
-      inputs_with_values.push({ name: input_name, value: input_value, type: 'text' });
-    });
-    createTestRun(runnableType, runnableId, inputs_with_values);
-    closeModal();
-  };
 
   const instructions =
     inputInstructions ||
@@ -201,12 +172,59 @@ const InputsModal: FC<InputsModalProps> = ({
     }
   });
 
+  useEffect(() => {
+    inputsMap.clear();
+    inputs.forEach((requirement: TestInput) => {
+      inputsMap.set(
+        requirement.name,
+        sessionData.get(requirement.name) || (requirement.default as string) || ''
+      );
+    });
+    setInputsMap(new Map(inputsMap));
+  }, [inputs, sessionData]);
+
+  useEffect(() => {
+    setInvalidInput(false);
+    setBaseInput(serializeMap(inputsMap));
+  }, [inputType, open]);
+
+  const handleInputTypeChange = (e: React.MouseEvent, value: string) => {
+    if (value !== null) setInputType(value);
+  };
+
+  const handleSubmitKeydown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (
+      open &&
+      e.key === 'Enter' &&
+      (e.metaKey || e.ctrlKey) &&
+      !missingRequiredInput &&
+      !invalidInput
+    ) {
+      submitClicked();
+    }
+  };
+
+  const submitClicked = () => {
+    const inputs_with_values: TestInput[] = [];
+    inputsMap.forEach((input_value, input_name) => {
+      inputs_with_values.push({ name: input_name, value: input_value, type: 'text' });
+    });
+    createTestRun(runnableType, runnableId, inputs_with_values);
+    closeModal();
+  };
+
   const serializeMap = (map: Map<string, unknown>): string => {
     const flatObj = inputs.map((requirement: TestInput) => {
       if (requirement.type === 'oauth_credentials') {
+        console.log(JSON.parse((map.get(requirement.name) as string) || '{ "access_token": "" }'));
+
         return {
           ...requirement,
-          value: JSON.parse((map.get(requirement.name) as string) || '{}') as OAuthCredentials,
+          value: JSON.parse(
+            // JSON.stringify(map.get(requirement.name) || {})
+            // (map.get(requirement.name) as string) || '{}'
+            (map.get(requirement.name) as string) || '{ "access_token": "" }'
+          ) as OAuthCredentials,
         };
       } else if (requirement.type === 'radio') {
         const firstVal =
@@ -224,10 +242,6 @@ const InputsModal: FC<InputsModalProps> = ({
     return inputType === 'JSON' ? JSON.stringify(flatObj, null, 3) : YAML.dump(flatObj);
   };
 
-  const handleInputTypeChange = (e: React.MouseEvent, value: string) => {
-    if (value !== null) setInputType(value);
-  };
-
   const parseSerialChanges = (changes: string): TestInput[] | undefined => {
     let parsed: TestInput[];
     try {
@@ -236,6 +250,12 @@ const InputsModal: FC<InputsModalProps> = ({
       } else {
         parsed = YAML.load(changes) as TestInput[];
       }
+      // Convert OAuth input values to strings
+      parsed.forEach((input) => {
+        if (input.type === 'oauth_credentials') {
+          input.value = JSON.stringify(input.value);
+        }
+      });
       setInvalidInput(false);
       return parsed;
     } catch (e) {

--- a/client/src/components/InputsModal/InputsModal.tsx
+++ b/client/src/components/InputsModal/InputsModal.tsx
@@ -93,7 +93,6 @@ const InputsModal: FC<InputsModalProps> = ({
     if (input.type === 'oauth_credentials') {
       try {
         const oAuthJSON = JSON.parse(
-          // JSON.stringify(inputsMap.get(input.name) || {})
           (inputsMap.get(input.name) as string) || '{ "access_token": null }'
         ) as OAuthCredentials;
         const accessTokenIsEmpty = oAuthJSON.access_token === '';
@@ -216,13 +215,9 @@ const InputsModal: FC<InputsModalProps> = ({
   const serializeMap = (map: Map<string, unknown>): string => {
     const flatObj = inputs.map((requirement: TestInput) => {
       if (requirement.type === 'oauth_credentials') {
-        console.log(JSON.parse((map.get(requirement.name) as string) || '{ "access_token": "" }'));
-
         return {
           ...requirement,
           value: JSON.parse(
-            // JSON.stringify(map.get(requirement.name) || {})
-            // (map.get(requirement.name) as string) || '{}'
             (map.get(requirement.name) as string) || '{ "access_token": "" }'
           ) as OAuthCredentials,
         };


### PR DESCRIPTION
# Summary

JSON string parsing and type handling was throwing errors in the input fields for OAuth, particularly when switching between field inputs to serial inputs. This should no longer occur.

# Testing Guidance

1. Before, editing JSON inputs where an OAuth input was present would cause snackbar errors to appear indicating the JSON could not be parsed. This should be fixed.

<img width="848" alt="Screenshot 2023-07-26 at 5 51 58 PM" src="https://github.com/inferno-framework/inferno-core/assets/11209247/93034a65-20b9-4f99-baee-02e35e50ddac">

2. Before, editing the OAuth fields in the JSON input and then switching back to field inputs would throw an uncaught JSON parse error. This should be fixed. Making changes and switching between inputs should be error free.

<img width="848" alt="Screenshot 2023-07-26 at 5 52 15 PM" src="https://github.com/inferno-framework/inferno-core/assets/11209247/b607f4b3-e959-4eab-ae9a-f9d26d8a8c4d">


These can be tested in the Demonstration Suite.