### PR TITLE
Fix npm install that fails due to wrong checksum in package-lock.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20791,7 +20791,7 @@
     "node_modules/semver": {
       "version": "7.5.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"


### PR DESCRIPTION
# Summary

We were getting CI test failures on https://github.com/inferno-framework/inferno-core/pull/375 after merging `main` back into that branch on the `npm i` step regarding an invalid checksum on a downloaded npm package.  I investigated to make sure nobody was tampering with npm packages (that would be very bad) somehow.  Go to `main` and run `npm i` and you'll get:

```sh
npm ERR! code EINTEGRITY
npm ERR! sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw== integrity checksum failed when using sha512: wanted sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw== but got sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==. (26872 bytes)
```

Turns out we've had an issue in the `main` branch since https://github.com/inferno-framework/inferno-core/pull/369 where the semver dependency wasn't properly updated somehow to include the right checksum for integrity checks.

![Screenshot 2023-10-20 at 3 39 16 PM](https://github.com/inferno-framework/inferno-core/assets/412901/9730ea94-410d-414d-9356-5090047b425f)

I verified that the checksum in there is for v6.3.0, even though we are now on v7.5.3.

I do not know why this wasn't picked up earlier by GitHub's build step on PRs.  Though @360dgries had noticed it in July, but at the time others couldn't replicate it and I think we may have chalked it up to his unique Windows setup?

# Testing Guidance

Prior to this, `npm i` will cause an ERR.  After this, `npm i` will not.

