### PR TITLE
FI-2236: Support arbitrary fields in HL7 validator cliContext

### DIFF
--- a/spec/inferno/dsl/fhir_resource_validation_spec.rb
+++ b/spec/inferno/dsl/fhir_resource_validation_spec.rb
@@ -199,11 +199,12 @@ RSpec.describe Inferno::DSL::FHIRResourceValidation do
     it 'uses the right cli_context when submitting the validation request' do
       v3 = Inferno::DSL::FHIRResourceValidation::Validator.new do
         url 'http://example.com'
-        igs ['hl7.fhir.us.core#1.0.1']
+        igs 'hl7.fhir.us.core#1.0.1'
         cli_context do
           txServer nil
           displayWarnings true
           doNative true
+          igs ['hl7.fhir.us.core#3.1.1']
         end
       end
 
@@ -212,7 +213,7 @@ RSpec.describe Inferno::DSL::FHIRResourceValidation do
           sv: '4.0.1',
           doNative: true,
           extensions: ['any'],
-          igs: ['hl7.fhir.us.core#1.0.1'],
+          igs: ['hl7.fhir.us.core#1.0.1', 'hl7.fhir.us.core#3.1.1'],
           txServer: nil,
           displayWarnings: true,
           profiles: [profile_url]

--- a/spec/inferno/dsl/fhir_resource_validation_spec.rb
+++ b/spec/inferno/dsl/fhir_resource_validation_spec.rb
@@ -104,7 +104,6 @@ RSpec.describe Inferno::DSL::FHIRResourceValidation do
       {
         cliContext: {
           sv: '4.0.1',
-          igs: [],
           doNative: false,
           extensions: ['any'],
           profiles: [profile_url]
@@ -172,41 +171,48 @@ RSpec.describe Inferno::DSL::FHIRResourceValidation do
     end
   end
 
-  describe '.method_missing' do
+  describe '.cli_context' do
     it 'applies the correct settings to cli_context' do
       v1 = Inferno::DSL::FHIRResourceValidation::Validator.new do
-        url validation_url
-        txServer nil
+        url 'http://example.com'
+        cli_context do
+          txServer nil
+        end
       end
 
       v2 = Inferno::DSL::FHIRResourceValidation::Validator.new do
-        url validation_url
-        displayWarnings true
+        url 'http://example.com'
+        cli_context({
+                      displayWarnings: true
+                    })
       end
 
-      expect(v1.cli_context.fetch(:txServer, :missing)).to eq(nil)
-      expect(v1.cli_context.fetch(:displayWarnings, :missing)).to eq(:missing)
-      expect(v1.txServer).to eq(nil)
+      expect(v1.cli_context.definition.fetch(:txServer, :missing)).to eq(nil)
+      expect(v1.cli_context.definition.fetch(:displayWarnings, :missing)).to eq(:missing)
+      expect(v1.cli_context.txServer).to eq(nil)
 
-      expect(v2.cli_context.fetch(:txServer, :missing)).to eq(:missing)
-      expect(v2.cli_context[:displayWarnings]).to eq(true)
-      expect(v2.displayWarnings).to eq(true)
+      expect(v2.cli_context.definition.fetch(:txServer, :missing)).to eq(:missing)
+      expect(v2.cli_context.definition[:displayWarnings]).to eq(true)
+      expect(v2.cli_context.displayWarnings).to eq(true)
     end
 
     it 'uses the right cli_context when submitting the validation request' do
       v3 = Inferno::DSL::FHIRResourceValidation::Validator.new do
         url 'http://example.com'
-        txServer nil
-        displayWarnings true
         igs ['hl7.fhir.us.core#1.0.1']
+        cli_context do
+          txServer nil
+          displayWarnings true
+          doNative true
+        end
       end
 
       expected_request_body = {
         cliContext: {
           sv: '4.0.1',
-          igs: ['hl7.fhir.us.core#1.0.1'],
-          doNative: false,
+          doNative: true,
           extensions: ['any'],
+          igs: ['hl7.fhir.us.core#1.0.1'],
           txServer: nil,
           displayWarnings: true,
           profiles: [profile_url]

--- a/spec/inferno/dsl/fhir_resource_validation_spec.rb
+++ b/spec/inferno/dsl/fhir_resource_validation_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Inferno::DSL::FHIRResourceValidation do
           outcomes: [{
             fileInfo: {
               fileName: 'Patient/id.json',
-              fileContent: resource.to_json,
+              fileContent: resource.source_contents,
               fileType: 'json'
             },
             issues: []
@@ -111,7 +111,7 @@ RSpec.describe Inferno::DSL::FHIRResourceValidation do
         filesToValidate: [
           {
             fileName: 'Patient/0000.json',
-            fileContent: resource2.to_json,
+            fileContent: resource2.source_contents,
             fileType: 'json'
           }
         ],
@@ -187,6 +187,14 @@ RSpec.describe Inferno::DSL::FHIRResourceValidation do
                     })
       end
 
+      v3 = Inferno::DSL::FHIRResourceValidation::Validator.new do
+        url 'http://example.com'
+        cli_context({
+                      'igs' => ['hl7.fhir.us.core#1.0.1'],
+                      'extensions' => []
+                    })
+      end
+
       expect(v1.cli_context.definition.fetch(:txServer, :missing)).to eq(nil)
       expect(v1.cli_context.definition.fetch(:displayWarnings, :missing)).to eq(:missing)
       expect(v1.cli_context.txServer).to eq(nil)
@@ -194,10 +202,13 @@ RSpec.describe Inferno::DSL::FHIRResourceValidation do
       expect(v2.cli_context.definition.fetch(:txServer, :missing)).to eq(:missing)
       expect(v2.cli_context.definition[:displayWarnings]).to eq(true)
       expect(v2.cli_context.displayWarnings).to eq(true)
+
+      expect(v3.cli_context.igs).to eq(['hl7.fhir.us.core#1.0.1'])
+      expect(v3.cli_context.extensions).to eq([])
     end
 
     it 'uses the right cli_context when submitting the validation request' do
-      v3 = Inferno::DSL::FHIRResourceValidation::Validator.new do
+      v4 = Inferno::DSL::FHIRResourceValidation::Validator.new do
         url 'http://example.com'
         igs 'hl7.fhir.us.core#1.0.1'
         cli_context do
@@ -213,7 +224,7 @@ RSpec.describe Inferno::DSL::FHIRResourceValidation do
           sv: '4.0.1',
           doNative: true,
           extensions: ['any'],
-          igs: ['hl7.fhir.us.core#1.0.1', 'hl7.fhir.us.core#3.1.1'],
+          igs: ['hl7.fhir.us.core#3.1.1'],
           txServer: nil,
           displayWarnings: true,
           profiles: [profile_url]
@@ -221,7 +232,7 @@ RSpec.describe Inferno::DSL::FHIRResourceValidation do
         filesToValidate: [
           {
             fileName: 'Patient/.json',
-            fileContent: resource.to_json,
+            fileContent: resource.source_contents,
             fileType: 'json'
           }
         ],
@@ -232,7 +243,7 @@ RSpec.describe Inferno::DSL::FHIRResourceValidation do
         .with(body: expected_request_body)
         .to_return(status: 200, body: '{}')
 
-      expect(v3.validate(resource, profile_url)).to eq('{}')
+      expect(v4.validate(resource, profile_url)).to eq('{}')
       # if the request body doesn't match the stub,
       # validate will throw an exception
     end


### PR DESCRIPTION
# Summary
This PR enables test kits to specify settings for the HL7 validator wrapper via the `cliContext` field of the validation request. The `cliContext` is used to define settings for a validator session such as FHIR version, whether to disable terminology checks, whether code display issues should be a warning or error, etc. 

Example request:
```json
{
  "cliContext": {
    "sv": "4.0.1",
    "ig": [
      "hl7.fhir.us.core#4.0.0"
    ],
    "locale": "en"
  },
  "filesToValidate": [
    {
      "fileName": "manually_entered_file.json",
      "fileContent": "{\"resourceType\": \"Patient\"}",
      "fileType": "json"
    }
  ],
  "sessionId": "32fc25cf-020e-4492-ace5-03fe904d22e0"
}
```

Essentially [every option from the validator CLI](https://confluence.hl7.org/display/FHIR/Using+the+FHIR+Validator) is also available here  (though unfortunately the names don't always match exactly and there's no full list of option names. The HL7 validator wrapper has a little doco [here](https://github.com/hapifhir/org.hl7.fhir.validator-wrapper/blob/master/src/commonMain/resources/static-content/openapi.yml#L194) but it doesn't appear to list everything. We may have to refer to the [CliContext source code](https://github.com/hapifhir/org.hl7.fhir.core/blob/master/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/model/CliContext.java) for the full list and field names to use)

The approach here is to define `method_missing` so that arbitrary fields can be set on `cliContext` without Inferno having to specifically add support for them. The other approach I considered was just having test kits set the raw `cliContext` in the validator block. Anything else would require us to define the set of options we support.

Also as part of this PR I set defaults for the "doNative" and "extensions" fields to match what we are using in our wrapper: https://github.com/inferno-framework/fhir-validator-wrapper/blob/main/src/main/java/org/mitre/inferno/Validator.java#L104

# Testing Guidance
To use the HL7 validator: 
- enable the `hl7_validator_service` in `docker-compose.background.yml` and `nginx.background.conf`
 - In your test suite, use `fhir_resource_validator` instead of `validator` and make sure it points to the hl7 wrapper. An easy place to do this is in the demo suite `dev_suites/dev_demo_ig_stu1/demo_suite.rb`:
```ruby
    fhir_resource_validator do
      url ENV.fetch('FHIR_RESOURCE_VALIDATOR_URL')
      exclude_message { |message| message.type == 'info' }
    end
```
Then add whatever other cliContext settings you want, for example:
```ruby
    fhir_resource_validator do
      url ENV.fetch('FHIR_RESOURCE_VALIDATOR_URL')
      cli_context do
        txServer nil
        displayWarnings true
      end
      exclude_message { |message| message.type == 'info' }
    end
```

Run the test and ensure the validator is using those settings based on the returned messages (or print the actual request to console somewhere)