### PR TITLE
FI-2463 large request fix

### DIFF
--- a/lib/inferno/utils/middleware/request_logger.rb
+++ b/lib/inferno/utils/middleware/request_logger.rb
@@ -55,7 +55,14 @@ module Inferno
           path = env['REQUEST_URI']
           query = env['rack.request.query_string']
           body = env['rack.input']
-          body = body.instance_of?(Puma::NullIO) ? nil : body.string
+          body =
+            if body.instance_of? Puma::NullIO
+              nil
+            else
+              contents = body.read
+              body.rewind
+              contents
+            end
           query_string = query.blank? ? '' : "?#{query}"
 
           logger.info("#{method} #{scheme}://#{host}#{path}#{query_string}")


### PR DESCRIPTION
# Summary

Large payloads in the body of API calls cause the logger to break due to how puma handles very large payloads differently than smaller payloads when parsing.

# Testing Guidance

Ensure that important test kits (e.g. g10) still work properly.  Replicating large input payloads do not break is more challenging, ask team for an example.

