### PR TITLE
Revert "FI-2035: Improve error handling for validator errors (#379)"

### DIFF
--- a/lib/inferno/exceptions.rb
+++ b/lib/inferno/exceptions.rb
@@ -39,16 +39,6 @@ module Inferno
       end
     end
 
-    class ErrorInValidatorException < TestResultException
-      # This extends TestResultException instead of RuntimeError
-      # to bypass printing the stack trace in the UI.
-      # (The stack trace of this exception may not be useful,
-      # instead the message should point to where in the validator an error occurred)
-      def result
-        'error'
-      end
-    end
-
     class ParentNotLoadedException < RuntimeError
       def initialize(klass, id)
         super("No #{klass.name.demodulize} found with id '#{id}'")

--- a/spec/inferno/dsl/fhir_validation_spec.rb
+++ b/spec/inferno/dsl/fhir_validation_spec.rb
@@ -130,45 +130,6 @@ RSpec.describe Inferno::DSL::FHIRValidation do
       end
     end
 
-    context 'with error from validator' do
-      let(:error_outcome) do
-        {
-          resourceType: 'OperationOutcome',
-          issue: [
-            {
-              severity: 'fatal',
-              code: 'structure',
-              diagnostics: 'Validator still warming up... Please wait',
-              details: {
-                text: 'Validator still warming up... Please wait'
-              }
-            }
-          ]
-        }.to_json
-      end
-
-      it 'throws ErrorInValidatorException when validator not ready yet' do
-        stub_request(:post, "#{validation_url}/validate?profile=#{profile_url}")
-          .with(body: resource_string)
-          .to_return(status: 503, body: error_outcome)
-
-        expect do
-          validator.resource_is_valid?(resource, profile_url, runnable)
-        end.to raise_error(Inferno::Exceptions::ErrorInValidatorException)
-        expect(runnable.messages.first[:message]).to include('Validator still warming up... Please wait')
-      end
-
-      it 'throws ErrorInValidatorException for non-JSON response' do
-        stub_request(:post, "#{validation_url}/validate?profile=#{profile_url}")
-          .with(body: resource_string)
-          .to_return(status: 500, body: '<html><body>Internal Server Error</body></html>')
-
-        expect do
-          validator.resource_is_valid?(resource, profile_url, runnable)
-        end.to raise_error(Inferno::Exceptions::ErrorInValidatorException)
-      end
-    end
-
     it 'posts the resource with primitive extensions intact' do
       stub_request(:post, "#{validation_url}/validate?profile=#{profile_url}")
         .with(body: resource_string)


### PR DESCRIPTION
#379 contained a breaking change which was not noticed. We need to revert it so that the functionality can be added in a non-breaking way.
