### PR TITLE
FI-2329 Add integer conversion to need_to_refresh? method

### DIFF
--- a/lib/inferno/dsl/oauth_credentials.rb
+++ b/lib/inferno/dsl/oauth_credentials.rb
@@ -80,7 +80,7 @@ module Inferno
 
         return true if expires_in.blank?
 
-        token_retrieval_time.to_i + expires_in - DateTime.now.to_i < 60
+        token_retrieval_time.to_i + expires_in.to_i - DateTime.now.to_i < 60
       end
 
       # @private


### PR DESCRIPTION
# Summary
one-line change to `need_to_refresh?` in `oauth_credentials.rb` to handle an error when `expires_in` is a non-integer type.


