### PR TITLE
Fi 2116 inferno version cli

### DIFF
--- a/lib/inferno/apps/cli/main.rb
+++ b/lib/inferno/apps/cli/main.rb
@@ -56,7 +56,7 @@ module Inferno
 
       desc 'version', "Output Inferno core version (#{Inferno::VERSION})"
       def version
-        puts Inferno::VERSION
+        puts "Inferno Core v#{Inferno::VERSION}"
       end
     end
   end

--- a/lib/inferno/apps/cli/main.rb
+++ b/lib/inferno/apps/cli/main.rb
@@ -4,6 +4,7 @@ require_relative 'services'
 require_relative 'suite'
 require_relative 'suites'
 require_relative 'new'
+require_relative '../../version'
 
 module Inferno
   module CLI
@@ -52,6 +53,11 @@ module Inferno
       subcommand 'suite', Suite
 
       register(New, 'new', 'new TEST_KIT_NAME', 'Run `inferno new --help` for full help')
+
+      desc 'version', "Output Inferno core version (#{Inferno::VERSION})"
+      def version
+        puts Inferno::VERSION
+      end
     end
   end
 end

--- a/lib/inferno/apps/cli/main_spec.rb
+++ b/lib/inferno/apps/cli/main_spec.rb
@@ -1,0 +1,12 @@
+require 'rspec'
+require 'thor'
+require 'inferno/apps/cli/main'
+require 'inferno/version'
+
+RSpec.describe Inferno::CLI::Main do # rubocop:disable RSpec/FilePath
+  context 'with version command' do
+    it 'outputs current Inferno version' do
+      expect { described_class.new.version }.to output("#{Inferno::VERSION}\n").to_stdout
+    end
+  end
+end


### PR DESCRIPTION
# Summary

Add Inferno version CLI command:
```
$ bundle exec bin/inferno version
Inferno Core v0.4.27
```

I think there should be some option to output test kit version and even HL7 Validator version, but that should be in future tickets/PRs.

# Testing Guidance

1. Checkout this branch
2. Run `./bin/inferno version`
