### PR TITLE
FI-2562: Fix incorrect progress status on run buttons

### DIFF
--- a/client/src/components/TestSuite/TestSession.tsx
+++ b/client/src/components/TestSuite/TestSession.tsx
@@ -137,7 +137,11 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
 
       const runnableFromSelected = runnableMap.get(selectedRunnable);
       if (runnableFromSelected) setIsRunning(runnableFromSelected, false);
-      deleteRunnables();
+
+      // Delete runnable from storage when test run is done
+      const updatedRunnables = currentRunnables;
+      delete updatedRunnables[testSession.id];
+      setCurrentRunnables(updatedRunnables);
     }
   }, [testRun]);
 
@@ -242,13 +246,6 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
       result.requests[requestIndex] = request;
       setResultsMap(new Map(resultsMap));
     }
-  };
-
-  // Delete runnable from storage when test run is done
-  const deleteRunnables = () => {
-    const updatedRunnables = currentRunnables;
-    delete updatedRunnables[testSession.id];
-    setCurrentRunnables(updatedRunnables);
   };
 
   const runTests = (runnableType: RunnableType, runnableId: string) => {

--- a/client/src/components/TestSuite/TestSession.tsx
+++ b/client/src/components/TestSuite/TestSession.tsx
@@ -137,11 +137,7 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
 
       const runnableFromSelected = runnableMap.get(selectedRunnable);
       if (runnableFromSelected) setIsRunning(runnableFromSelected, false);
-
-      // Delete runnable from storage when test run is done
-      const updatedRunnables = currentRunnables;
-      delete updatedRunnables[testSession.id];
-      setCurrentRunnables(updatedRunnables);
+      deleteRunnables();
     }
   }, [testRun]);
 
@@ -175,7 +171,6 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
   const showInputsModal = (runnableType: RunnableType, runnableId: string, inputs: TestInput[]) => {
     setInputs(inputs);
     setRunnableType(runnableType);
-    setCurrentRunnables({ ...currentRunnables, [testSession.id]: runnableId });
     setInputModalVisible(true);
   };
 
@@ -249,6 +244,13 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
     }
   };
 
+  // Delete runnable from storage when test run is done
+  const deleteRunnables = () => {
+    const updatedRunnables = currentRunnables;
+    delete updatedRunnables[testSession.id];
+    setCurrentRunnables(updatedRunnables);
+  };
+
   const runTests = (runnableType: RunnableType, runnableId: string) => {
     const runnable = runnableMap.get(runnableId);
     runnable?.inputs?.forEach((input: TestInput) => {
@@ -271,6 +273,9 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
         if (testRun) {
           const runnable = runnableMap.get(runnableId);
           if (runnable) setIsRunning(runnable, true);
+          if (runnableId) {
+            setCurrentRunnables({ ...currentRunnables, [testSession.id]: runnableId });
+          }
           setTestRun(testRun);
           setTestRunId(testRun.id);
           setTestRunCancelled(false);
@@ -407,7 +412,7 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
             <InputsModal
               createTestRun={createTestRun}
               runnableType={runnableType}
-              runnableId={currentRunnables[testSession.id]}
+              runnableId={selectedRunnable}
               title={(runnableMap.get(selectedRunnable) as Runnable).title}
               inputInstructions={(runnableMap.get(selectedRunnable) as Runnable).input_instructions}
               inputs={inputs}

--- a/client/src/components/TestSuite/TestSession.tsx
+++ b/client/src/components/TestSuite/TestSession.tsx
@@ -270,9 +270,7 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
         if (testRun) {
           const runnable = runnableMap.get(runnableId);
           if (runnable) setIsRunning(runnable, true);
-          if (runnableId) {
-            setCurrentRunnables({ ...currentRunnables, [testSession.id]: runnableId });
-          }
+          setCurrentRunnables({ ...currentRunnables, [testSession.id]: runnableId });
           setTestRun(testRun);
           setTestRunId(testRun.id);
           setTestRunCancelled(false);


### PR DESCRIPTION
# Summary

When cancelling out of an inputs modal, the run button would be incorrectly marked as "In Progress". This should no longer be happening.

# Testing Guidance

Check this behavior, also click around while tests are running to make sure results/statuses don't get mixed up