### PR TITLE
FI-2392-header-jog

### DIFF
--- a/lib/inferno/apps/web/index.html.erb
+++ b/lib/inferno/apps/web/index.html.erb
@@ -34,6 +34,9 @@
           display: none;
         }
       }
+      body {
+        margin: 0;
+      }
       .wrapper {
         height: 100%;
         display: flex;


### PR DESCRIPTION
Removes margin before React loading to fix slight header jog