### PR TITLE
FI-2035: Improve error handling for validator errors

### DIFF
--- a/lib/inferno/dsl/fhir_validation.rb
+++ b/lib/inferno/dsl/fhir_validation.rb
@@ -191,6 +191,7 @@ module Inferno
         #
         # @param resource [FHIR::Model]
         # @param profile_url [String]
+        # @param runnable [Inferno::Entities::Test]
         # @return [[Array(FHIR::OperationOutcome, Number)] the validation response and HTTP status code
         def validate(resource, profile_url, runnable)
           begin

--- a/lib/inferno/dsl/fhir_validation.rb
+++ b/lib/inferno/dsl/fhir_validation.rb
@@ -116,27 +116,14 @@ module Inferno
         def resource_is_valid?(resource, profile_url, runnable)
           profile_url ||= FHIR::Definitions.resource_definition(resource.resourceType).url
 
-          begin
-            validation_response = validate(resource, profile_url)
-          rescue StandardError => e
-            runnable.add_message('error', e.message)
-            raise Inferno::Exceptions::ErrorInValidatorException, "Unable to connect to validator at #{url}."
-          end
+          outcome, http_status = validate(resource, profile_url, runnable)
 
-          # The validator should return OperationOutcome both on successful validation and on error,
-          # so parse the OO before checking the HTTP status code.
-          outcome = FHIR::OperationOutcome.new(JSON.parse(validation_response.body))
-
-          message_hashes = outcome.issue&.map { |issue| message_hash_from_issue(issue, resource) } || []
-
-          message_hashes.concat(additional_validation_messages(resource, profile_url))
-
-          filter_messages(message_hashes)
+          message_hashes = message_hashes_from_outcome(outcome, resource, profile_url)
 
           message_hashes
             .each { |message_hash| runnable.add_message(message_hash[:type], message_hash[:message]) }
 
-          unless validation_response.status == 200
+          unless http_status == 200
             raise Inferno::Exceptions::ErrorInValidatorException,
                   'Error occurred in the validator. Review Messages tab or validator service logs for more information.'
           end
@@ -154,6 +141,17 @@ module Inferno
         # @private
         def filter_messages(message_hashes)
           message_hashes.reject! { |message| exclude_message.call(Entities::Message.new(message)) } if exclude_message
+        end
+
+        # @private
+        def message_hashes_from_outcome(outcome, resource, profile_url)
+          message_hashes = outcome.issue&.map { |issue| message_hash_from_issue(issue, resource) } || []
+
+          message_hashes.concat(additional_validation_messages(resource, profile_url))
+
+          filter_messages(message_hashes)
+
+          message_hashes
         end
 
         # @private
@@ -193,12 +191,32 @@ module Inferno
         #
         # @param resource [FHIR::Model]
         # @param profile_url [String]
-        # @return [Faraday::Response] the validation response
-        def validate(resource, profile_url)
-          Faraday.new(
-            url,
-            params: { profile: profile_url }
-          ).post('validate', resource.source_contents)
+        # @return [[Array(FHIR::OperationOutcome, Number)] the validation response and HTTP status code
+        def validate(resource, profile_url, runnable)
+          begin
+            response = Faraday.new(
+              url,
+              params: { profile: profile_url }
+            ).post('validate', resource.source_contents)
+          rescue StandardError => e
+            runnable.add_message('error', e.message)
+            raise Inferno::Exceptions::ErrorInValidatorException, "Unable to connect to validator at #{url}."
+          end
+          outcome = operation_outcome_from_validator_response(response.body, runnable)
+
+          [outcome, response.status]
+        end
+
+        # @private
+        def operation_outcome_from_validator_response(response, runnable)
+          if response.start_with? '{'
+            FHIR::OperationOutcome.new(JSON.parse(response))
+          else
+            runnable.add_message('error', "Validator Response: #{response}")
+            raise Inferno::Exceptions::ErrorInValidatorException,
+                  'Validator response was an unexpected format. '\
+                  'Review Messages tab or validator service logs for more information.'
+          end
         end
       end
 

--- a/lib/inferno/exceptions.rb
+++ b/lib/inferno/exceptions.rb
@@ -39,6 +39,16 @@ module Inferno
       end
     end
 
+    class ErrorInValidatorException < TestResultException
+      # This extends TestResultException instead of RuntimeError
+      # to bypass printing the stack trace in the UI.
+      # (The stack trace of this exception may not be useful,
+      # instead the message should point to where in the validator an error occurred)
+      def result
+        'error'
+      end
+    end
+
     class ParentNotLoadedException < RuntimeError
       def initialize(klass, id)
         super("No #{klass.name.demodulize} found with id '#{id}'")

--- a/spec/inferno/dsl/fhir_validation_spec.rb
+++ b/spec/inferno/dsl/fhir_validation_spec.rb
@@ -130,6 +130,45 @@ RSpec.describe Inferno::DSL::FHIRValidation do
       end
     end
 
+    context 'with error from validator' do
+      let(:error_outcome) do
+        {
+          resourceType: 'OperationOutcome',
+          issue: [
+            {
+              severity: 'fatal',
+              code: 'structure',
+              diagnostics: 'Validator still warming up... Please wait',
+              details: {
+                text: 'Validator still warming up... Please wait'
+              }
+            }
+          ]
+        }.to_json
+      end
+
+      it 'throws ErrorInValidatorException when validator not ready yet' do
+        stub_request(:post, "#{validation_url}/validate?profile=#{profile_url}")
+          .with(body: resource_string)
+          .to_return(status: 503, body: error_outcome)
+
+        expect do
+          validator.resource_is_valid?(resource, profile_url, runnable)
+        end.to raise_error(Inferno::Exceptions::ErrorInValidatorException)
+        expect(runnable.messages.first[:message]).to include('Validator still warming up... Please wait')
+      end
+
+      it 'throws ErrorInValidatorException for non-JSON response' do
+        stub_request(:post, "#{validation_url}/validate?profile=#{profile_url}")
+          .with(body: resource_string)
+          .to_return(status: 500, body: '<html><body>Internal Server Error</body></html>')
+
+        expect do
+          validator.resource_is_valid?(resource, profile_url, runnable)
+        end.to raise_error(Inferno::Exceptions::ErrorInValidatorException)
+      end
+    end
+
     it 'posts the resource with primitive extensions intact' do
       stub_request(:post, "#{validation_url}/validate?profile=#{profile_url}")
         .with(body: resource_string)


### PR DESCRIPTION
# Summary

This PR improves error handling when there is a problem in the validator, in two ways:
1. Problems reported as OperationOutcome with an HTTP status other than 200 will raise an `ErrorInValidatorException` which renders in the inferno UI as a purple error, and more detail, when given in the OO, will be in the Messages tab:
![image](https://github.com/inferno-framework/inferno-core/assets/13512036/ff970cd3-eabe-41e3-8b37-687e2585fd4b)
(note - this message is introduced in https://github.com/inferno-framework/fhir-validator-wrapper/pull/64 )
(note 2 - a future PR will introduce a better error handler in the validator, which will render errors as OOs. still TBD)

2. When the response from the validator can't be parsed as an OperationOutcome, for example when the validator returns an HTML page that just says "HTTP 500", that will be wrapped in an `ErrorInValidatorException`, and more detail if possible will be in the Messages tab. The overall message will indicate an issue with the validator and be a purple error, but not lead off with the stack trace of the Ruby code where things went off track because that's isn't useful:
![image](https://github.com/inferno-framework/inferno-core/assets/13512036/3a7ad6ea-2c51-4331-a4d0-4566caa3e1fb)

Please feel free to suggest alternate text.  Also I suspect the logic of the modified function could be cleaner so I'm going to keep thinking about how to clean that up.

# Testing Guidance
Testing this requires a test kit that actually validates resources via the validator service. I'm not sure what the "easiest" way to do that is, but I loaded the US Core 3.1.1 test kit into the `dev_suites` folders and it wasn't tough to get running. (There are some things that need to be pruned like references to TLS tests but those lines can be deleted/commented out)

Testing the various possibilities also requires an instance of the validator that you can easily control. 
https://github.com/inferno-framework/fhir-validator-wrapper/pull/64 introduces an OperationOutcome that is returned while the app is starting up. You may also want to manually add something like `throw new RuntimeException();` in a spot of your choosing in the validator to simulate an error there.

