### PR TITLE
FI-2347: Set radio default input

### DIFF
--- a/client/src/components/InputsModal/InputRadioGroup.tsx
+++ b/client/src/components/InputsModal/InputRadioGroup.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 import {
   FormControl,
   FormControlLabel,
@@ -33,6 +33,12 @@ const InputRadioGroup: FC<InputRadioGroupProps> = ({
   const [value, setValue] = React.useState(
     inputsMap.get(requirement.name) || requirement.default || firstValue
   );
+
+  // Set default on mounted
+  useEffect(() => {
+    inputsMap.set(requirement.name, value);
+    setInputsMap(new Map(inputsMap));
+  }, []);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = event.target.value;


### PR DESCRIPTION
# Summary

Fixes a bug where radio button default values weren't being set properly.

# Testing Guidance

Make sure the default radio button value in SMART STU2 for client_auth_type is getting set when mounted.

### Detailed Testing Procedure
1. Clone inferno-core.
2. In the `Gemfile`, uncomment this line: `gem 'onc_certification_g10_test_kit'`.
3. In `demo_suite.rb`, uncomment this line: `require 'onc_certification_g10_test_kit'`.
4. Make sure Docker is running and set up Inferno Core locally following the `Running Inferno Core for Development Purposes` instructions in the README. Navigate to [localhost:4567/inferno/](http://localhost:4567/inferno/).
5. In the UI, run all tests for SMART STU2 -- you can use filler values for required fields and cancel out of the wait test. 
6. Open the developer console (right click -> Inspect) and navigate to the Networks tab. 
7. Look for the `test_runs` API call and go to the Payload tab. Inputs and their values will be printed. The radio buttons should be showing empty values for the `client_auth_type` or `Client Authentication Method` field. This is confirming that the bug is appearing.
8. Switch to the `FI-2347-radio-default` branch and retry steps 5-7. The same fields should now have values. This is confirming that the bug is fixed.

<img width="728" alt="Screenshot 2023-12-07 at 10 00 30 PM" src="https://github.com/inferno-framework/inferno-core/assets/11209247/85b53f61-3700-46c4-8910-d50b2f5a1319">

