### PR TITLE
fi-2341 Update docs site to point to preview of new docs site.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,10 @@ layout: home
 title: Home
 nav_order: 1
 ---
+**We're updating this site!  Preview the new [Inferno Framework Home](https://inferno-framework.github.io/index_new.html) before we release it on February 13 and [let us know what you think](https://inferno-framework.github.io/inferno-core/overview.html#contact-the-inferno-team).**
+
+----
+
 # Inferno Framework
 {: .fs-9 }
 


### PR DESCRIPTION
# Summary

This just adds a link to the new documentation site that we will be cutting over to next month.  We've made it 'public' by going over it in the tech talk, so may as well add that link now publicly.

# Testing Guidance

Generate and server the docs site locally: https://github.com/inferno-framework/inferno-core#documentation

Ensure that the site looks like below, grammar is ok, and that the links go to the spots that make sense. I used absolute URLs because its just easier because one wouldn't resolve while testing.  This is very temporary, we will be deprecating parts of this inferno_core documentation then.

 
![Screenshot 2024-01-10 at 4 55 58 PM](https://github.com/inferno-framework/inferno-core/assets/412901/469a64d5-a7b3-48f8-9483-f21b09802600)


