### PR TITLE
FI-2396-redirect-session

### DIFF
--- a/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
+++ b/client/src/components/SuiteOptionsPage/SuiteOptionsPage.tsx
@@ -77,7 +77,8 @@ const SuiteOptionsPage: FC<SuiteOptionsPageProps> = ({ testSuite }) => {
         if (testSession && testSession.test_suite) {
           navigate(`/${testSession.test_suite_id}/${testSession.id}`);
           // Use window navigation as a workaround for router errors
-          window.location.href = `/${basePath}/${testSession.test_suite_id}/${testSession.id}`;
+          const root = basePath ? `/${basePath}` : window.location.origin;
+          window.location.href = `${root}/${testSession.test_suite_id}/${testSession.id}`;
         }
       })
       .catch((e: Error) => {


### PR DESCRIPTION
# Summary

Adds a check for the root of the URL for the new session redirect event; if there is no basePath defined, the root will default to the existing location origin. This will break if the origin and the intended base path are different.

## Testing Guidance

TBD