### PR TITLE
FI-2426: Fix tagged request query in postgres

### DIFF
--- a/lib/inferno/repositories/requests.rb
+++ b/lib/inferno/repositories/requests.rb
@@ -139,7 +139,7 @@ module Inferno
                 select uncounted_requests.request_id request_id
                 from (
                         select r.id request_id, t.id tag_id from requests r
-                        inner join requests_tags rt on r.`index` = rt.requests_id
+                        inner join requests_tags rt on r."index" = rt.requests_id
                         inner join tags t on rt.tags_id = t.id
                         where r.test_session_id = :test_session_id
                         and r.result_id in (
@@ -163,7 +163,7 @@ module Inferno
                 ) as matched_requests
             inner join requests final_requests on final_requests.id = matched_requests.request_id
             where final_requests.test_session_id = :test_session_id
-            order by final_requests.`index`
+            order by final_requests."index"
           SQL
         end
 


### PR DESCRIPTION
Postgres doesn't like backticks.

```
ERROR:  syntax error at or near "`" at character 172
STATEMENT:  select final_requests.* from ( select uncounted_requests.request_id request_id from ( select r.id request_id, t.id tag_id from requests r inner join requests_tags rt on r.`index` = rt.requests_id inner join tags t on rt.tags_id = t.id where r.test_session_id = '5Alp5lIjHQ0' and r.result_id in ( SELECT a.id FROM results a WHERE a.test_session_id = r.test_session_id AND a.id IN ( SELECT id FROM results b WHERE (b.test_session_id = a.test_session_id AND b.test_id = a.test_id) OR (b.test_session_id = a.test_session_id AND b.test_group_id = a.test_group_id) OR (b.test_session_id = a.test_session_id AND b.test_suite_id = a.test_suite_id) ORDER BY updated_at DESC LIMIT 1 ) ) and t.name in ('Condition?patient&asserted-date') group by r.id, t.id ) as uncounted_requests group by uncounted_requests.request_id having count(*) = 1 ) as matched_requests inner join requests final_requests on final_requests.id = matched_requests.request_id where final_requests.test_session_id = '5Alp5lIjHQ0' order by final_requests.`index`
```