### PR TITLE
Backend job to start up sessions on HL7 validator wrapper

### DIFF
--- a/Dockerfile.fhir_resource_validator
+++ b/Dockerfile.fhir_resource_validator
@@ -1,0 +1,12 @@
+FROM markiantorno/validator-wrapper
+
+USER root
+# Java certs need to be installed as root, so switch to that user for this step only
+# (the image does not contain 'sudo')
+RUN wget https://gitlab.mitre.org/mitre-scripts/mitre-pki/-/raw/master/tool_scripts/install_certs.sh -O - | MODE=java sh
+
+USER $APPLICATION_USER
+
+# CMD should be the same as in the original validator-wrapper Dockerfile
+# https://github.com/hapifhir/org.hl7.fhir.validator-wrapper/blob/master/Dockerfile
+CMD ["java", "-server", "-XX:+UnlockExperimentalVMOptions", "-XX:InitialRAMPercentage=79", "-XX:MinRAMPercentage=79", "-XX:MaxRAMPercentage=79", "-XX:+UseG1GC", "-XX:MaxGCPauseMillis=100", "-XX:+UseStringDeduplication", "-XX:+CrashOnOutOfMemoryError", "-jar", "validator-wrapper.jar", "-startServer"]

--- a/Dockerfile.fhir_resource_validator
+++ b/Dockerfile.fhir_resource_validator
@@ -7,6 +7,4 @@ RUN wget https://gitlab.mitre.org/mitre-scripts/mitre-pki/-/raw/master/tool_scri
 
 USER $APPLICATION_USER
 
-# CMD should be the same as in the original validator-wrapper Dockerfile
-# https://github.com/hapifhir/org.hl7.fhir.validator-wrapper/blob/master/Dockerfile
-CMD ["java", "-server", "-XX:+UnlockExperimentalVMOptions", "-XX:InitialRAMPercentage=79", "-XX:MinRAMPercentage=79", "-XX:MaxRAMPercentage=79", "-XX:+UseG1GC", "-XX:MaxGCPauseMillis=100", "-XX:+UseStringDeduplication", "-XX:+CrashOnOutOfMemoryError", "-jar", "validator-wrapper.jar", "-startServer"]
+# CMD is inherited from parent image as long as we don't override it or ENTRYPOINT

--- a/docker-compose.background.yml
+++ b/docker-compose.background.yml
@@ -32,6 +32,14 @@ services:
   # the section in nginx.background.conf need to be uncommented
   # hl7_validator_service:
   #   image: markiantorno/validator-wrapper
+  #   # If running on the MITRE network, comment out the "image" line above
+  #   # and uncomment the "build" section below
+  #   # build:
+  #   #   context: .
+  #   #   dockerfile: Dockerfile.fhir_resource_validator
   #   # Update this path to match your directory structure
   #   volumes:
   #     - ./igs:/home/igs
+  #     # To let the service share your local FHIR package cache,
+  #     # uncomment the below line
+  #     # - ~/.fhir:/home/ktor/.fhir

--- a/lib/inferno/config/boot/validator.rb
+++ b/lib/inferno/config/boot/validator.rb
@@ -1,0 +1,20 @@
+Inferno::Application.boot(:validator) do
+  init do
+    use :suites
+
+    # This process should only run once, 
+    # so do not run this step on worker threads
+    # next if Sidekiq.server?
+
+    Inferno::Repositories::TestSuites.new.all.each do |suite|
+      suite.fhir_validators.each do |name, validators|
+
+        validators.each do |validator|
+          if validator.is_a? Inferno::DSL::FHIRResourceValidation::Validator
+            Inferno::Jobs.perform(Inferno::Jobs::InvokeValidatorSession, validator.url, validator.igs)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/inferno/config/boot/validator.rb
+++ b/lib/inferno/config/boot/validator.rb
@@ -2,16 +2,15 @@ Inferno::Application.boot(:validator) do
   init do
     use :suites
 
-    # This process should only run once, 
-    # so do not run this step on worker threads
-    # next if Sidekiq.server?
+    # This process should only run once, to start one job per validator,
+    # so skipping it on workers will start it only once from the "web" process
+    next if Sidekiq.server?
 
     Inferno::Repositories::TestSuites.new.all.each do |suite|
       suite.fhir_validators.each do |name, validators|
-
-        validators.each do |validator|
+        validators.each_with_index do |validator, index|
           if validator.is_a? Inferno::DSL::FHIRResourceValidation::Validator
-            Inferno::Jobs.perform(Inferno::Jobs::InvokeValidatorSession, validator.url, validator.igs)
+            Inferno::Jobs.perform(Inferno::Jobs::InvokeValidatorSession, suite.id, name.to_s, index)
           end
         end
       end

--- a/lib/inferno/dsl/fhir_resource_validation.rb
+++ b/lib/inferno/dsl/fhir_resource_validation.rb
@@ -27,13 +27,12 @@ module Inferno
 
       class Validator
         attr_reader :requirements
+        attr_accessor :session_id
 
         # @private
         def initialize(requirements = nil, &)
           instance_eval(&)
           @requirements = requirements
-
-          Jobs.perform(Jobs::InvokeValidatorSession, url, igs)
         end
 
         # @private

--- a/lib/inferno/dsl/fhir_resource_validation.rb
+++ b/lib/inferno/dsl/fhir_resource_validation.rb
@@ -32,6 +32,8 @@ module Inferno
         def initialize(requirements = nil, &)
           instance_eval(&)
           @requirements = requirements
+
+          Jobs.perform(Jobs::InvokeValidatorSession, url, igs)
         end
 
         # @private

--- a/lib/inferno/jobs.rb
+++ b/lib/inferno/jobs.rb
@@ -2,6 +2,7 @@ require 'sidekiq'
 
 require_relative 'jobs/execute_test_run'
 require_relative 'jobs/resume_test_run'
+require_relative 'jobs/invoke_validator_session'
 
 module Inferno
   module Jobs

--- a/lib/inferno/jobs/invoke_validator_session.rb
+++ b/lib/inferno/jobs/invoke_validator_session.rb
@@ -1,0 +1,46 @@
+module Inferno
+  module Jobs
+    class InvokeValidatorSession
+      include Sidekiq::Worker
+
+      def perform(url, igs, disable_tx = false, display_issues_are_warnings = true)
+        request_body = {
+          cliContext: {
+            sv: '4.0.1',
+            displayWarnings: display_issues_are_warnings,
+            # txServer: nil,          # -tx n/a
+            igs: igs || []
+          },
+          filesToValidate: [
+            {
+              fileName: 'manually_entered_file.json',
+              fileContent: FHIR::Patient.new.to_json,
+              fileType: 'json'
+            }
+          ]
+        }
+
+        request_body[:cliContext][:txServer] = nil if disable_tx
+
+        # puts request_body.to_json
+
+        response = Faraday.new(
+          url,
+          request: { timeout: 600 }
+        ).post('validate', request_body.to_json, content_type: 'application/json')
+
+        if response.body.start_with? '{'
+          res = JSON.parse(response.body)
+          session_id = res['sessionId']
+          puts session_id
+          # TODO: put this session ID somewhere so we can look it up
+
+        else
+          puts response.body
+          puts response.status
+          # TODO: something went wrong. now what?
+        end
+      end
+    end
+  end
+end

--- a/lib/inferno/jobs/invoke_validator_session.rb
+++ b/lib/inferno/jobs/invoke_validator_session.rb
@@ -3,44 +3,17 @@ module Inferno
     class InvokeValidatorSession
       include Sidekiq::Worker
 
-      def perform(url, igs, disable_tx = false, display_issues_are_warnings = true)
-        request_body = {
-          cliContext: {
-            sv: '4.0.1',
-            displayWarnings: display_issues_are_warnings,
-            # txServer: nil,          # -tx n/a
-            igs: igs || []
-          },
-          filesToValidate: [
-            {
-              fileName: 'session_starter.json',
-              fileContent: FHIR::Patient.new.to_json,
-              fileType: 'json'
-            }
-          ]
-        }
+      def perform(suite_id, validator_name, validator_index)
+        suite = Inferno::Repositories::TestSuites.new.find suite_id
+        validator = suite.fhir_validators[validator_name.to_sym][validator_index]
 
-        request_body[:cliContext][:txServer] = nil if disable_tx
+        response_body = validator.validate(FHIR::Patient.new, 'http://hl7.org/fhir/StructureDefinition/Patient')
 
-        response = Faraday.new(
-          url,
-          request: { timeout: 600 }
-        ).post('validate', request_body.to_json, content_type: 'application/json')
-
-        if response.body.start_with? '{'
-          res = JSON.parse(response.body)
+        if response_body.start_with? '{'
+          res = JSON.parse(response_body)
           session_id = res['sessionId']
-          # TODO: (FI-2311) store this session ID so it can be referenced as needed,
-          # instead of iterating through all test suites to find where it goes
-          Inferno::Repositories::TestSuites.new.all.each do |suite|
-            suite.fhir_validators.each do |name, validators|
-              validators.each do |validator|
-                if validator.url == url and validator.igs == igs
-                  validator.session_id = session_id
-                end
-              end
-            end
-          end
+          # TODO: (FI-2311) store this session ID so it can be referenced as needed
+          validator.session_id = session_id
         else
           Inferno::Application['logger'].error("InvokeValidatorSession - error calling validator. #{response.inspect}")
         end

--- a/lib/inferno/jobs/invoke_validator_session.rb
+++ b/lib/inferno/jobs/invoke_validator_session.rb
@@ -15,7 +15,7 @@ module Inferno
           # TODO: (FI-2311) store this session ID so it can be referenced as needed
           validator.session_id = session_id
         else
-          Inferno::Application['logger'].error("InvokeValidatorSession - error calling validator. #{response.inspect}")
+          Inferno::Application['logger'].error("InvokeValidatorSession - error from validator: #{response_body}")
         end
       end
     end


### PR DESCRIPTION
# Summary
The HL7 validator wrapper uses sessions to allow for different combinations of settings to be used on the same server without stomping on each other. Starting up a session can be slow, especially with multiple IGs. This PR introduces a new sidekiq job that runs at startup to spin up a session for each defined validator.

Note 1: We only want to spin up one session per validator, and the "boot" sequence runs on both the web process and any worker processes, so to ensure the job only runs once per validator, the validator boot item breaks out early if running on a worker process.

Note 2: there is an issue in the underlying validation library in the HL7 wrapper where if we try to spin up multiple sessions in a fresh docker container only one will succeed, the rest will fail. See https://github.com/hapifhir/org.hl7.fhir.core/issues/1491 for details on that. This still works when there is only one configured validator, but in the real world there will be situations where there are multiple validators so that other issue is critical to resolve here.
As a hackish workaround, you can mount your own FHIR cache into the docker container so that it doesn't have to download files. Add the following volume to `docker-compose.background.yml`
```diff
  hl7_validator_service:
    image: markiantorno/validator-wrapper
    # Update this path to match your directory structure
    volumes:
      - ./igs:/home/igs
+      - ~/.fhir:/home/ktor/.fhir
```




# Testing Guidance

 - enable the `hl7_validator_service` in `docker-compose.background.yml` and `nginx.background.conf`
 - In your test suite, use `fhir_resource_validator` instead of `validator` and make sure it points to the hl7 wrapper. An easy place to do this is in the demo suite `dev_suites/dev_demo_ig_stu1/demo_suite.rb`:
```ruby
    fhir_resource_validator do
      url ENV.fetch('FHIR_RESOURCE_VALIDATOR_URL')
      exclude_message { |message| message.type == 'info' }
    end
```
Resource validation is invoked in Demo Group Instance 1, 1.1.0.7:
![image](https://github.com/inferno-framework/inferno-core/assets/13512036/90e86d8c-3d11-43f3-9af1-9b7a4e41e703)

Ideally, this step should be fast since the session is already loaded, but sometimes the validator will pull down additional IGs for example if they are referenced in extensions. Another way to tell if the process is actually using the session ID is to add a print statement in `fhir_resource_validation.rb`, for example:
```ruby
        def wrap_resource_for_hl7_wrapper(resource, profile_url)
          puts "using session_id #{@session_id}"
          wrapped_resource = {
          [...]
```
