### PR TITLE
Update null test

### DIFF
--- a/client/src/components/TestSuite/TestRunProgressBar/__tests__/TestRunProgressBar.test.tsx
+++ b/client/src/components/TestSuite/TestRunProgressBar/__tests__/TestRunProgressBar.test.tsx
@@ -61,7 +61,7 @@ describe('The TestRunProgressBar Component', () => {
     expect(testRunCancelled).toEqual(true);
 
     setTimeout(() => {
-      const progressBarElement = screen.getByTestId('progress-bar');
+      const progressBarElement = screen.queryByTestId('progress-bar');
       expect(progressBarElement).toBeNull();
     }, 500);
   });


### PR DESCRIPTION
# Summary

Null tests were using `getByTestId` instead of `queryByTestId`, which was throwing errors when elements were null.
