### PR TITLE
FI-2166: improve validator error handling without changing API

### DIFF
--- a/lib/inferno/dsl/fhir_validation.rb
+++ b/lib/inferno/dsl/fhir_validation.rb
@@ -217,7 +217,7 @@ module Inferno
           if response.start_with? '{'
             FHIR::OperationOutcome.new(JSON.parse(response))
           else
-            runnable.add_message('error', "Validator Response: #{response}")
+            runnable.add_message('error', "Validator Response:\n#{response}")
             raise Inferno::Exceptions::ErrorInValidatorException,
                   'Validator response was an unexpected format. '\
                   'Review Messages tab or validator service logs for more information.'

--- a/lib/inferno/dsl/fhir_validation.rb
+++ b/lib/inferno/dsl/fhir_validation.rb
@@ -116,8 +116,43 @@ module Inferno
         def resource_is_valid?(resource, profile_url, runnable)
           profile_url ||= FHIR::Definitions.resource_definition(resource.resourceType).url
 
-          outcome = FHIR::OperationOutcome.new(JSON.parse(validate(resource, profile_url)))
+          begin
+            response = call_validator(resource, profile_url)
+          rescue StandardError => e
+            # This could be a complete failure to connect (validator isn't running)
+            # or a timeout (validator took too long to respond).
+            runnable.add_message('error', e.message)
+            raise Inferno::Exceptions::ErrorInValidatorException, "Unable to connect to validator at #{url}."
+          end
+          outcome = operation_outcome_from_validator_response(response.body, runnable)
 
+          message_hashes = message_hashes_from_outcome(outcome, resource, profile_url)
+
+          message_hashes
+            .each { |message_hash| runnable.add_message(message_hash[:type], message_hash[:message]) }
+
+          unless response.status == 200
+            raise Inferno::Exceptions::ErrorInValidatorException,
+                  'Error occurred in the validator. Review Messages tab or validator service logs for more information.'
+          end
+
+          message_hashes
+            .none? { |message_hash| message_hash[:type] == 'error' }
+        rescue Inferno::Exceptions::ErrorInValidatorException
+          raise
+        rescue StandardError => e
+          runnable.add_message('error', e.message)
+          raise Inferno::Exceptions::ErrorInValidatorException,
+                'Error occurred in the validator. Review Messages tab or validator service logs for more information.'
+        end
+
+        # @private
+        def filter_messages(message_hashes)
+          message_hashes.reject! { |message| exclude_message.call(Entities::Message.new(message)) } if exclude_message
+        end
+
+        # @private
+        def message_hashes_from_outcome(outcome, resource, profile_url)
           message_hashes = outcome.issue&.map { |issue| message_hash_from_issue(issue, resource) } || []
 
           message_hashes.concat(additional_validation_messages(resource, profile_url))
@@ -125,13 +160,6 @@ module Inferno
           filter_messages(message_hashes)
 
           message_hashes
-            .each { |message_hash| runnable.add_message(message_hash[:type], message_hash[:message]) }
-            .none? { |message_hash| message_hash[:type] == 'error' }
-        end
-
-        # @private
-        def filter_messages(message_hashes)
-          message_hashes.reject! { |message| exclude_message.call(Entities::Message.new(message)) } if exclude_message
         end
 
         # @private
@@ -173,10 +201,27 @@ module Inferno
         # @param profile_url [String]
         # @return [String] the body of the validation response
         def validate(resource, profile_url)
+          call_validator(resource, profile_url).body
+        end
+
+        # @private
+        def call_validator(resource, profile_url)
           Faraday.new(
             url,
             params: { profile: profile_url }
-          ).post('validate', resource.source_contents).body
+          ).post('validate', resource.source_contents)
+        end
+
+        # @private
+        def operation_outcome_from_validator_response(response, runnable)
+          if response.start_with? '{'
+            FHIR::OperationOutcome.new(JSON.parse(response))
+          else
+            runnable.add_message('error', "Validator Response: #{response}")
+            raise Inferno::Exceptions::ErrorInValidatorException,
+                  'Validator response was an unexpected format. '\
+                  'Review Messages tab or validator service logs for more information.'
+          end
         end
       end
 

--- a/lib/inferno/exceptions.rb
+++ b/lib/inferno/exceptions.rb
@@ -39,11 +39,14 @@ module Inferno
       end
     end
 
+    # ErrorInValidatorException is used when an exception occurred in
+    # calling the validator service, for example a connection timeout
+    # or an unexpected response format.
+    # Note: This class extends TestResultException instead of RuntimeError
+    # to bypass printing the stack trace in the UI, since
+    # the stack trace of this exception is not likely be useful.
+    # Instead the message should point to where in the validator an error occurred.
     class ErrorInValidatorException < TestResultException
-      # This extends TestResultException instead of RuntimeError
-      # to bypass printing the stack trace in the UI.
-      # (The stack trace of this exception may not be useful,
-      # instead the message should point to where in the validator an error occurred)
       def result
         'error'
       end

--- a/lib/inferno/exceptions.rb
+++ b/lib/inferno/exceptions.rb
@@ -39,6 +39,16 @@ module Inferno
       end
     end
 
+    class ErrorInValidatorException < TestResultException
+      # This extends TestResultException instead of RuntimeError
+      # to bypass printing the stack trace in the UI.
+      # (The stack trace of this exception may not be useful,
+      # instead the message should point to where in the validator an error occurred)
+      def result
+        'error'
+      end
+    end
+
     class ParentNotLoadedException < RuntimeError
       def initialize(klass, id)
         super("No #{klass.name.demodulize} found with id '#{id}'")

--- a/spec/inferno/dsl/fhir_validation_spec.rb
+++ b/spec/inferno/dsl/fhir_validation_spec.rb
@@ -130,6 +130,45 @@ RSpec.describe Inferno::DSL::FHIRValidation do
       end
     end
 
+    context 'with error from validator' do
+      let(:error_outcome) do
+        {
+          resourceType: 'OperationOutcome',
+          issue: [
+            {
+              severity: 'fatal',
+              code: 'structure',
+              diagnostics: 'Validator still warming up... Please wait',
+              details: {
+                text: 'Validator still warming up... Please wait'
+              }
+            }
+          ]
+        }.to_json
+      end
+
+      it 'throws ErrorInValidatorException when validator not ready yet' do
+        stub_request(:post, "#{validation_url}/validate?profile=#{profile_url}")
+          .with(body: resource_string)
+          .to_return(status: 503, body: error_outcome)
+
+        expect do
+          validator.resource_is_valid?(resource, profile_url, runnable)
+        end.to raise_error(Inferno::Exceptions::ErrorInValidatorException)
+        expect(runnable.messages.first[:message]).to include('Validator still warming up... Please wait')
+      end
+
+      it 'throws ErrorInValidatorException for non-JSON response' do
+        stub_request(:post, "#{validation_url}/validate?profile=#{profile_url}")
+          .with(body: resource_string)
+          .to_return(status: 500, body: '<html><body>Internal Server Error</body></html>')
+
+        expect do
+          validator.resource_is_valid?(resource, profile_url, runnable)
+        end.to raise_error(Inferno::Exceptions::ErrorInValidatorException)
+      end
+    end
+
     it 'posts the resource with primitive extensions intact' do
       stub_request(:post, "#{validation_url}/validate?profile=#{profile_url}")
         .with(body: resource_string)


### PR DESCRIPTION
# Summary
This PR is a reissuing of #379 but without changing the method signature of the Validator.validate() function.

This does mean that there are some slight differences between calling `validate` and `resource_is_valid?` - see Notes section below - but the changes in this PR should still be a net positive. `validate` remains the "do it yourself" option and `resource_is_valid?` does everything for you

This PR improves error handling when there is a problem in the validator, in three ways:
1. Problems reported as OperationOutcome with an HTTP status other than 200 will raise an `ErrorInValidatorException` which renders in the inferno UI as a purple error, and more detail, when given in the OO, will be in the Messages tab:
![image](https://github.com/inferno-framework/inferno-core/assets/13512036/ff970cd3-eabe-41e3-8b37-687e2585fd4b)

2. When the response from the validator can't be parsed as an OperationOutcome, for example when the validator returns an HTML page that just says "HTTP 500", that will be wrapped in an `ErrorInValidatorException`, and more detail if possible will be in the Messages tab. The overall message will indicate an issue with the validator and be a purple error, but not lead off with the stack trace of the Ruby code where things went off track because that's isn't useful:
![image](https://github.com/inferno-framework/inferno-core/assets/13512036/e0033674-75cb-455b-bb81-d87f5dfd1550)

3. If the validator isn't even running, the error message will more specifically explain the problem rather than just show the ruby exception:
![image](https://github.com/inferno-framework/inferno-core/assets/13512036/b8fbeea9-b17f-4eb9-aba6-c2b8e3b661e7)


# Testing Guidance
Testing this requires a test kit that actually validates resources via the validator service. The easiest way to do this is to enable the g10 test kit gem (see instructions at the top of `Gemfile`)

Testing the various possibilities also requires an instance of the validator that you can easily control. Recommend setting up an instance of the validator wrapper separate from Docker so you can manually add something like throw new RuntimeException(); in a spot of your choosing to simulate an error there.

# Notes
There are some slight differences in the behavior of `validate` and `resource_is_valid?` but I don't think it's possible to completely synchronize those without modifying the method signature of `validate` or maybe some other much more significant refactoring. 

Part of the issue is that the HTTP status code of the validator response is meaningful, but `validate` only returns the response body, not the code. 

The other part of the issue is that the `validate` method doesn't get passed the `runnable`, so if there's an error (a timeout or failure to connect) we can't add the text of the error message to help debug. We could move the exception handler for that error into `validate` or the new `call_validator`, but I don't think it's useful for the validate method, and doing so means we can't add the exception message to the runnable (to be able to distinguish whether it's that timeout or failure to connect)

My proposal would be to revisit the `validate` method signature if we switch to using the HL7 validator because there will be additional DSL changes needed at that time as well. (See the notes on #396)