### PR TITLE
Update new website link on old documentation site

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ layout: home
 title: Home
 nav_order: 1
 ---
-**We're updating this site!  Preview the new [Inferno Framework Home](https://inferno-framework.github.io/index_new.html) before we release it on February 13 and [let us know what you think](https://inferno-framework.github.io/inferno-core/overview.html#contact-the-inferno-team).**
+**The new [Inferno Framework Home](https://inferno-framework.github.io) is now released! Feel free to [let us know what you think](https://inferno-framework.github.io/inferno-core/overview.html#contact-the-inferno-team).**
 
 ----
 


### PR DESCRIPTION
# Summary

Google still returns the old documentation site which links to the new site at `/index_new.html` that's now a 404. I replaced the link with `https://inferno-framework.github.io` and changed the wording from "before we release it on February 13th."

Intuitively it feels nicer if it links to `/documentation` instead of `/`, but I kept it this way since its probably better for SEO.

I also didn't nit pick the wording or styling around it and maybe we could use a stronger depreciation notice or even a JavaScript redirect but I just wanted to get rid of the 404.  Feel free to close this if something like that is in the works (or I can start a new PR for that if we need it).

# Testing Guidance

Double check my markdown please. I'll use the link inevitably if this gets deployed.