### PR TITLE
FI-2318 Allow for form data at session create endpoint

### DIFF
--- a/lib/inferno/apps/web/controllers/test_sessions/create.rb
+++ b/lib/inferno/apps/web/controllers/test_sessions/create.rb
@@ -10,7 +10,9 @@ module Inferno
 
           def handle(req, res)
             params = req.params.to_h
-            params.merge!(JSON.parse(req.body.string).symbolize_keys) unless req.body.string.blank?
+            unless req.body.string.blank? || req.env['CONTENT_TYPE'].include?('multipart/form-data')
+              params.merge!(JSON.parse(req.body.string).symbolize_keys)
+            end
 
             session = repo.create(create_params(params))
 

--- a/spec/request_helper.rb
+++ b/spec/request_helper.rb
@@ -11,6 +11,10 @@ module RequestHelpers
     post path, data.to_json, 'CONTENT_TYPE' => 'application/json'
   end
 
+  def post_form_data(path, data)
+    post path, data, 'CONTENT_TYPE' => 'multipart/form-data'
+  end
+
   def parsed_body
     JSON.parse(last_response.body)
   end

--- a/spec/requests/test_sessions_spec.rb
+++ b/spec/requests/test_sessions_spec.rb
@@ -52,6 +52,18 @@ RSpec.describe '/test_sessions' do
           expect(persisted_session.suite_options).to eq(expected_options)
         end
       end
+
+      context 'with form data' do
+        it 'renders the test session json' do
+          post_form_data create_path, input
+
+          expect(last_response.status).to eq(200)
+
+          expect(parsed_body).to include(*response_fields)
+          expect(parsed_body['id']).to be_present
+          expect(parsed_body['test_suite_id']).to eq(test_suite_id)
+        end
+      end
     end
 
     context 'with invalid input' do


### PR DESCRIPTION
# Summary
Added a guard in the `test_session` create endpoint so it only parses as a json when the request does not contain form-data.

# Testing Guidance
Added a spec test in `spec/requests/test_sessions_spec.rb` as well as a helper function to setup the form data request.  Requesting a closer look at these to make sure I set them up correctly, as I'm still picking up the ins-outs of spec testing the more web-facing parts of the project.
