### PR TITLE
FI-2434: Remove results from last test run query

### DIFF
--- a/lib/inferno/repositories/test_runs.rb
+++ b/lib/inferno/repositories/test_runs.rb
@@ -56,7 +56,7 @@ module Inferno
             .order(Sequel.desc(:updated_at))
             .limit(1)
             .to_a
-            .map { |record| record.to_json_data(json_serializer_options).deep_symbolize_keys! }
+            .map { |record| record.to_json_data.deep_symbolize_keys! }
             &.first
             &.to_hash
 


### PR DESCRIPTION
# Summary
During testing for granular scopes in the US Core test kit, there are several redirects back to Inferno once a large number of tests have already been run. This can result in the session taking over 10 seconds to load in the UI. An initial investigation revealed two slow routes: loading the last test run, and loading all the results.

Before:

![Screenshot 2024-01-18 at 8 34 48 AM](https://github.com/inferno-framework/inferno-core/assets/15969967/19b42ef2-3fc8-4598-96b4-e9d629dbcb41)

The last test run route includes all of the results for that test run, but the UI does not use them. The UI uses the results from the results route, so including the results in the last test run route just results in wasted duplicated effort to load and serialize those results. This branch updates the query used by the last test run route to only return the test run without its results.

After:

![Screenshot 2024-01-18 at 8 32 48 AM](https://github.com/inferno-framework/inferno-core/assets/15969967/611d906a-d865-452b-b84b-5e1b088eba57)

# Testing Guidance
Load up g10 and run the single patient api tests on `main`. Reload the session and inspect the time it takes for the requests to complete (note that the requests will be duplicated, but this seems to be something that only happens in dev, not prod). Load up g10 on this branch and reload that same session. When you inspect the requests, you should see that the last test run request is no longer slow, and the results query is significantly faster.
