### PR TITLE
FI-2330: Request tags

### DIFF
--- a/dev_suites/dev_demo_ig_stu1/groups/demo_group.rb
+++ b/dev_suites/dev_demo_ig_stu1/groups/demo_group.rb
@@ -330,5 +330,20 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
     test 'read from scratch' do
       run { assert scratch[:abc] == 'xyz' }
     end
+
+    test 'tag a request' do
+      run do
+        fhir_read :patient, patient_id, client: :this_client_name, tags: ['example_tag_1', 'example_tag_2']
+      end
+    end
+
+    test 'load a tagged request' do
+      run do
+        tagged_requests = load_tagged_requests('example_tag_1', 'example_tag_2')
+
+        assert tagged_requests.length == 1, 'Incorrect number of requests loaded'
+        assert request.id == tagged_requests.first.id, 'Incorrect request loaded'
+      end
+    end
   end
 end

--- a/lib/inferno/db/migrations/009_add_request_tags.rb
+++ b/lib/inferno/db/migrations/009_add_request_tags.rb
@@ -1,0 +1,18 @@
+Sequel.migration do
+  change do
+    create_table :tags do
+      column :id, String, primary_key: true, null: false, size: 36
+      column :name, String, size: 255, null: false
+
+      index :name, unique: true
+    end
+
+    create_table :requests_tags do
+      foreign_key :tags_id, :tags, index: true, type: String, null: false, size: 36, key: [:id]
+      foreign_key :requests_id, :requests, index: true, type: Integer, null: false, key: [:index]
+
+      index [:tags_id, :requests_id], unique: true
+      index [:requests_id, :tags_id], unique: true
+    end
+  end
+end

--- a/lib/inferno/db/schema.rb
+++ b/lib/inferno/db/schema.rb
@@ -4,6 +4,15 @@ Sequel.migration do
       Integer :version, :default=>0, :null=>false
     end
     
+    create_table(:tags, :ignore_index_errors=>true) do
+      String :id, :size=>36, :null=>false
+      String :name, :size=>255, :null=>false
+      
+      primary_key [:id]
+      
+      index [:name], :unique=>true
+    end
+    
     create_table(:test_sessions) do
       String :id, :size=>36, :null=>false
       String :test_suite_id, :size=>255, :null=>false
@@ -120,6 +129,16 @@ Sequel.migration do
       
       index [:requests_id]
       index [:results_id]
+    end
+    
+    create_table(:requests_tags, :ignore_index_errors=>true) do
+      foreign_key :tags_id, :tags, :type=>String, :size=>36, :null=>false, :key=>[:id]
+      foreign_key :requests_id, :requests, :null=>false, :key=>[:index]
+      
+      index [:requests_id]
+      index [:requests_id, :tags_id], :unique=>true
+      index [:tags_id]
+      index [:tags_id, :requests_id], :unique=>true
     end
   end
 end

--- a/lib/inferno/dsl/fhir_client.rb
+++ b/lib/inferno/dsl/fhir_client.rb
@@ -101,6 +101,7 @@ module Inferno
       #   other tests
       # @param headers [Hash] custom headers for this operation
       # @param operation_method [Symbol] indicates which request type to use for the operation
+      # @param tags [Array<String>] a list of tags to assign to the request
       # @return [Inferno::Entities::Request]
       def fhir_operation(
             path,
@@ -135,6 +136,7 @@ module Inferno
       # @param client [Symbol]
       # @param name [Symbol] Name for this request to allow it to be used by
       #   other tests
+      # @param tags [Array<String>] a list of tags to assign to the request
       # @return [Inferno::Entities::Request]
       def fhir_get_capability_statement(client: :default, name: nil, tags: [])
         store_request_and_refresh_token(fhir_client(client), name, tags) do
@@ -151,6 +153,7 @@ module Inferno
       # @param client [Symbol]
       # @param name [Symbol] Name for this request to allow it to be used by
       #   other tests
+      # @param tags [Array<String>] a list of tags to assign to the request
       # @return [Inferno::Entities::Request]
       def fhir_create(resource, client: :default, name: nil, tags: [])
         store_request_and_refresh_token(fhir_client(client), name, tags) do
@@ -167,6 +170,7 @@ module Inferno
       # @param client [Symbol]
       # @param name [Symbol] Name for this request to allow it to be used by
       #   other tests
+      # @param tags [Array<String>] a list of tags to assign to the request
       # @return [Inferno::Entities::Request]
       def fhir_read(resource_type, id, client: :default, name: nil, tags: [])
         store_request_and_refresh_token(fhir_client(client), name, tags) do
@@ -184,6 +188,7 @@ module Inferno
       # @param client [Symbol]
       # @param name [Symbol] Name for this request to allow it to be used by
       #   other tests
+      # @param tags [Array<String>] a list of tags to assign to the request
       # @return [Inferno::Entities::Request]
       def fhir_vread(resource_type, id, version_id, client: :default, name: nil, tags: [])
         store_request_and_refresh_token(fhir_client(client), name, tags) do
@@ -200,6 +205,7 @@ module Inferno
       # @param client [Symbol]
       # @param name [Symbol] Name for this request to allow it to be used by
       #   other tests
+      # @param tags [Array<String>] a list of tags to assign to the request
       # @return [Inferno::Entities::Request]
       def fhir_update(resource, id, client: :default, name: nil, tags: [])
         store_request_and_refresh_token(fhir_client(client), name, tags) do
@@ -217,6 +223,7 @@ module Inferno
       # @param client [Symbol]
       # @param name [Symbol] Name for this request to allow it to be used by
       #   other tests
+      # @param tags [Array<String>] a list of tags to assign to the request
       # @return [Inferno::Entities::Request]
       def fhir_patch(resource_type, id, patchset, client: :default, name: nil, tags: [])
         store_request_and_refresh_token(fhir_client(client), name, tags) do
@@ -233,6 +240,7 @@ module Inferno
       # @param client [Symbol]
       # @param name [Symbol] Name for this request to allow it to be used by
       #   other tests
+      # @param tags [Array<String>] a list of tags to assign to the request
       # @return [Inferno::Entities::Request]
       def fhir_history(resource_type = nil, id = nil, client: :default, name: nil, tags: [])
         store_request_and_refresh_token(fhir_client(client), name, tags) do
@@ -256,6 +264,7 @@ module Inferno
       # @param name [Symbol] Name for this request to allow it to be used by
       #   other tests
       # @param search_method [Symbol] Use `:post` to search via POST
+      # @param tags [Array<String>] a list of tags to assign to the request
       # @return [Inferno::Entities::Request]
       def fhir_search(
             resource_type = nil,
@@ -291,6 +300,7 @@ module Inferno
       # @param client [Symbol]
       # @param name [Symbol] Name for this request to allow it to be used by
       #   other tests
+      # @param tags [Array<String>] a list of tags to assign to the request
       # @return [Inferno::Entities::Request]
       def fhir_delete(resource_type, id, client: :default, name: nil, tags: [])
         store_request('outgoing', name, tags) do
@@ -306,6 +316,7 @@ module Inferno
       # @param client [Symbol]
       # @param name [Symbol] Name for this request to allow it to be used by
       #   other tests
+      # @param tags [Array<String>] a list of tags to assign to the request
       # @return [Inferno::Entities::Request]
       def fhir_transaction(bundle = nil, client: :default, name: nil, tags: [])
         store_request('outgoing', name, tags) do

--- a/lib/inferno/dsl/fhir_client.rb
+++ b/lib/inferno/dsl/fhir_client.rb
@@ -104,14 +104,14 @@ module Inferno
       # @param tags [Array<String>] a list of tags to assign to the request
       # @return [Inferno::Entities::Request]
       def fhir_operation(
-            path,
-            body: nil,
-            client: :default,
-            name: nil,
-            headers: {},
-            operation_method: :post,
-            tags: []
-          )
+        path,
+        body: nil,
+        client: :default,
+        name: nil,
+        headers: {},
+        operation_method: :post,
+        tags: []
+      )
         store_request_and_refresh_token(fhir_client(client), name, tags) do
           tcp_exception_handler do
             operation_headers = fhir_client(client).fhir_headers
@@ -267,13 +267,13 @@ module Inferno
       # @param tags [Array<String>] a list of tags to assign to the request
       # @return [Inferno::Entities::Request]
       def fhir_search(
-            resource_type = nil,
-            client: :default,
-            params: {},
-            name: nil,
-            search_method: :get,
-            tags: []
-          )
+        resource_type = nil,
+        client: :default,
+        params: {},
+        name: nil,
+        search_method: :get,
+        tags: []
+      )
         search =
           if search_method == :post
             { body: params }

--- a/lib/inferno/dsl/http_client.rb
+++ b/lib/inferno/dsl/http_client.rb
@@ -69,8 +69,8 @@ module Inferno
       #   other tests
       # @param headers [Hash] Input headers here
       # @return [Inferno::Entities::Request]
-      def get(url = '', client: :default, name: nil, headers: nil)
-        store_request('outgoing', name) do
+      def get(url = '', client: :default, name: nil, headers: nil, tags: [])
+        store_request('outgoing', name, tags) do
           tcp_exception_handler do
             client = http_client(client)
 
@@ -104,8 +104,8 @@ module Inferno
       #   other tests
       # @param headers [Hash] Input headers here
       # @return [Inferno::Entities::Request]
-      def post(url = '', body: nil, client: :default, name: nil, headers: nil)
-        store_request('outgoing', name) do
+      def post(url = '', body: nil, client: :default, name: nil, headers: nil, tags: [])
+        store_request('outgoing', name, tags) do
           tcp_exception_handler do
             client = http_client(client)
 
@@ -130,8 +130,8 @@ module Inferno
       #   other tests
       # @param headers [Hash] Input headers here
       # @return [Inferno::Entities::Request]
-      def delete(url = '', client: :default, name: :nil, headers: nil)
-        store_request('outgoing', name) do
+      def delete(url = '', client: :default, name: :nil, headers: nil, tags: [])
+        store_request('outgoing', name, tags) do
           tcp_exception_handler do
             client = http_client(client)
 
@@ -160,7 +160,7 @@ module Inferno
       #   other tests
       # @param headers [Hash] Input headers here
       # @return [Inferno::Entities::Request]
-      def stream(block, url = '', limit = 100, client: :default, name: nil, headers: nil)
+      def stream(block, url = '', limit = 100, client: :default, name: nil, headers: nil, tags: [])
         streamed = []
 
         collector = proc do |chunk, bytes|
@@ -169,7 +169,7 @@ module Inferno
           block.call(chunk, bytes)
         end
 
-        store_request('outgoing', name) do
+        store_request('outgoing', name, tags) do
           tcp_exception_handler do
             client = http_client(client)
 

--- a/lib/inferno/dsl/http_client.rb
+++ b/lib/inferno/dsl/http_client.rb
@@ -68,6 +68,7 @@ module Inferno
       # @param name [Symbol] Name for this request to allow it to be used by
       #   other tests
       # @param headers [Hash] Input headers here
+      # @param tags [Array<String>] a list of tags to assign to the request
       # @return [Inferno::Entities::Request]
       def get(url = '', client: :default, name: nil, headers: nil, tags: [])
         store_request('outgoing', name, tags) do
@@ -103,6 +104,7 @@ module Inferno
       # @param name [Symbol] Name for this request to allow it to be used by
       #   other tests
       # @param headers [Hash] Input headers here
+      # @param tags [Array<String>] a list of tags to assign to the request
       # @return [Inferno::Entities::Request]
       def post(url = '', body: nil, client: :default, name: nil, headers: nil, tags: [])
         store_request('outgoing', name, tags) do
@@ -129,6 +131,7 @@ module Inferno
       # @param name [Symbol] Name for this request to allow it to be used by
       #   other tests
       # @param headers [Hash] Input headers here
+      # @param tags [Array<String>] a list of tags to assign to the request
       # @return [Inferno::Entities::Request]
       def delete(url = '', client: :default, name: :nil, headers: nil, tags: [])
         store_request('outgoing', name, tags) do
@@ -159,6 +162,7 @@ module Inferno
       # @param name [Symbol] Name for this request to allow it to be used by
       #   other tests
       # @param headers [Hash] Input headers here
+      # @param tags [Array<String>] a list of tags to assign to the request
       # @return [Inferno::Entities::Request]
       def stream(block, url = '', limit = 100, client: :default, name: nil, headers: nil, tags: [])
         streamed = []

--- a/lib/inferno/dsl/request_storage.rb
+++ b/lib/inferno/dsl/request_storage.rb
@@ -36,6 +36,14 @@ module Inferno
         request&.resource
       end
 
+      def load_tagged_requests(*tags)
+        return [] if tags.blank?
+
+        Repositories::Requests.new.tagged_requests(self.test_session_id, tags).tap do |tagged_requests|
+          requests.concat(tagged_requests)
+        end
+      end
+
       # @private
       def named_request(name)
         requests.find { |request| request.name == self.class.config.request_name(name.to_sym) }

--- a/lib/inferno/dsl/request_storage.rb
+++ b/lib/inferno/dsl/request_storage.rb
@@ -36,6 +36,10 @@ module Inferno
         request&.resource
       end
 
+      # Returns requests which match all of the given tags
+      #
+      # @param tags [String]
+      # @return [Inferno::Entities::Request]
       def load_tagged_requests(*tags)
         return [] if tags.blank?
 

--- a/lib/inferno/dsl/request_storage.rb
+++ b/lib/inferno/dsl/request_storage.rb
@@ -50,18 +50,18 @@ module Inferno
       end
 
       # @private
-      def store_request(direction, name = nil, &block)
+      def store_request(direction, name, tags, &block)
         response = block.call
 
         name = self.class.config.request_name(name)
         request =
           if response.is_a? FHIR::ClientReply
             Entities::Request.from_fhir_client_reply(
-              response, direction:, name:, test_session_id:
+              response, direction:, name:, test_session_id:, tags:
             )
           else
             Entities::Request.from_http_response(
-              response, direction:, name:, test_session_id:
+              response, direction:, name:, test_session_id:, tags:
             )
           end
 

--- a/lib/inferno/dsl/request_storage.rb
+++ b/lib/inferno/dsl/request_storage.rb
@@ -43,7 +43,7 @@ module Inferno
       def load_tagged_requests(*tags)
         return [] if tags.blank?
 
-        Repositories::Requests.new.tagged_requests(self.test_session_id, tags).tap do |tagged_requests|
+        Repositories::Requests.new.tagged_requests(test_session_id, tags).tap do |tagged_requests|
           requests.concat(tagged_requests)
         end
       end

--- a/lib/inferno/dsl/resume_test_route.rb
+++ b/lib/inferno/dsl/resume_test_route.rb
@@ -24,6 +24,11 @@ module Inferno
       end
 
       # @private
+      def tags
+        self.class.singleton_class.instance_variable_get(:@tags)
+      end
+
+      # @private
       def find_test_run(test_run_identifier)
         test_runs_repo.find_latest_waiting_by_identifier(test_run_identifier)
       end
@@ -44,7 +49,8 @@ module Inferno
           request.to_hash.merge(
             test_session_id: test_run.test_session_id,
             result_id: waiting_result.id,
-            name: test.config.request_name(test.incoming_request_name)
+            name: test.config.request_name(test.incoming_request_name),
+            tags:
           )
         )
       end

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -347,9 +347,10 @@ module Inferno
       #   {Inferno::Entities::Request} object with the information for the
       #   incoming request.
       # @return [void]
-      def resume_test_route(method, path, &block)
+      def resume_test_route(method, path, tags: [], &block)
         route_class = Class.new(ResumeTestRoute) do |klass|
           klass.singleton_class.instance_variable_set(:@test_run_identifier_block, block)
+          klass.singleton_class.instance_variable_set(:@tags, tags)
         end
 
         route(method, path, route_class)

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -318,7 +318,7 @@ module Inferno
       #
       # @see Inferno::DSL::Results#wait
       # @example
-      #   resume_test_route :get, '/launch' do
+      #   resume_test_route :get, '/launch', tags: ['launch'] do
       #     request.query_parameters['iss']
       #   end
       #
@@ -341,6 +341,7 @@ module Inferno
       #   [Any of the path options available in Hanami
       #   Router](https://github.com/hanami/router/tree/f41001d4c3ee9e2d2c7bb142f74b43f8e1d3a265#a-beautiful-dsl)
       #   can be used here.
+      # @param tags [Array<String>] a list of tags to assign to the request
       # @yield This method takes a block which must return the identifier
       #   defined when a test was set to wait for the test run that hit this
       #   route. The block has access to the `request` method which returns a

--- a/lib/inferno/entities/request.rb
+++ b/lib/inferno/entities/request.rb
@@ -151,7 +151,7 @@ module Inferno
 
       class << self
         # @private
-        def from_hanami_request(request, name: nil)
+        def from_hanami_request(request, name: nil, tags: [])
           url = "#{request.base_url}#{request.path}"
           url += "?#{request.query_string}" if request.query_string.present?
           request_headers =
@@ -166,12 +166,13 @@ module Inferno
             direction: 'incoming',
             name:,
             request_body: request.body.string,
-            headers: request_headers
+            headers: request_headers,
+            tags:
           )
         end
 
         # @private
-        def from_http_response(response, test_session_id:, direction: 'outgoing', name: nil)
+        def from_http_response(response, test_session_id:, direction: 'outgoing', name: nil, tags: [])
           request_headers =
             response.env.request_headers
               .map { |header_name, value| Header.new(name: header_name.downcase, value:, type: 'request') }
@@ -188,12 +189,13 @@ module Inferno
             request_body: response.env.request_body,
             response_body: response.body,
             test_session_id:,
-            headers: request_headers + response_headers
+            headers: request_headers + response_headers,
+            tags:
           )
         end
 
         # @private
-        def from_fhir_client_reply(reply, test_session_id:, direction: 'outgoing', name: nil)
+        def from_fhir_client_reply(reply, test_session_id:, direction: 'outgoing', name: nil, tags: [])
           request = reply.request
           response = reply.response
           request_headers = request[:headers]
@@ -216,7 +218,8 @@ module Inferno
             request_body:,
             response_body: response[:body],
             test_session_id:,
-            headers: request_headers + response_headers
+            headers: request_headers + response_headers,
+            tags:
           )
         end
       end

--- a/lib/inferno/entities/request.rb
+++ b/lib/inferno/entities/request.rb
@@ -34,7 +34,7 @@ module Inferno
       ATTRIBUTES = [
         :id, :index, :verb, :url, :direction, :name, :status,
         :request_body, :response_body, :result_id, :test_session_id, :created_at,
-        :updated_at, :headers
+        :updated_at, :headers, :tags
       ].freeze
       SUMMARY_FIELDS = [
         :id, :index, :url, :verb, :direction, :name, :status, :result_id, :created_at, :updated_at
@@ -48,6 +48,18 @@ module Inferno
 
         @name = params[:name]&.to_sym
         @headers = params[:headers]&.map { |header| header.is_a?(Hash) ? Header.new(header) : header } || []
+        format_tags(params[:tags] || [])
+      end
+
+      def format_tags(raw_tags)
+        @tags = raw_tags.map do |tag|
+          case tag
+          when Hash
+            tag[:name]
+          when String
+            tag
+          end
+        end
       end
 
       # @return [Hash<String, String>]
@@ -124,6 +136,7 @@ module Inferno
           test_session_id:,
           request_headers: request_headers.map(&:to_hash),
           response_headers: response_headers.map(&:to_hash),
+          tags:,
           created_at:,
           updated_at:
         }.compact

--- a/lib/inferno/repositories/requests.rb
+++ b/lib/inferno/repositories/requests.rb
@@ -12,7 +12,7 @@ module Inferno
         headers = create_headers(request, params)
 
         params[:tags]&.each do |tag|
-          request.add_tag(name: tag, request_id: request.index)
+          request.add_tag(tag)
         end
 
         build_entity(
@@ -120,8 +120,8 @@ module Inferno
           super
         end
 
-        def add_tag(tag_hash)
-          tag = Tags::Model.find_or_create(tag_hash.slice(:name))
+        def add_tag(tag_name)
+          tag = Tags::Model.find_or_create(name: tag_name)
 
           Inferno::Application['db.connection'][:requests_tags].insert(
             tags_id: tag.id,

--- a/lib/inferno/repositories/tags.rb
+++ b/lib/inferno/repositories/tags.rb
@@ -1,0 +1,18 @@
+module Inferno
+  module Repositories
+    class Tags < Repository
+      class Model < Sequel::Model(db)
+        many_to_many :requests,
+                     class: 'Inferno::Repositories::Requests::Model',
+                     join_table: :requests_tags,
+                     left_key: :tags_id,
+                     right_key: :requests_id
+
+        def before_create
+          self.id = SecureRandom.uuid
+          super
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/request.rb
+++ b/spec/factories/request.rb
@@ -27,6 +27,8 @@ FactoryBot.define do
       ]
     end
 
+    tags { [] }
+
     request_body { nil }
 
     sequence(:response_body) { |n| "RESPONSE_BODY #{n}" }

--- a/spec/inferno/dsl/fhir_client_spec.rb
+++ b/spec/inferno/dsl/fhir_client_spec.rb
@@ -387,6 +387,13 @@ RSpec.describe Inferno::DSL::FHIRClient do
       expect(group.request).to eq(result)
     end
 
+    it 'adds tags to the request' do
+      tags = ['abc', 'def']
+      request = group.fhir_get_capability_statement(tags:)
+
+      expect(request.tags).to match_array(tags)
+    end
+
     context 'with the client parameter' do
       it 'uses that client' do
         other_url = 'http://www.example.com/fhir/r4'

--- a/spec/inferno/dsl/http_client_spec.rb
+++ b/spec/inferno/dsl/http_client_spec.rb
@@ -122,6 +122,17 @@ RSpec.describe Inferno::DSL::HTTPClient do
         expect(request.response_body).to eq('BODY')
       end
 
+      it 'adds tags to a request' do
+        stub_request(:get, base_url)
+          .to_return(status: 200, body: response_body)
+
+        tags = ['abc', 'def']
+
+        request = group.get(tags:)
+
+        expect(request.tags).to match_array(tags)
+      end
+
       context 'without a url argument' do
         let(:stub_get_request) do
           stub_request(:get, base_url)

--- a/spec/inferno/repositories/requests_spec.rb
+++ b/spec/inferno/repositories/requests_spec.rb
@@ -129,4 +129,35 @@ RSpec.describe Inferno::Repositories::Requests do
       expect(request.headers).to be_present
     end
   end
+
+  describe '#tagged_requests' do
+    it 'returns an empty array when no requests match' do
+      request = repo_create(:request, request_params)
+
+      requests = repo.tagged_requests(request.test_session_id, [SecureRandom.uuid])
+      expect(requests).to be_an(Array)
+      expect(requests.length).to eq(1)
+    end
+
+    it 'returns requests matching a tag' do
+      request = repo_create(:request, request_params)
+      tags = request.tags
+
+      tags.each do |tag|
+        requests = repo.tagged_requests(request.test_session_id, [tag])
+
+        expect(requests.length).to eq(1)
+        expect(requests.first.id).to eq(request.id)
+      end
+    end
+
+    it 'returns requests matching all tags' do
+      request = repo_create(:request, request_params)
+
+      requests = repo.tagged_requests(request.test_session_id, request.tags)
+
+      expect(requests.length).to eq(1)
+      expect(requests.first.id).to eq(request.id)
+    end
+  end
 end

--- a/spec/inferno/repositories/requests_spec.rb
+++ b/spec/inferno/repositories/requests_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe Inferno::Repositories::Requests do
       requests = repo.tagged_requests(request.test_session_id, [SecureRandom.uuid])
 
       expect(requests).to be_an(Array)
-      expect(requests.length).to eq(1)
+      expect(requests.length).to eq(0)
     end
 
     it 'returns requests matching a tag' do

--- a/spec/inferno/repositories/requests_spec.rb
+++ b/spec/inferno/repositories/requests_spec.rb
@@ -5,23 +5,23 @@ RSpec.describe Inferno::Repositories::Requests do
   let(:test_run) { repo_create(:test_run) }
   let(:result) { repo_create(:result, test_run:) }
   let(:test_session) { test_run.test_session }
+  let(:request_params) do
+    {
+      verb: 'get',
+      url: 'http://example.com',
+      direction: 'outgoing',
+      status: 200,
+      request_body: 'REQUEST_BODY',
+      response_body: 'RESPONSE_BODY',
+      result_id: result.id,
+      test_session_id: test_session.id,
+      request_headers: [{ name: 'REQUEST_HEADER_NAME', value: 'REQUEST_HEADER_VALUE', type: 'request' }],
+      response_headers: [{ name: 'RESPONSE_HEADER_NAME', value: 'RESPONSE_HEADER_VALUE', type: 'response' }],
+      tags: ['abc', 'def']
+    }
+  end
 
   describe '#create' do
-    let(:request_params) do
-      {
-        verb: 'get',
-        url: 'http://example.com',
-        direction: 'outgoing',
-        status: 200,
-        request_body: 'REQUEST_BODY',
-        response_body: 'RESPONSE_BODY',
-        result_id: result.id,
-        test_session_id: test_session.id,
-        request_headers: [{ name: 'REQUEST_HEADER_NAME', value: 'REQUEST_HEADER_VALUE', type: 'request' }],
-        response_headers: [{ name: 'RESPONSE_HEADER_NAME', value: 'RESPONSE_HEADER_VALUE', type: 'response' }]
-      }
-    end
-
     it 'persists a request' do
       request = repo.create(request_params)
 
@@ -67,7 +67,7 @@ RSpec.describe Inferno::Repositories::Requests do
   end
 
   describe '#find_full_request' do
-    let(:persisted_request) { repo_create(:request) }
+    let(:persisted_request) { repo_create(:request, request_params) }
 
     it 'returns a complete request' do
       request = repo.find_full_request(persisted_request.id)
@@ -86,6 +86,8 @@ RSpec.describe Inferno::Repositories::Requests do
       expect(request.headers.length).to eq(persisted_request.headers.length)
       expect(request.request_headers.length).to eq(persisted_request.request_headers.length)
       expect(request.response_headers.length).to eq(persisted_request.response_headers.length)
+      expect(request.tags).to be_present
+      expect(request.tags).to match_array(persisted_request.tags)
     end
   end
 


### PR DESCRIPTION
# Summary
This branch adds the ability to assign arbitrary tags to requests, and then find requests with particular tags.

# Testing Guidance
This branch includes changes to the db, so be sure to run `bundle exec inferno migrate`.

There are unit tests as well as an example in the demo suite you can mess around with.