### PR TITLE
FI-2330: Change store_request to use keyword params

### DIFF
--- a/lib/inferno/dsl/fhir_client.rb
+++ b/lib/inferno/dsl/fhir_client.rb
@@ -303,7 +303,7 @@ module Inferno
       # @param tags [Array<String>] a list of tags to assign to the request
       # @return [Inferno::Entities::Request]
       def fhir_delete(resource_type, id, client: :default, name: nil, tags: [])
-        store_request('outgoing', name, tags) do
+        store_request('outgoing', name:, tags:) do
           tcp_exception_handler do
             fhir_client(client).destroy(fhir_class_from_resource_type(resource_type), id)
           end
@@ -319,7 +319,7 @@ module Inferno
       # @param tags [Array<String>] a list of tags to assign to the request
       # @return [Inferno::Entities::Request]
       def fhir_transaction(bundle = nil, client: :default, name: nil, tags: [])
-        store_request('outgoing', name, tags) do
+        store_request('outgoing', name:, tags:) do
           tcp_exception_handler do
             fhir_client(client).transaction_bundle = bundle if bundle.present?
             fhir_client(client).end_transaction
@@ -339,7 +339,7 @@ module Inferno
       # request methods don't have to be wrapped twice.
       # @private
       def store_request_and_refresh_token(client, name, tags, &block)
-        store_request('outgoing', name, tags) do
+        store_request('outgoing', name:, tags:) do
           perform_refresh(client) if client.need_to_refresh? && client.able_to_refresh?
           block.call
         end

--- a/lib/inferno/dsl/http_client.rb
+++ b/lib/inferno/dsl/http_client.rb
@@ -71,7 +71,7 @@ module Inferno
       # @param tags [Array<String>] a list of tags to assign to the request
       # @return [Inferno::Entities::Request]
       def get(url = '', client: :default, name: nil, headers: nil, tags: [])
-        store_request('outgoing', name, tags) do
+        store_request('outgoing', name:, tags:) do
           tcp_exception_handler do
             client = http_client(client)
 
@@ -107,7 +107,7 @@ module Inferno
       # @param tags [Array<String>] a list of tags to assign to the request
       # @return [Inferno::Entities::Request]
       def post(url = '', body: nil, client: :default, name: nil, headers: nil, tags: [])
-        store_request('outgoing', name, tags) do
+        store_request('outgoing', name:, tags:) do
           tcp_exception_handler do
             client = http_client(client)
 
@@ -134,7 +134,7 @@ module Inferno
       # @param tags [Array<String>] a list of tags to assign to the request
       # @return [Inferno::Entities::Request]
       def delete(url = '', client: :default, name: :nil, headers: nil, tags: [])
-        store_request('outgoing', name, tags) do
+        store_request('outgoing', name:, tags:) do
           tcp_exception_handler do
             client = http_client(client)
 
@@ -173,7 +173,7 @@ module Inferno
           block.call(chunk, bytes)
         end
 
-        store_request('outgoing', name, tags) do
+        store_request('outgoing', name:, tags:) do
           tcp_exception_handler do
             client = http_client(client)
 

--- a/lib/inferno/dsl/request_storage.rb
+++ b/lib/inferno/dsl/request_storage.rb
@@ -54,7 +54,7 @@ module Inferno
       end
 
       # @private
-      def store_request(direction, name, tags, &block)
+      def store_request(direction, name: nil, tags: [], &block)
         response = block.call
 
         name = self.class.config.request_name(name)


### PR DESCRIPTION
# Summary
Follow-on to #407 

This enables compatibility with any callers that don't need to name or tag the request they're storing.

Specifically, there is at least one relevant caller in US Core [here](https://github.com/inferno-framework/us-core-test-kit/blob/main/lib/us_core_test_kit/search_test.rb#L560).

# Testing Guidance
Run with US Core and g10 test kits