### PR TITLE
FI-2337: add disableDefaultResourceFetcher to fhir_resource_validator.cliContext defaults

### DIFF
--- a/lib/inferno/dsl/fhir_resource_validation.rb
+++ b/lib/inferno/dsl/fhir_resource_validation.rb
@@ -313,7 +313,8 @@ module Inferno
         CLICONTEXT_DEFAULTS = {
           sv: '4.0.1',
           doNative: false,
-          extensions: ['any']
+          extensions: ['any'],
+          disableDefaultResourceFetcher: true
         }.freeze
 
         # @private

--- a/spec/inferno/dsl/fhir_resource_validation_spec.rb
+++ b/spec/inferno/dsl/fhir_resource_validation_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe Inferno::DSL::FHIRResourceValidation do
           sv: '4.0.1',
           doNative: false,
           extensions: ['any'],
+          disableDefaultResourceFetcher: true,
           profiles: [profile_url]
         },
         filesToValidate: [
@@ -224,6 +225,7 @@ RSpec.describe Inferno::DSL::FHIRResourceValidation do
           sv: '4.0.1',
           doNative: true,
           extensions: ['any'],
+          disableDefaultResourceFetcher: true,
           igs: ['hl7.fhir.us.core#3.1.1'],
           txServer: nil,
           displayWarnings: true,


### PR DESCRIPTION
# Summary
Adds the new HL7 validator wrapper cliContext setting `disableDefaultResourceFetcher` to our cliContext defaults. This depends on https://github.com/hapifhir/org.hl7.fhir.core/pull/1526 but can be merged in before that because the hl7 validator wrapper ignores any unrecognized options. (confirmed against the production instance at https://validator.fhir.org/ )

Full details on this setting are available on the ^ linked PR, but it prevents fetching of unknown profiles and extensions, for example when a resource reports a profile in `meta.profile` that is not part of the IG under test. The Inferno validator wrapper does not fetch these profiles so this setting makes the hl7 wrapper match the inferno wrapper in that regard.

# Testing Guidance
Here are the usual notes on using the hl7 validator wrapper:

 - enable the `hl7_validator_service` in `docker-compose.background.yml` and `nginx.background.conf`
 - In your test suite, use `fhir_resource_validator` instead of `validator` and make sure it points to the hl7 wrapper. An easy place to do this is in the demo suite `dev_suites/dev_demo_ig_stu1/demo_suite.rb`:
```ruby
    fhir_resource_validator do
      url ENV.fetch('FHIR_RESOURCE_VALIDATOR_URL')
      exclude_message { |message| message.type == 'info' }
    end
```

