### PR TITLE
FI-2041: Custom suites with no ids now throw standard error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -325,6 +325,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   x86_64-darwin-20
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/inferno/config/boot/suites.rb
+++ b/lib/inferno/config/boot/suites.rb
@@ -25,5 +25,15 @@ Inferno::Application.boot(:suites) do
     end
 
     ObjectSpace.each_object(TracePoint, &:disable)
+
+    Inferno::Entities::TestSuite::descendants.each do |descendant|
+      if descendant.id.blank?
+        raise StandardError.new "Error initializing test suites: custom test suite ID cannot be blank"
+      # When ID not assigned in custom test suites, Runnable.id will return default ID equal to the custom test suite's parent class name
+      elsif descendant.id == "Inferno::Entities::TestSuite"
+        raise StandardError.new "Error initializing test suites: custom test suite ID is not set"
+      end
+    end
+    
   end
 end

--- a/lib/inferno/config/boot/suites.rb
+++ b/lib/inferno/config/boot/suites.rb
@@ -30,12 +30,11 @@ Inferno::Application.boot(:suites) do
       if descendant.id.blank?
         raise StandardError, 'Error initializing test suites: custom test suite ID cannot be blank'
       end
-      # When ID not assigned in custom test suites, Runnable.id will return default ID 
-      #equal to the custom test suite's parent class name
+      # When ID not assigned in custom test suites, Runnable.id will return default ID
+      # equal to the custom test suite's parent class name
       if descendant.id == 'Inferno::Entities::TestSuite'
         raise StandardError, 'Error initializing test suites: custom test suite ID is not set'
       end
     end
-    
   end
 end

--- a/lib/inferno/config/boot/suites.rb
+++ b/lib/inferno/config/boot/suites.rb
@@ -33,7 +33,7 @@ Inferno::Application.boot(:suites) do
       # When ID not assigned in custom test suites, Runnable.id will return default ID
       # equal to the custom test suite's parent class name
       if descendant.id == 'Inferno::Entities::TestSuite'
-        raise StandardError, 'Error initializing test suites: custom test suite ID is not set'
+        raise StandardError, 'Error initializing test suite #{descendant.name}: test suite ID is not set'
       end
     end
   end

--- a/lib/inferno/config/boot/suites.rb
+++ b/lib/inferno/config/boot/suites.rb
@@ -27,13 +27,10 @@ Inferno::Application.boot(:suites) do
     ObjectSpace.each_object(TracePoint, &:disable)
 
     Inferno::Entities::TestSuite.descendants.each do |descendant|
-      if descendant.id.blank?
-        raise StandardError, 'Error initializing test suites: custom test suite ID cannot be blank'
-      end
       # When ID not assigned in custom test suites, Runnable.id will return default ID
       # equal to the custom test suite's parent class name
-      if descendant.id == 'Inferno::Entities::TestSuite'
-        raise StandardError, 'Error initializing test suite #{descendant.name}: test suite ID is not set'
+      if descendant.id.blank? || descendant.id == 'Inferno::Entities::TestSuite'
+        raise StandardError, "Error initializing test suite #{descendant.name}: test suite ID is not set"
       end
     end
   end

--- a/lib/inferno/config/boot/suites.rb
+++ b/lib/inferno/config/boot/suites.rb
@@ -26,12 +26,14 @@ Inferno::Application.boot(:suites) do
 
     ObjectSpace.each_object(TracePoint, &:disable)
 
-    Inferno::Entities::TestSuite::descendants.each do |descendant|
+    Inferno::Entities::TestSuite.descendants.each do |descendant|
       if descendant.id.blank?
-        raise StandardError.new "Error initializing test suites: custom test suite ID cannot be blank"
-      # When ID not assigned in custom test suites, Runnable.id will return default ID equal to the custom test suite's parent class name
-      elsif descendant.id == "Inferno::Entities::TestSuite"
-        raise StandardError.new "Error initializing test suites: custom test suite ID is not set"
+        raise StandardError, 'Error initializing test suites: custom test suite ID cannot be blank'
+      end
+      # When ID not assigned in custom test suites, Runnable.id will return default ID 
+      #equal to the custom test suite's parent class name
+      if descendant.id == 'Inferno::Entities::TestSuite'
+        raise StandardError, 'Error initializing test suites: custom test suite ID is not set'
       end
     end
     


### PR DESCRIPTION
# Summary
Original bug: a critical error would result when initializing Inferno with custom test suites that either:
a) had a blank id field (e.g., id = '')
b) had no id field

The console output did not provide meaningful information to the source of the error.
[JIRA ticket link](https://oncprojectracking.healthit.gov/support/browse/FI-2041)
These conditions are now checked for and, if present, will throw a standard error with a specific message during startup.

To reproduce: in `inferno-core` > `dev_suites` > `demo_suite.rb`, edit line 7 with the `id` field to be an empty string or comment out the line entirely.  Then run inferno per the README instructions.

# Testing Guidance
None
