### PR TITLE
FI-2349: Input Chaining Fix

### DIFF
--- a/lib/inferno/dsl/configurable.rb
+++ b/lib/inferno/dsl/configurable.rb
@@ -177,6 +177,11 @@ module Inferno
           inputs[identifier]&.type
         end
 
+        # @private
+        def input_optional(identifier)
+          inputs[identifier]&.optional
+        end
+
         ### Output Configuration ###
 
         # The output configuration for this runnable.

--- a/lib/inferno/dsl/configurable.rb
+++ b/lib/inferno/dsl/configurable.rb
@@ -178,7 +178,7 @@ module Inferno
         end
 
         # @private
-        def input_optional(identifier)
+        def input_optional?(identifier)
           inputs[identifier]&.optional
         end
 

--- a/lib/inferno/test_runner.rb
+++ b/lib/inferno/test_runner.rb
@@ -117,7 +117,7 @@ module Inferno
     def check_inputs(test, _test_instance, inputs)
       inputs.each do |key, value|
         optional = test.config.input_optional?(key)
-        if value.nil? && optional
+        if value.nil? && !optional
           raise Exceptions::SkipException,
                 "Input '#{test.config.input_name(key)}' is nil, skipping test."
         end

--- a/lib/inferno/test_runner.rb
+++ b/lib/inferno/test_runner.rb
@@ -72,6 +72,7 @@ module Inferno
 
       result = begin
         raise Exceptions::CancelException, 'Test cancelled by user' if test_run_is_cancelling
+
         check_inputs(test, test_instance, inputs)
 
         test_instance.load_named_requests
@@ -86,12 +87,12 @@ module Inferno
         'error'
       end
 
-        outputs = save_outputs(test_instance)
-        output_json_string = JSON.generate(outputs)
+      outputs = save_outputs(test_instance)
+      output_json_string = JSON.generate(outputs)
 
-        if result == 'wait'
-          test_runs_repo.mark_as_waiting(test_run.id, test_instance.identifier, test_instance.wait_timeout)
-        end
+      if result == 'wait'
+        test_runs_repo.mark_as_waiting(test_run.id, test_instance.identifier, test_instance.wait_timeout)
+      end
 
       test_result = persist_result(
         {
@@ -113,10 +114,13 @@ module Inferno
       test_result
     end
 
-    def check_inputs(test, test_instance, inputs)
+    def check_inputs(test, _test_instance, inputs)
       inputs.each do |key, value|
         optional = test.config.input_optional?(key)
-        raise Exceptions::SkipException, "Input '#{test.config.input_name(key)}' is nil, skipping test." if value.nil? && optional
+        if value.nil? && optional
+          raise Exceptions::SkipException,
+                "Input '#{test.config.input_name(key)}' is nil, skipping test."
+        end
       end
     end
 

--- a/lib/inferno/test_runner.rb
+++ b/lib/inferno/test_runner.rb
@@ -70,15 +70,7 @@ module Inferno
           suite_options: test_session.suite_options_hash
         )
 
-      result = ''
-
-      inputs.each do |key, value|
-        if value.nil? && !test.config.input_optional(key)
-          result = 'skip'
-          test_instance.result_message = format_markdown("Input '#{key}' is nil, skipping test.")
-          break
-        end
-      end
+      result = check_inputs(test, test_instance, inputs)
 
       if result.blank?
         result = begin
@@ -122,6 +114,19 @@ module Inferno
       update_parent_result(test.parent)
 
       test_result
+    end
+
+    def check_inputs(test, test_instance, inputs)
+      result = ''
+      inputs.each do |key, value|
+        optional = test.config.input_optional(key)
+        next unless value.nil? && optional
+
+        result = 'skip'
+        test_instance.result_message = format_markdown("Input '#{key}' is nil, skipping test.")
+        break
+      end
+      result
     end
 
     def run_group(group, scratch)

--- a/spec/inferno/dsl/test_creation_spec.rb
+++ b/spec/inferno/dsl/test_creation_spec.rb
@@ -8,20 +8,23 @@ RSpec.describe InfrastructureTest::Suite do
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:results_repo) { Inferno::Repositories::Results.new }
 
-  let(:inline_inputs) {[
-    { suite_input: 'suite_input_value' },
-    { outer_group_input: 'outer_group_input_value' },
-    { inner_group_input: 'inner_group_input_value' },
-    { test_input: 'test_input_value' }
-  ]}
+  let(:inline_inputs) do
+    [
+      { suite_input: 'suite_input_value' },
+      { outer_group_input: 'outer_group_input_value' },
+      { inner_group_input: 'inner_group_input_value' },
+      { test_input: 'test_input_value' }
+    ]
+  end
 
-  let(:external_inputs) {[
-    { suite_input: 'suite_input_value' },
-    { external_outer_group_input: 'outer_group_input_value' },
-    { external_inner_group_input: 'inner_group_input_value' },
-    { external_test1_input: 'test_input_value' }
-  ]}
-
+  let(:external_inputs) do
+    [
+      { suite_input: 'suite_input_value' },
+      { external_outer_group_input: 'outer_group_input_value' },
+      { external_inner_group_input: 'inner_group_input_value' },
+      { external_test1_input: 'test_input_value' }
+    ]
+  end
 
   describe 'inline definitions' do
     let(:outer_inline_group) { suite.groups.first }
@@ -30,7 +33,6 @@ RSpec.describe InfrastructureTest::Suite do
 
     describe 'suite' do
       let(:test_run) { repo_create(:test_run, test_suite_id: suite.id, test_session_id: test_session.id) }
-
 
       before do
         (inline_inputs + external_inputs).uniq.each do |input|
@@ -44,7 +46,7 @@ RSpec.describe InfrastructureTest::Suite do
           end
         end
       end
-      
+
       it 'contains correct metadata' do
         expect(suite.id).to eq('infra_test')
         expect(suite.title).to eq('Infrastructure Test Suite')

--- a/spec/inferno/dsl/test_creation_spec.rb
+++ b/spec/inferno/dsl/test_creation_spec.rb
@@ -5,7 +5,23 @@ RSpec.describe InfrastructureTest::Suite do
   let(:test_run) { Inferno::Entities::TestRun.new(id: SecureRandom.uuid) }
   let(:runner) { Inferno::TestRunner.new(test_session:, test_run:) }
   let(:test_session) { repo_create(:test_session, test_suite_id: suite.id) }
+  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:results_repo) { Inferno::Repositories::Results.new }
+
+  let(:inline_inputs) {[
+    { suite_input: 'suite_input_value' },
+    { outer_group_input: 'outer_group_input_value' },
+    { inner_group_input: 'inner_group_input_value' },
+    { test_input: 'test_input_value' }
+  ]}
+
+  let(:external_inputs) {[
+    { suite_input: 'suite_input_value' },
+    { external_outer_group_input: 'outer_group_input_value' },
+    { external_inner_group_input: 'inner_group_input_value' },
+    { external_test1_input: 'test_input_value' }
+  ]}
+
 
   describe 'inline definitions' do
     let(:outer_inline_group) { suite.groups.first }
@@ -15,6 +31,20 @@ RSpec.describe InfrastructureTest::Suite do
     describe 'suite' do
       let(:test_run) { repo_create(:test_run, test_suite_id: suite.id, test_session_id: test_session.id) }
 
+
+      before do
+        (inline_inputs + external_inputs).uniq.each do |input|
+          input.each do |name, value|
+            session_data_repo.save(
+              test_session_id: test_session.id,
+              name:,
+              value:,
+              type: 'text'
+            )
+          end
+        end
+      end
+      
       it 'contains correct metadata' do
         expect(suite.id).to eq('infra_test')
         expect(suite.title).to eq('Infrastructure Test Suite')
@@ -85,6 +115,19 @@ RSpec.describe InfrastructureTest::Suite do
         )
       end
 
+      before do
+        inline_inputs.each do |input|
+          input.each do |name, value|
+            session_data_repo.save(
+              test_session_id: test_session.id,
+              name:,
+              value:,
+              type: 'text'
+            )
+          end
+        end
+      end
+
       it 'contains the correct metadata' do
         expect(outer_inline_group.title).to eq('Outer inline group title')
         expect(outer_inline_group.short_title).to eq('Outer inline group short title')
@@ -141,6 +184,19 @@ RSpec.describe InfrastructureTest::Suite do
           runnable: { test_group_id: inner_inline_group.id },
           test_session:
         )
+      end
+
+      before do
+        inline_inputs.each do |input|
+          input.each do |name, value|
+            session_data_repo.save(
+              test_session_id: test_session.id,
+              name:,
+              value:,
+              type: 'text'
+            )
+          end
+        end
       end
 
       it 'contains the correct metadata' do
@@ -204,6 +260,19 @@ RSpec.describe InfrastructureTest::Suite do
         )
       end
 
+      before do
+        inline_inputs.each do |input|
+          input.each do |name, value|
+            session_data_repo.save(
+              test_session_id: test_session.id,
+              name:,
+              value:,
+              type: 'text'
+            )
+          end
+        end
+      end
+
       it 'contains the correct metadata' do
         expect(inline_test1.title).to eq('Inline test 1')
         expect(inline_test1.short_title).to eq('Inline test 1')
@@ -256,6 +325,19 @@ RSpec.describe InfrastructureTest::Suite do
           runnable: { test_group_id: external_outer_group.id },
           test_session:
         )
+      end
+
+      before do
+        external_inputs.each do |input|
+          input.each do |name, value|
+            session_data_repo.save(
+              test_session_id: test_session.id,
+              name:,
+              value:,
+              type: 'text'
+            )
+          end
+        end
       end
 
       it 'contains a nested id' do
@@ -313,6 +395,19 @@ RSpec.describe InfrastructureTest::Suite do
           runnable: { test_group_id: external_inner_group.id },
           test_session:
         )
+      end
+
+      before do
+        external_inputs.each do |input|
+          input.each do |name, value|
+            session_data_repo.save(
+              test_session_id: test_session.id,
+              name:,
+              value:,
+              type: 'text'
+            )
+          end
+        end
       end
 
       it 'contains a nested id' do
@@ -375,6 +470,19 @@ RSpec.describe InfrastructureTest::Suite do
           runnable: { test_id: external_test.id },
           test_session:
         )
+      end
+
+      before do
+        external_inputs.each do |input|
+          input.each do |name, value|
+            session_data_repo.save(
+              test_session_id: test_session.id,
+              name:,
+              value:,
+              type: 'text'
+            )
+          end
+        end
       end
 
       it 'contains a nested id' do

--- a/spec/inferno/test_runner_spec.rb
+++ b/spec/inferno/test_runner_spec.rb
@@ -141,11 +141,13 @@ RSpec.describe Inferno::TestRunner do
 
     let(:suite) { OptionsSuite::Suite }
 
-    let(:inputs) {[
-      { v1_input: 'v1_input_value' },
-      { v2_input: 'v2_input_value' },
-      { all_versions_input: 'all_versions_input_value' }
-    ]}
+    let(:inputs) do
+      [
+        { v1_input: 'v1_input_value' },
+        { v2_input: 'v2_input_value' },
+        { all_versions_input: 'all_versions_input_value' }
+      ]
+    end
 
     before do
       inputs.each do |input|
@@ -160,9 +162,9 @@ RSpec.describe Inferno::TestRunner do
       end
     end
 
-    it 'only runs groups which should be included based on options' do     
+    it 'only runs groups which should be included based on options' do
       test_session.suite_options = [Inferno::DSL::SuiteOption.new(id: :ig_version, value: '1')]
-      
+
       runner.run(suite)
 
       results = results_repo.current_results_for_test_session(test_session.id)

--- a/spec/inferno/test_runner_spec.rb
+++ b/spec/inferno/test_runner_spec.rb
@@ -141,9 +141,28 @@ RSpec.describe Inferno::TestRunner do
 
     let(:suite) { OptionsSuite::Suite }
 
-    it 'only runs groups which should be included based on options' do
-      test_session.suite_options = [Inferno::DSL::SuiteOption.new(id: :ig_version, value: '1')]
+    let(:inputs) {[
+      { v1_input: 'v1_input_value' },
+      { v2_input: 'v2_input_value' },
+      { all_versions_input: 'all_versions_input_value' }
+    ]}
 
+    before do
+      inputs.each do |input|
+        input.each do |name, value|
+          session_data_repo.save(
+            test_session_id: test_session.id,
+            name:,
+            value:,
+            type: 'text'
+          )
+        end
+      end
+    end
+
+    it 'only runs groups which should be included based on options' do     
+      test_session.suite_options = [Inferno::DSL::SuiteOption.new(id: :ig_version, value: '1')]
+      
       runner.run(suite)
 
       results = results_repo.current_results_for_test_session(test_session.id)


### PR DESCRIPTION
# Summary
If you have a group where one test sets an output that then gets chained into a following tests 'input', if that output is nil when the input is required often times test writers don't think to guard against a nil value. Made fix to inferno core so that before a test is run, it will check each input, and if the input is non-optional and nil, it will skip the test. 

# Testing Guidance
Run `bundle exec rspec` and ensure that all unit tests still pass after this change
