### PR TITLE
FI-2468: Enable different test results in resume_test_route

### DIFF
--- a/dev_suites/dev_demo_ig_stu1/demo_suite.rb
+++ b/dev_suites/dev_demo_ig_stu1/demo_suite.rb
@@ -52,7 +52,11 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
     end
 
     config options: {
-      wait_test_url: "#{Inferno::Application['base_url']}/custom/demo/resume"
+      wait_test_url: "#{Inferno::Application['base_url']}/custom/demo/resume",
+      wait_test_fail_url: "#{Inferno::Application['base_url']}/custom/demo/resume_fail",
+      wait_test_skip_url: "#{Inferno::Application['base_url']}/custom/demo/resume_skip",
+      wait_test_omit_url: "#{Inferno::Application['base_url']}/custom/demo/resume_omit",
+      wait_test_cancel_url: "#{Inferno::Application['base_url']}/custom/demo/resume_cancel"
     }
 
     group do
@@ -124,6 +128,22 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
         request.query_parameters['xyz']
       end
 
+      resume_test_route :get, '/resume_fail', result: 'fail' do |request|
+        request.query_parameters['xyz']
+      end
+
+      resume_test_route :get, '/resume_skip', result: 'skip' do |request|
+        request.query_parameters['xyz']
+      end
+
+      resume_test_route :get, '/resume_omit', result: 'omit' do |request|
+        request.query_parameters['xyz']
+      end
+
+      resume_test_route :get, '/resume_cancel', result: 'cancel' do |request|
+        request.query_parameters['xyz']
+      end
+
       test do
         title 'Pass test'
         run { pass }
@@ -137,8 +157,27 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
           wait(
             identifier: 'abc',
             message: %(
-              [Follow this link to proceed](#{config.options[:wait_test_url]}?xyz=abc).
-              Waiting to receive a request at ```#{config.options[:wait_test_url]}?xyz=abc```.
+              [Follow this link to pass the test and proceed](#{config.options[:wait_test_url]}?xyz=abc).
+
+              [Follow this link to fail the test and proceed](#{config.options[:wait_test_fail_url]}?xyz=abc).
+
+              [Follow this link to skip the test and proceed](#{config.options[:wait_test_skip_url]}?xyz=abc).
+
+              [Follow this link to omit the test and proceed](#{config.options[:wait_test_omit_url]}?xyz=abc).
+
+              [Follow this link to cancel the test and proceed](#{config.options[:wait_test_cancel_url]}?xyz=abc).
+
+              Waiting to receive a request at one of:
+
+              ```#{config.options[:wait_test_url]}?xyz=abc```,
+
+              ```#{config.options[:wait_test_fail_url]}?xyz=abc```,
+
+              ```#{config.options[:wait_test_skip_url]}?xyz=abc```,
+
+              ```#{config.options[:wait_test_omit_url]}?xyz=abc```,
+
+              ```#{config.options[:wait_test_cancel_url]}?xyz=abc```.
             )
           )
         end

--- a/docs/advanced-test-features/waiting-for-requests.md
+++ b/docs/advanced-test-features/waiting-for-requests.md
@@ -38,11 +38,15 @@ docs](/inferno-core/docs/Inferno/DSL/Results.html#wait-instance_method)
 ### Handling the Incoming Request
 The route to make a test resume execution is created with
 [`resume_test_route`](/inferno-core/docs/Inferno/DSL/Runnable.html#resume_test_route-instance_method),
-which takes three arguments:
+which takes five arguments:
 * `method` - A symbol for the HTTP verb for the incoming request (`:get`,
   `:post`, etc.)
 * `path` - A string for the route path. The route will be served at
   `INFERNO_BASE/custom/SUITE_ID/CUSTOM_ROUTE_PATH`.
+* `tags` - An array of strings with which the incoming request will be tagged.
+* `result` - A string for the result of the test. Must be one of `'pass'`,
+  `'fail'`, `'skip'`, `'omit'`, or `'cancel'`
+  (see [Results](/inferno-core/writing-tests/assertions-and-results.html#results)). The default is `'pass'`.
 * A block which extracts `identifier` from the incoming request and returns it.
   In this block, `request` can be used to access a [`Request`
   object](/inferno-core/docs/Inferno/Entities/Request.html) which contains the

--- a/lib/inferno/apps/web/controllers/test_runs/destroy.rb
+++ b/lib/inferno/apps/web/controllers/test_runs/destroy.rb
@@ -21,7 +21,7 @@ module Inferno
 
             if test_run_is_waiting
               waiting_result = results_repo.find_waiting_result(test_run_id: test_run.id)
-              results_repo.cancel_waiting_result(waiting_result.id, 'Test cancelled by user')
+              results_repo.update_result(waiting_result.id, 'cancel', 'Test cancelled by user')
               Jobs.perform(Jobs::ResumeTestRun, test_run.id)
             end
 

--- a/lib/inferno/dsl/resume_test_route.rb
+++ b/lib/inferno/dsl/resume_test_route.rb
@@ -29,6 +29,11 @@ module Inferno
       end
 
       # @private
+      def result
+        self.class.singleton_class.instance_variable_get(:@result)
+      end
+
+      # @private
       def find_test_run(test_run_identifier)
         test_runs_repo.find_latest_waiting_by_identifier(test_run_identifier)
       end
@@ -40,7 +45,18 @@ module Inferno
 
       # @private
       def update_result(waiting_result)
-        results_repo.pass_waiting_result(waiting_result.id)
+        case result
+        when 'fail'
+          results_repo.fail_waiting_result(waiting_result.id)
+        when 'skip'
+          results_repo.skip_waiting_result(waiting_result.id)
+        when 'omit'
+          results_repo.omit_waiting_result(waiting_result.id)
+        when 'cancel'
+          results_repo.cancel_waiting_result(waiting_result.id)
+        else
+          results_repo.pass_waiting_result(waiting_result.id)
+        end
       end
 
       # @private

--- a/lib/inferno/dsl/resume_test_route.rb
+++ b/lib/inferno/dsl/resume_test_route.rb
@@ -45,18 +45,7 @@ module Inferno
 
       # @private
       def update_result(waiting_result)
-        case result
-        when 'fail'
-          results_repo.fail_waiting_result(waiting_result.id)
-        when 'skip'
-          results_repo.skip_waiting_result(waiting_result.id)
-        when 'omit'
-          results_repo.omit_waiting_result(waiting_result.id)
-        when 'cancel'
-          results_repo.cancel_waiting_result(waiting_result.id)
-        else
-          results_repo.pass_waiting_result(waiting_result.id)
-        end
+        results_repo.update_result(waiting_result.id, result)
       end
 
       # @private

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -342,16 +342,19 @@ module Inferno
       #   Router](https://github.com/hanami/router/tree/f41001d4c3ee9e2d2c7bb142f74b43f8e1d3a265#a-beautiful-dsl)
       #   can be used here.
       # @param tags [Array<String>] a list of tags to assign to the request
+      # @param result [String] the result for the waiting test. Must be one of:
+      #   'pass', 'fail', 'skip', 'omit', 'cancel'
       # @yield This method takes a block which must return the identifier
       #   defined when a test was set to wait for the test run that hit this
       #   route. The block has access to the `request` method which returns a
       #   {Inferno::Entities::Request} object with the information for the
       #   incoming request.
       # @return [void]
-      def resume_test_route(method, path, tags: [], &block)
+      def resume_test_route(method, path, tags: [], result: 'pass', &block)
         route_class = Class.new(ResumeTestRoute) do |klass|
           klass.singleton_class.instance_variable_set(:@test_run_identifier_block, block)
           klass.singleton_class.instance_variable_set(:@tags, tags)
+          klass.singleton_class.instance_variable_set(:@result, result)
         end
 
         route(method, path, route_class)

--- a/lib/inferno/repositories/results.rb
+++ b/lib/inferno/repositories/results.rb
@@ -140,6 +140,18 @@ module Inferno
         update(result_id, result: 'pass', result_message: message)
       end
 
+      def fail_waiting_result(result_id, message = nil)
+        update(result_id, result: 'fail', result_message: message)
+      end
+
+      def skip_waiting_result(result_id, message = nil)
+        update(result_id, result: 'skip', result_message: message)
+      end
+
+      def omit_waiting_result(result_id, message = nil)
+        update(result_id, result: 'omit', result_message: message)
+      end
+
       def cancel_waiting_result(result_id, message = nil)
         update(result_id, result: 'cancel', result_message: message)
       end

--- a/lib/inferno/repositories/results.rb
+++ b/lib/inferno/repositories/results.rb
@@ -136,24 +136,8 @@ module Inferno
           end
       end
 
-      def pass_waiting_result(result_id, message = nil)
-        update(result_id, result: 'pass', result_message: message)
-      end
-
-      def fail_waiting_result(result_id, message = nil)
-        update(result_id, result: 'fail', result_message: message)
-      end
-
-      def skip_waiting_result(result_id, message = nil)
-        update(result_id, result: 'skip', result_message: message)
-      end
-
-      def omit_waiting_result(result_id, message = nil)
-        update(result_id, result: 'omit', result_message: message)
-      end
-
-      def cancel_waiting_result(result_id, message = nil)
-        update(result_id, result: 'cancel', result_message: message)
+      def update_result(result_id, result, result_message = nil)
+        update(result_id, result:, result_message:)
       end
 
       def json_serializer_options

--- a/spec/inferno/dsl/runnable_spec.rb
+++ b/spec/inferno/dsl/runnable_spec.rb
@@ -75,6 +75,38 @@ RSpec.describe Inferno::DSL::Runnable do
 
         expect(updated_run.identifier).to be_nil
       end
+
+      it 'results in a fail when fail result is specified' do
+        get '/custom/demo/resume_fail?xyz=IDENTIFIER'
+
+        updated_result = Inferno::Repositories::Results.new.find(result.id)
+
+        expect(updated_result.result).to eq('fail')
+      end
+
+      it 'results in a skip when skip result is specified' do
+        get '/custom/demo/resume_skip?xyz=IDENTIFIER'
+
+        updated_result = Inferno::Repositories::Results.new.find(result.id)
+
+        expect(updated_result.result).to eq('skip')
+      end
+
+      it 'results in an omit when omit result is specified' do
+        get '/custom/demo/resume_omit?xyz=IDENTIFIER'
+
+        updated_result = Inferno::Repositories::Results.new.find(result.id)
+
+        expect(updated_result.result).to eq('omit')
+      end
+
+      it 'results in a cancel when cancel result is specified' do
+        get '/custom/demo/resume_cancel?xyz=IDENTIFIER'
+
+        updated_result = Inferno::Repositories::Results.new.find(result.id)
+
+        expect(updated_result.result).to eq('cancel')
+      end
     end
   end
 


### PR DESCRIPTION
# Summary
This allows different URLs to trigger different test results for a waiting test by adding keyword param `result` to `resume_test_route`.

# Testing Guidance
Run the demo suite Wait Group and test the various URLs.