### PR TITLE
fi-2237 setting default validator url

### DIFF
--- a/dev_suites/dev_demo_ig_stu1/demo_suite.rb
+++ b/dev_suites/dev_demo_ig_stu1/demo_suite.rb
@@ -48,7 +48,6 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
     end
 
     validator do
-      url ENV.fetch('VALIDATOR_URL')
       exclude_message { |message| message.type == 'info' }
     end
 

--- a/lib/inferno/dsl/fhir_resource_validation.rb
+++ b/lib/inferno/dsl/fhir_resource_validation.rb
@@ -43,9 +43,9 @@ module Inferno
         # Set the url of the validator service
         #
         # @param validator_url [String]
-        def url(validator_url = default_validator_url)
+        def url(validator_url = nil)
           @url = validator_url if validator_url
-
+          @url ||= default_validator_url
           @url
         end
 

--- a/lib/inferno/dsl/fhir_resource_validation.rb
+++ b/lib/inferno/dsl/fhir_resource_validation.rb
@@ -43,7 +43,7 @@ module Inferno
         # Set the url of the validator service
         #
         # @param validator_url [String]
-        def url(validator_url = nil)
+        def url(validator_url = default_validator_url)
           @url = validator_url if validator_url
 
           @url

--- a/lib/inferno/dsl/fhir_validation.rb
+++ b/lib/inferno/dsl/fhir_validation.rb
@@ -58,9 +58,9 @@ module Inferno
         # Set the url of the validator service
         #
         # @param validator_url [String]
-        def url(validator_url = default_validator_url)
+        def url(validator_url = nil)
           @url = validator_url if validator_url
-
+          @url ||= default_validator_url
           @url
         end
 

--- a/lib/inferno/dsl/fhir_validation.rb
+++ b/lib/inferno/dsl/fhir_validation.rb
@@ -58,7 +58,7 @@ module Inferno
         # Set the url of the validator service
         #
         # @param validator_url [String]
-        def url(validator_url = nil)
+        def url(validator_url = default_validator_url)
           @url = validator_url if validator_url
 
           @url


### PR DESCRIPTION
# Summary

Set `validator` method to have the default url as the default parameter so that the url does not have to be explicitly declared in the test kits. 

