### PR TITLE
FI-2235: Include IGs in igs folder in validation requests by default

### DIFF
--- a/.env
+++ b/.env
@@ -3,6 +3,7 @@ VALIDATOR_URL=http://localhost/validatorapi
 REDIS_URL=redis://localhost:6379/0
 G10_VALIDATOR_URL=http://localhost/validatorapi
 FHIR_RESOURCE_VALIDATOR_URL=http://localhost/hl7validatorapi
+IGS_PATH=./igs
 
 # The base path where inferno will be hosted. Leave blank to host inferno at the
 # root of its host.

--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,4 @@
 LOAD_DEV_SUITES=dev_*
 VALIDATOR_URL=https://example.com/validatorapi
 ASYNC_JOBS=false
+IGS_PATH=

--- a/docker-compose.background.yml
+++ b/docker-compose.background.yml
@@ -2,9 +2,9 @@ version: '3'
 services:
   validator_service:
     image: infernocommunity/fhir-validator-service
-    # Update this path to match your directory structure
+    # Update the IGS_PATH env var to match your directory structure
     volumes:
-      - ./igs:/home/igs
+      - ${IGS_PATH:-./igs}:/home/igs
   fhir_validator_app:
     image: infernocommunity/fhir-validator-app
     depends_on:
@@ -37,9 +37,9 @@ services:
   #   # build:
   #   #   context: .
   #   #   dockerfile: Dockerfile.fhir_resource_validator
-  #   # Update this path to match your directory structure
   #   volumes:
-  #     - ./igs:/home/igs
+  #     # Update the IGS_PATH env var to match your directory structure
+  #     - ${IGS_PATH:-./igs}:/app/igs
   #     # To let the service share your local FHIR package cache,
   #     # uncomment the below line
   #     # - ~/.fhir:/home/ktor/.fhir

--- a/lib/inferno/dsl/fhir_resource_validation.rb
+++ b/lib/inferno/dsl/fhir_resource_validation.rb
@@ -297,10 +297,20 @@ module Inferno
       class CliContext
         attr_reader :definition
 
+        # @private
+        def self.default_igs
+          igs_path = ENV['IGS_PATH']
+          return [] unless igs_path && File.directory?(igs_path)
+
+          # Docker volume maps IGS_PATH to './igs' in the container, so realign the paths for any files
+          Dir["#{igs_path}/*.tgz"].select { |f| File.file?(f) }.map { |f| f.sub(igs_path, './igs') }
+        end
+
         CLICONTEXT_DEFAULTS = {
           sv: '4.0.1',
           doNative: false,
-          extensions: ['any']
+          extensions: ['any'],
+          igs: CliContext.default_igs
         }.freeze
 
         # @private

--- a/spec/inferno/dsl/fhir_resource_validation_spec.rb
+++ b/spec/inferno/dsl/fhir_resource_validation_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe Inferno::DSL::FHIRResourceValidation do
           sv: '4.0.1',
           doNative: false,
           extensions: ['any'],
+          igs: [],
           profiles: [profile_url]
         },
         filesToValidate: [
@@ -246,6 +247,18 @@ RSpec.describe Inferno::DSL::FHIRResourceValidation do
       expect(v4.validate(resource, profile_url)).to eq('{}')
       # if the request body doesn't match the stub,
       # validate will throw an exception
+    end
+
+    it 'finds the IGs in the configured default IG path' do
+      ENV['IGS_PATH'] = ''
+      igs = Inferno::DSL::FHIRResourceValidation::CliContext.default_igs
+      expect(igs).to eq([])
+
+      ENV['IGS_PATH'] = './spec/fixtures'
+      igs = Inferno::DSL::FHIRResourceValidation::CliContext.default_igs
+      expect(igs).to eq(['./igs/small_package.tgz'])
+    ensure
+      ENV['IGS_PATH'] = ''
     end
   end
 


### PR DESCRIPTION
# Summary
This PR introduces a new environment variable `IGS_PATH` which represents the path to a folder containing IGs relevant to the current test suite. 

Today, this folder is mapped in the docker compose file as a volume on the inferno-validator-service, where the validator at startup loads all IGs in the given folder. To replicate this behavior in the HL7 validator-wrapper, we need to provide the filenames of the IGs in the `cliContext` of the request. This PR reads the files in the directory and sets them as the default `igs`, but if a test suite doesn't want to use all IGs in that directory they can still specify another or none in their `fhir_resource_validator` block.

Because the docker volume maps the path to the `igs/` folder in the container, the filenames of all .tgz files it finds are mapped to `./igs/file.tgz` so that the validator can find them. (Is there a better way to do this?)

Just to ensure that docker doesn't crash with a strange error if the env var is missing, I set a default of `./igs`  (that's what the `:-` syntax is)

# Testing Guidance
To use the HL7 validator: 
- enable the `hl7_validator_service` in `docker-compose.background.yml` and `nginx.background.conf`
 - In your test suite, use `fhir_resource_validator` instead of `validator` and make sure it points to the hl7 wrapper. An easy place to do this is in the demo suite `dev_suites/dev_demo_ig_stu1/demo_suite.rb`:
```ruby
    fhir_resource_validator do
      url ENV.fetch('FHIR_RESOURCE_VALIDATOR_URL')
      exclude_message { |message| message.type == 'info' }
    end
```

I recommend adding one or two IGs to the ./igs folder, or change the env var in `.env` to point to someplace you have some IGs. When inferno starts up it will run the InvokeValidatorSession job and spin up a session in the validator. A couple options to confirm it worked as expected:
1. Print out the request being made to the service (`puts request_body` in `fhir_resource_validation.rb - call_validator` is a good spot)
2. Watch the logs of the hl7 validator service to make sure you see the appropriate IGs being loaded
