### PR TITLE
FI-2053: Fix inputs dialog overflow

### DIFF
--- a/client/src/components/InputsModal/InputsModal.tsx
+++ b/client/src/components/InputsModal/InputsModal.tsx
@@ -285,7 +285,7 @@ const InputsModal: FC<InputsModalProps> = ({
       </DialogTitle>
       <DialogContent>
         <main>
-          <DialogContentText component="div">
+          <DialogContentText component="div" style={{ wordBreak: 'break-word' }}>
             <ReactMarkdown>
               {instructions +
                 (inputType === 'Field'

--- a/client/src/components/InputsModal/InputsModal.tsx
+++ b/client/src/components/InputsModal/InputsModal.tsx
@@ -240,7 +240,7 @@ const InputsModal: FC<InputsModalProps> = ({
       }
     });
     return inputType === 'JSON'
-      ? JSON.stringify(flatObj, null, 3)
+      ? JSON.stringify(flatObj, null, 2)
       : YAML.dump(flatObj, { lineWidth: -1 });
   };
 

--- a/client/src/components/InputsModal/InputsModal.tsx
+++ b/client/src/components/InputsModal/InputsModal.tsx
@@ -209,9 +209,12 @@ const InputsModal: FC<InputsModalProps> = ({
 
   const serializeMap = (map: Map<string, unknown>): string => {
     const flatObj = inputs.map((requirement: TestInput) => {
+      // Parse out \n chars from descriptions
+      const parsedDescription = requirement.description?.replaceAll('\n', ' ').trim();
       if (requirement.type === 'oauth_credentials') {
         return {
           ...requirement,
+          description: parsedDescription,
           value: JSON.parse(
             (map.get(requirement.name) as string) || '{ "access_token": "" }'
           ) as OAuthCredentials,
@@ -223,10 +226,15 @@ const InputsModal: FC<InputsModalProps> = ({
             : '';
         return {
           ...requirement,
+          description: parsedDescription,
           value: map.get(requirement.name) || requirement.default || firstVal,
         };
       } else {
-        return { ...requirement, value: map.get(requirement.name) || '' };
+        return {
+          ...requirement,
+          description: parsedDescription,
+          value: map.get(requirement.name) || '',
+        };
       }
     });
     return inputType === 'JSON' ? JSON.stringify(flatObj, null, 3) : YAML.dump(flatObj);

--- a/client/src/components/InputsModal/InputsModal.tsx
+++ b/client/src/components/InputsModal/InputsModal.tsx
@@ -285,6 +285,7 @@ const InputsModal: FC<InputsModalProps> = ({
       maxWidth="sm"
       onKeyDown={handleSubmitKeydown}
       onClose={closeModal}
+      className={classes.dialog}
     >
       <DialogTitle component="div">
         <Typography component="h1" variant="h6">

--- a/client/src/components/InputsModal/InputsModal.tsx
+++ b/client/src/components/InputsModal/InputsModal.tsx
@@ -239,7 +239,9 @@ const InputsModal: FC<InputsModalProps> = ({
         };
       }
     });
-    return inputType === 'JSON' ? JSON.stringify(flatObj, null, 3) : YAML.dump(flatObj);
+    return inputType === 'JSON'
+      ? JSON.stringify(flatObj, null, 3)
+      : YAML.dump(flatObj, { lineWidth: -1 });
   };
 
   const parseSerialChanges = (changes: string): TestInput[] | undefined => {
@@ -287,7 +289,6 @@ const InputsModal: FC<InputsModalProps> = ({
       maxWidth="sm"
       onKeyDown={handleSubmitKeydown}
       onClose={closeModal}
-      className={classes.dialog}
     >
       <DialogTitle component="div">
         <Typography component="h1" variant="h6">

--- a/client/src/components/InputsModal/styles.tsx
+++ b/client/src/components/InputsModal/styles.tsx
@@ -2,11 +2,6 @@ import { Theme } from '@mui/material/styles';
 import { makeStyles } from 'tss-react/mui';
 
 export default makeStyles()((theme: Theme) => ({
-  dialog: {
-    '.MuiDialog-paper': {
-      maxWidth: '700px',
-    },
-  },
   textarea: {
     resize: 'vertical',
     maxHeight: '400px',

--- a/client/src/components/InputsModal/styles.tsx
+++ b/client/src/components/InputsModal/styles.tsx
@@ -2,6 +2,11 @@ import { Theme } from '@mui/material/styles';
 import { makeStyles } from 'tss-react/mui';
 
 export default makeStyles()((theme: Theme) => ({
+  dialog: {
+    '.MuiDialog-paper': {
+      maxWidth: '700px',
+    },
+  },
   textarea: {
     resize: 'vertical',
     maxHeight: '400px',

--- a/client/src/components/RequestDetailModal/CodeBlock.tsx
+++ b/client/src/components/RequestDetailModal/CodeBlock.tsx
@@ -22,7 +22,9 @@ const CodeBlock: FC<CodeBlockProps> = ({ body, headers }) => {
         data-testid="code-block"
       >
         <pre data-testid="pre">
-          <code data-testid="code">{formatBodyIfJSON(body, headers)}</code>
+          <code data-testid="code" className={classes.code}>
+            {formatBodyIfJSON(body, headers)}
+          </code>
         </pre>
       </Container>
     );

--- a/client/src/components/RequestDetailModal/styles.tsx
+++ b/client/src/components/RequestDetailModal/styles.tsx
@@ -23,6 +23,9 @@ export default makeStyles()((_theme: Theme) => ({
     fontSize: 'small',
     marginTop: '10px',
   },
+  code: {
+    textWrap: 'wrap',
+  },
   inputIcon: {
     float: 'right',
     verticalAlign: 'middle',


### PR DESCRIPTION
# Summary

Fixes input dialog horizontal overflow issues: markdown scrolling in descriptions, JSON/YAML newlines and autowrapping, horizontal scrollbars

# Testing Guidance

Test on g(10) Multi-Patient Auth -- run tests and in the inputs, horizontal scrollbar should no longer appear. Switching to YAML should also no longer break lines unnecessarily.