### PR TITLE
FI-2086: fix errors on webpack shutdown

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bundle exec puma
 worker: bundle exec sidekiq -r ./worker.rb
-webpack: npm run start
+webpack: ./node_modules/.bin/webpack serve --config ./webpack.config.js --mode=development

--- a/lib/inferno/apps/cli/main.rb
+++ b/lib/inferno/apps/cli/main.rb
@@ -36,7 +36,6 @@ module Inferno
           command = "rerun \"#{command}\" --background"
         end
 
-        # system command
         exec command
       end
 

--- a/lib/inferno/apps/cli/main.rb
+++ b/lib/inferno/apps/cli/main.rb
@@ -36,7 +36,8 @@ module Inferno
           command = "rerun \"#{command}\" --background"
         end
 
-        system command
+        # system command
+        exec command
       end
 
       desc 'suites', 'List available test suites'


### PR DESCRIPTION
# Summary
Bug fix for [FI-2086 webpack not shutting down correctly](https://oncprojectracking.healthit.gov/support/browse/FI-2086)

This PR fixes two bugs related to shutdown of `inferno-core`:
## **1.  Hanging terminal on exit**
* Issue summary
     * When inferno is successfully started via terminal and then exited, the terminal window hangs after the shutdown process has been completed
 * Steps to reproduce
      1.  Follow `inferno-core` README instructions for preliminary setup
      2. Run inferno from the CLI:  `bin/inferno start`
      3. Exit with `Ctrl+C` 
      4. Shutdown messages will print and all processes will terminate, but the terminal will not fully exit back to the command line prompt until additional keystrokes are entered
 * Solution
      * Changed Ruby method used to execute shell commands in `main.rb`.  The original `system` method invokes a separate process to run `foreman start` and waits for this new process to return, but it never does.  Instead, the `exec` method call replaces the current process and never returns by design - this is appropriate for our use cases since there is no further Ruby code that needs to be executed after the `foreman start` command is launched. 

## **2. Webpack process is not shut down along with other processes**
* Issue summary
     * If inferno encounters terminal errors while launching and prematurely exits, the `node` process running webpack is not also terminated.  As a result, when inferno is restarted, it produces an `EADDRINUSE` error for IP `0.0.0.0` and port `3000`.  This error also occurs upon an automated restart when inferno is run with the `watch` flag set.
 * Steps to reproduce
      * Follow `inferno-core` README instructions for preliminary startup 
      * Case 1 - failed launch
           * Inject an error into the inferno source code prior to launching (commenting out the `id` line in `demo_suite.rb` is an easy option)
           * Run inferno: `bin/inferno start` - inferno will throw an error and exit 
           * Run inferno again - before the original error can be thrown, webpack will print the `EADDRINUSE` error and inferno will terminate
     * Case 2 - successful launch with automatic re-run on changes
          * With no errors in the source code, run inferno with the `watch` flag set: `bin/inferno start --watch`
          * Change a file in the source code to trigger a rerun - when the startup process occurs for a second time, the `EADDRINUSE` error will be thrown and inferno will terminate
     * In both cases, the `webpack` process can still be found running and needs to be manually terminated 
 * Solution
      * The source of this error appears to result from `npm start` not propagating signal interrupts to the process it launches (`webpack` in our case).  [Here](https://lisk.com/blog/posts/why-we-stopped-using-npm-start-child-processes) is a blog post about the issue in a different context.  
      * The solution is to bypass the `npm` process entirely by replacing the call to `npm run start` in the `Procfile` with the command that `npm start` would trigger in `package.json`, which is the `webpack serve` invocation.  This eliminates an unnecessary intermediary process and means signals to pass directly from the `foreman` process to the `node` (webpack) process, allowing graceful shutdown.    

# Testing Guidance

These solutions were developed and tested on a Mac OS and verified to also work on a Windows and Linux OS by Diego.  