### PR TITLE
FI-2038: Prevent modal close on edit

### DIFF
--- a/client/src/components/InputsModal/InputCheckboxGroup.tsx
+++ b/client/src/components/InputsModal/InputCheckboxGroup.tsx
@@ -16,7 +16,7 @@ export interface InputCheckboxGroupProps {
   requirement: TestInput;
   index: number;
   inputsMap: Map<string, unknown>;
-  setInputsMap: (map: Map<string, unknown>) => void;
+  setInputsMap: (map: Map<string, unknown>, edited?: boolean) => void;
 }
 
 const InputCheckboxGroup: FC<InputCheckboxGroupProps> = ({
@@ -64,7 +64,8 @@ const InputCheckboxGroup: FC<InputCheckboxGroupProps> = ({
   useEffect(() => {
     // Make sure starting values get set in inputsMap
     inputsMap.set(requirement.name, transformValuesToJSONArray(values));
-    setInputsMap(new Map(inputsMap));
+    setInputsMap(new Map(inputsMap), false);
+    console.log('set map');
   }, []);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/client/src/components/InputsModal/InputCheckboxGroup.tsx
+++ b/client/src/components/InputsModal/InputCheckboxGroup.tsx
@@ -65,7 +65,6 @@ const InputCheckboxGroup: FC<InputCheckboxGroupProps> = ({
     // Make sure starting values get set in inputsMap
     inputsMap.set(requirement.name, transformValuesToJSONArray(values));
     setInputsMap(new Map(inputsMap), false);
-    console.log('set map');
   }, []);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/client/src/components/InputsModal/InputOAuthCredentials.tsx
+++ b/client/src/components/InputsModal/InputOAuthCredentials.tsx
@@ -17,7 +17,7 @@ export interface InputOAuthCredentialsProps {
   requirement: TestInput;
   index: number;
   inputsMap: Map<string, unknown>;
-  setInputsMap: (map: Map<string, unknown>) => void;
+  setInputsMap: (map: Map<string, unknown>, edited?: boolean) => void;
 }
 
 export interface InputOAuthField {

--- a/client/src/components/InputsModal/InputRadioGroup.tsx
+++ b/client/src/components/InputsModal/InputRadioGroup.tsx
@@ -16,7 +16,7 @@ export interface InputRadioGroupProps {
   requirement: TestInput;
   index: number;
   inputsMap: Map<string, unknown>;
-  setInputsMap: (map: Map<string, unknown>) => void;
+  setInputsMap: (map: Map<string, unknown>, edited?: boolean) => void;
 }
 
 const InputRadioGroup: FC<InputRadioGroupProps> = ({

--- a/client/src/components/InputsModal/InputTextArea.tsx
+++ b/client/src/components/InputsModal/InputTextArea.tsx
@@ -9,7 +9,7 @@ export interface InputTextAreaProps {
   requirement: TestInput;
   index: number;
   inputsMap: Map<string, unknown>;
-  setInputsMap: (map: Map<string, unknown>) => void;
+  setInputsMap: (map: Map<string, unknown>, edited?: boolean) => void;
 }
 
 const InputTextArea: FC<InputTextAreaProps> = ({ requirement, index, inputsMap, setInputsMap }) => {

--- a/client/src/components/InputsModal/InputTextField.tsx
+++ b/client/src/components/InputsModal/InputTextField.tsx
@@ -9,7 +9,7 @@ export interface InputTextFieldProps {
   requirement: TestInput;
   index: number;
   inputsMap: Map<string, unknown>;
-  setInputsMap: (map: Map<string, unknown>) => void;
+  setInputsMap: (map: Map<string, unknown>, edited?: boolean) => void;
 }
 
 const InputTextField: FC<InputTextFieldProps> = ({

--- a/client/src/components/InputsModal/InputsModal.tsx
+++ b/client/src/components/InputsModal/InputsModal.tsx
@@ -275,6 +275,7 @@ const InputsModal: FC<InputsModalProps> = ({
   };
 
   const handleSerialChanges = (serialChanges: string) => {
+    setEdited(true);
     const parsedChanges = parseSerialChanges(serialChanges);
     if (parsedChanges !== undefined && parsedChanges.keys !== undefined) {
       parsedChanges.forEach((change: TestInput) => {

--- a/client/src/components/InputsModal/InputsModal.tsx
+++ b/client/src/components/InputsModal/InputsModal.tsx
@@ -60,6 +60,7 @@ const InputsModal: FC<InputsModalProps> = ({
   const { classes } = useStyles();
   const { enqueueSnackbar } = useSnackbar();
   const [open, setOpen] = React.useState<boolean>(true);
+  const [edited, setEdited] = React.useState<boolean>(false);
   const [inputsMap, setInputsMap] = React.useState<Map<string, unknown>>(new Map());
   const [inputType, setInputType] = React.useState<string>('Field');
   const [baseInput, setBaseInput] = React.useState<string>('');
@@ -121,7 +122,7 @@ const InputsModal: FC<InputsModalProps> = ({
             requirement={requirement}
             index={index}
             inputsMap={inputsMap}
-            setInputsMap={setInputsMap}
+            setInputsMap={(newInputsMap) => handleSetInputsMap(newInputsMap)}
             key={`input-${index}`}
           />
         );
@@ -131,7 +132,9 @@ const InputsModal: FC<InputsModalProps> = ({
             requirement={requirement}
             index={index}
             inputsMap={inputsMap}
-            setInputsMap={setInputsMap}
+            setInputsMap={(newInputsMap, editStatus) =>
+              handleSetInputsMap(newInputsMap, editStatus)
+            }
             key={`input-${index}`}
           />
         );
@@ -141,7 +144,7 @@ const InputsModal: FC<InputsModalProps> = ({
             requirement={requirement}
             index={index}
             inputsMap={inputsMap}
-            setInputsMap={setInputsMap}
+            setInputsMap={(newInputsMap) => handleSetInputsMap(newInputsMap)}
             key={`input-${index}`}
           />
         );
@@ -151,7 +154,7 @@ const InputsModal: FC<InputsModalProps> = ({
             requirement={requirement}
             index={index}
             inputsMap={inputsMap}
-            setInputsMap={setInputsMap}
+            setInputsMap={(newInputsMap) => handleSetInputsMap(newInputsMap)}
             key={`input-${index}`}
           />
         );
@@ -161,7 +164,7 @@ const InputsModal: FC<InputsModalProps> = ({
             requirement={requirement}
             index={index}
             inputsMap={inputsMap}
-            setInputsMap={setInputsMap}
+            setInputsMap={(newInputsMap) => handleSetInputsMap(newInputsMap)}
             key={`input-${index}`}
           />
         );
@@ -186,6 +189,11 @@ const InputsModal: FC<InputsModalProps> = ({
 
   const handleInputTypeChange = (e: React.MouseEvent, value: string) => {
     if (value !== null) setInputType(value);
+  };
+
+  const handleSetInputsMap = (inputsMap: Map<string, unknown>, edited?: boolean) => {
+    setInputsMap(inputsMap);
+    setEdited(edited !== false); // explicit check for false values
   };
 
   const handleSubmitKeydown = (e: React.KeyboardEvent<HTMLDivElement>) => {
@@ -267,9 +275,12 @@ const InputsModal: FC<InputsModalProps> = ({
     setInputsMap(new Map(inputsMap));
   };
 
-  const closeModal = () => {
-    setOpen(false);
-    hideModal();
+  const closeModal = (edited = false) => {
+    // For external clicks, check if inputs have been edited first
+    if (!edited) {
+      setOpen(false);
+      hideModal();
+    }
   };
 
   return (
@@ -278,7 +289,7 @@ const InputsModal: FC<InputsModalProps> = ({
       fullWidth
       maxWidth="sm"
       onKeyDown={handleSubmitKeydown}
-      onClose={closeModal}
+      onClose={() => closeModal(edited)}
     >
       <DialogTitle component="div">
         <Typography component="h1" variant="h6">
@@ -356,7 +367,12 @@ const InputsModal: FC<InputsModalProps> = ({
           </ToggleButtonGroup>
         </Paper>
         <Box>
-          <Button color="secondary" data-testid="cancel-button" onClick={closeModal} sx={{ mr: 1 }}>
+          <Button
+            color="secondary"
+            data-testid="cancel-button"
+            onClick={() => closeModal()}
+            sx={{ mr: 1 }}
+          >
             Cancel
           </Button>
           <Button

--- a/client/src/components/InputsModal/InputsModal.tsx
+++ b/client/src/components/InputsModal/InputsModal.tsx
@@ -63,7 +63,7 @@ const InputsModal: FC<InputsModalProps> = ({
   const { classes } = useStyles();
   const { enqueueSnackbar } = useSnackbar();
   const [open, setOpen] = React.useState<boolean>(true);
-  const [edited, setEdited] = React.useState<boolean>(false);
+  const [inputsEdited, setInputsEdited] = React.useState<boolean>(false);
   const [inputsMap, setInputsMap] = React.useState<Map<string, unknown>>(new Map());
   const [inputType, setInputType] = React.useState<string>('Field');
   const [baseInput, setBaseInput] = React.useState<string>('');
@@ -196,7 +196,7 @@ const InputsModal: FC<InputsModalProps> = ({
 
   const handleSetInputsMap = (inputsMap: Map<string, unknown>, edited?: boolean) => {
     setInputsMap(inputsMap);
-    setEdited(edited !== false); // explicit check for false values
+    setInputsEdited(inputsEdited || edited !== false); // explicit check for false values
   };
 
   const handleSubmitKeydown = (e: React.KeyboardEvent<HTMLDivElement>) => {
@@ -278,7 +278,6 @@ const InputsModal: FC<InputsModalProps> = ({
   };
 
   const handleSerialChanges = (serialChanges: string) => {
-    setEdited(true);
     const parsedChanges = parseSerialChanges(serialChanges);
     if (parsedChanges !== undefined && parsedChanges.keys !== undefined) {
       parsedChanges.forEach((change: TestInput) => {
@@ -286,7 +285,7 @@ const InputsModal: FC<InputsModalProps> = ({
           inputsMap.set(change.name, change.value || '');
       });
     }
-    setInputsMap(new Map(inputsMap));
+    handleSetInputsMap(new Map(inputsMap), true);
   };
 
   const closeModal = (edited = false) => {
@@ -303,7 +302,7 @@ const InputsModal: FC<InputsModalProps> = ({
       fullWidth
       maxWidth="sm"
       onKeyDown={handleSubmitKeydown}
-      onClose={() => closeModal(edited)}
+      onClose={() => closeModal(inputsEdited)}
     >
       <DialogTitle component="div">
         <Box display="flex" justifyContent="space-between">

--- a/client/src/components/InputsModal/InputsModal.tsx
+++ b/client/src/components/InputsModal/InputsModal.tsx
@@ -13,7 +13,9 @@ import {
   Typography,
   Paper,
   Box,
+  IconButton,
 } from '@mui/material';
+import { Close } from '@mui/icons-material';
 import ReactMarkdown from 'react-markdown';
 import YAML from 'js-yaml';
 import { useSnackbar } from 'notistack';
@@ -23,6 +25,7 @@ import InputCheckboxGroup from './InputCheckboxGroup';
 import InputRadioGroup from './InputRadioGroup';
 import InputTextArea from './InputTextArea';
 import InputTextField from './InputTextField';
+import CustomTooltip from '../_common/CustomTooltip';
 import useStyles from './styles';
 
 export interface InputsModalProps {
@@ -303,9 +306,24 @@ const InputsModal: FC<InputsModalProps> = ({
       onClose={() => closeModal(edited)}
     >
       <DialogTitle component="div">
-        <Typography component="h1" variant="h6">
-          {title}
-        </Typography>
+        <Box display="flex" justifyContent="space-between">
+          <Typography component="h1" variant="h6">
+            {title}
+          </Typography>
+          <CustomTooltip title="Cancel - Inputs will be lost">
+            <IconButton
+              onClick={() => closeModal()}
+              aria-label="cancel"
+              sx={{
+                position: 'absolute',
+                right: 8,
+                top: 8,
+              }}
+            >
+              <Close />
+            </IconButton>
+          </CustomTooltip>
+        </Box>
       </DialogTitle>
       <DialogContent>
         <main>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,30 @@
+coverage:
+  status:
+    project: off
+    patch: off
+
+flag_management:
+  individual_flags:
+    - name: backend
+      paths:
+        - config/
+        - dev_suites/
+        - lib/
+        - spec/
+      statuses:
+        - type: project
+          target: 90%
+          threshold: 1%
+        - type: patch
+          target: 90%
+          threshold: 1%
+    - name: frontend
+      paths:
+        - client/
+      statuses:
+        - type: project
+          target: auto
+          threshold: 1%
+        - type: patch
+          target: auto
+          threshold: 1%

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,6 +4,8 @@ coverage:
     patch: off
 
 flag_management:
+  default_rules:
+    carryforward: true;
   individual_flags:
     - name: backend
       paths:


### PR DESCRIPTION
# Summary

While editing inputs in the dialog, clicking outside the dialog should no longer automatically close the modal.

# Testing Guidance

- [ ] 1) Open inputs dialog by running tests. Click outside the dialog, dialog should close. Double check with a dialog with checkbox inputs.
- [ ] 2) Open inputs dialog again. Modify some input values. Clicking outside the dialog should not close the dialog.
