### PR TITLE
FI-2198 Markdown processing added to group level

### DIFF
--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
@@ -7,6 +7,7 @@ import InputOutputList from './TestListItem/InputOutputList';
 import ResultIcon from './ResultIcon';
 import TestRunButton from '~/components/TestSuite/TestRunButton/TestRunButton';
 import { shouldShowDescription } from '~/components/TestSuite/TestSuiteUtilities';
+import remarkGfm from 'remark-gfm';
 
 interface TestGroupCardProps {
   children: React.ReactNode;
@@ -22,7 +23,7 @@ const TestGroupCard: FC<TestGroupCardProps> = ({ children, runnable, runTests, v
 
   // render markdown once on mount - it's too slow with re-rendering
   const description = useMemo(() => {
-    return runnable.description ? <ReactMarkdown>{runnable.description}</ReactMarkdown> : undefined;
+    return runnable.description ? <ReactMarkdown remarkPlugins={[remarkGfm]}>{runnable.description}</ReactMarkdown> : undefined;
   }, [runnable.description]);
 
   const runnableType = 'tests' in runnable ? RunnableType.TestGroup : RunnableType.TestSuite;

--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
@@ -24,8 +24,8 @@ const TestGroupCard: FC<TestGroupCardProps> = ({ children, runnable, runTests, v
   // render markdown once on mount - it's too slow with re-rendering
   const description = useMemo(() => {
     return runnable.description ? (
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{runnable.description}</ReactMarkdown>) :
-      undefined;
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{runnable.description}</ReactMarkdown>
+      ) : undefined;
   }, [runnable.description]);
 
   const runnableType = 'tests' in runnable ? RunnableType.TestGroup : RunnableType.TestSuite;

--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
@@ -23,8 +23,8 @@ const TestGroupCard: FC<TestGroupCardProps> = ({ children, runnable, runTests, v
 
   // render markdown once on mount - it's too slow with re-rendering
   const description = useMemo(() => {
-    return runnable.description ? 
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{runnable.description}</ReactMarkdown> : undefined;
+    return (runnable.description ? 
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{runnable.description}</ReactMarkdown> : undefined);
   }, [runnable.description]);
 
   const runnableType = 'tests' in runnable ? RunnableType.TestGroup : RunnableType.TestSuite;

--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
@@ -24,8 +24,8 @@ const TestGroupCard: FC<TestGroupCardProps> = ({ children, runnable, runTests, v
   // render markdown once on mount - it's too slow with re-rendering
   const description = useMemo(() => {
     return runnable.description ? (
-        <ReactMarkdown remarkPlugins={[remarkGfm]}>{runnable.description}</ReactMarkdown>
-      ) : undefined;
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{runnable.description}</ReactMarkdown>
+    ) : undefined;
   }, [runnable.description]);
 
   const runnableType = 'tests' in runnable ? RunnableType.TestGroup : RunnableType.TestSuite;

--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
@@ -23,7 +23,8 @@ const TestGroupCard: FC<TestGroupCardProps> = ({ children, runnable, runTests, v
 
   // render markdown once on mount - it's too slow with re-rendering
   const description = useMemo(() => {
-    return runnable.description ? <ReactMarkdown remarkPlugins={[remarkGfm]}>{runnable.description}</ReactMarkdown> : undefined;
+    return runnable.description ? <ReactMarkdown remarkPlugins={[remarkGfm]}>
+      {runnable.description}</ReactMarkdown> : undefined;
   }, [runnable.description]);
 
   const runnableType = 'tests' in runnable ? RunnableType.TestGroup : RunnableType.TestSuite;

--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
@@ -23,8 +23,8 @@ const TestGroupCard: FC<TestGroupCardProps> = ({ children, runnable, runTests, v
 
   // render markdown once on mount - it's too slow with re-rendering
   const description = useMemo(() => {
-    return runnable.description ? <ReactMarkdown remarkPlugins={[remarkGfm]}>
-      {runnable.description}</ReactMarkdown> : undefined;
+    return runnable.description ? 
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{runnable.description}</ReactMarkdown> : undefined;
   }, [runnable.description]);
 
   const runnableType = 'tests' in runnable ? RunnableType.TestGroup : RunnableType.TestSuite;

--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
@@ -23,8 +23,9 @@ const TestGroupCard: FC<TestGroupCardProps> = ({ children, runnable, runTests, v
 
   // render markdown once on mount - it's too slow with re-rendering
   const description = useMemo(() => {
-    return (runnable.description ? 
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{runnable.description}</ReactMarkdown> : undefined);
+    return runnable.description ? (
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{runnable.description}</ReactMarkdown>) :
+      undefined;
   }, [runnable.description]);
 
   const runnableType = 'tests' in runnable ? RunnableType.TestGroup : RunnableType.TestSuite;

--- a/dev_suites/dev_demo_ig_stu1/groups/demo_group.rb
+++ b/dev_suites/dev_demo_ig_stu1/groups/demo_group.rb
@@ -15,7 +15,8 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
     | Entry 1 | Entry 2 | Entry 3|
     | Entry 4 | Entry 5 | Entry 6 |
 
-    This is a dummy canonical link http://hl7.org/fhir/ValueSet/my-valueset|0.8 that should not be interpreted as a table
+    This is a dummy canonical link http://hl7.org/fhir/ValueSet/my-valueset|0.8 that should not be 
+    interpreted as a table
     )
 
     # Inputs and outputs

--- a/dev_suites/dev_demo_ig_stu1/groups/demo_group.rb
+++ b/dev_suites/dev_demo_ig_stu1/groups/demo_group.rb
@@ -15,7 +15,7 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
     | Entry 1 | Entry 2 | Entry 3|
     | Entry 4 | Entry 5 | Entry 6 |
 
-    This is a dummy canonical link http://hl7.org/fhir/ValueSet/my-valueset|0.8 that should not be 
+    This is a dummy canonical link http://hl7.org/fhir/ValueSet/my-valueset|0.8 that should not be
     interpreted as a table
     )
 

--- a/dev_suites/dev_demo_ig_stu1/groups/demo_group.rb
+++ b/dev_suites/dev_demo_ig_stu1/groups/demo_group.rb
@@ -9,6 +9,11 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
     # This is a markdown header
     **Inferno** [github](https://github.com/inferno-framework/inferno-core)
 
+    Below is a markdown table
+    | Column 1 | Column 2 | Column 3 |
+    | :--- | :---: | ---: |
+    | Entry 1 | Entry 2 | Entry 3|
+    | Entry 4 | Entry 5 | Entry 6 |
     )
 
     # Inputs and outputs

--- a/dev_suites/dev_demo_ig_stu1/groups/demo_group.rb
+++ b/dev_suites/dev_demo_ig_stu1/groups/demo_group.rb
@@ -14,6 +14,8 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
     | :--- | :---: | ---: |
     | Entry 1 | Entry 2 | Entry 3|
     | Entry 4 | Entry 5 | Entry 6 |
+
+    This is a dummy canonical link http://hl7.org/fhir/ValueSet/my-valueset|0.8 that should not be interpreted as a table
     )
 
     # Inputs and outputs


### PR DESCRIPTION

# Completion of FI-2198
Added remarkGfm to the TestGroupCard so that tables can be used in descriptions for groups.

Example table added to group 1 in Demonstration Suite
