### PR TITLE
FI-2567: Fix client instance variables

### DIFF
--- a/lib/inferno/dsl/fhir_client_builder.rb
+++ b/lib/inferno/dsl/fhir_client_builder.rb
@@ -90,7 +90,7 @@ module Inferno
 
       # @private
       def method_missing(name, *args, &)
-        return runnable.call(name, *args, &) if runnable.respond_to? name
+        return runnable.send(name, *args, &) if runnable.respond_to? name
 
         super
       end

--- a/lib/inferno/dsl/http_client_builder.rb
+++ b/lib/inferno/dsl/http_client_builder.rb
@@ -45,7 +45,7 @@ module Inferno
 
       # @private
       def method_missing(name, *args, &)
-        return runnable.call(name, *args, &) if runnable.respond_to? name
+        return runnable.send(name, *args, &) if runnable.respond_to? name
 
         super
       end

--- a/spec/inferno/dsl/fhir_client_spec.rb
+++ b/spec/inferno/dsl/fhir_client_spec.rb
@@ -39,6 +39,16 @@ RSpec.describe Inferno::DSL::FHIRClient do
   let(:default_client) { group.fhir_clients[:default] }
   let(:bundle) { FHIR::Bundle.new(type: 'history', entry: [{ resource: }]) }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
+  let(:test) do
+    Class.new(Inferno::Entities::Test) do
+      input :foo
+
+      fhir_client do
+        url 'http://www.example.com/fhir'
+        headers 'Authorization' => "Basic #{foo}"
+      end
+    end
+  end
   let(:boolean_parameter) do
     FHIR::Parameters::Parameter.new.tap do |param|
       param.name = 'PARAM_BOOL'
@@ -131,6 +141,20 @@ RSpec.describe Inferno::DSL::FHIRClient do
         expect do
           group.fhir_client
         end.to raise_error(SocketError, 'not a TCP error')
+      end
+    end
+
+    context 'with input references' do
+      it 'gets the input value from the runnable' do
+        runnable = test.new(inputs: { foo: 'BLAH' })
+        request =
+          stub_request(:get, "#{base_url}/Patient/1")
+            .with(headers: { 'Authorization' => "Basic BLAH" })
+            .to_return(status: 200, body: FHIR::Patient.new(id: 1).to_json)
+
+        runnable.fhir_read(:patient, '1')
+
+        expect(request).to have_been_made.once
       end
     end
   end

--- a/spec/inferno/dsl/fhir_client_spec.rb
+++ b/spec/inferno/dsl/fhir_client_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe Inferno::DSL::FHIRClient do
         runnable = test.new(inputs: { foo: 'BLAH' })
         request =
           stub_request(:get, "#{base_url}/Patient/1")
-            .with(headers: { 'Authorization' => "Basic BLAH" })
+            .with(headers: { 'Authorization' => 'Basic BLAH' })
             .to_return(status: 200, body: FHIR::Patient.new(id: 1).to_json)
 
         runnable.fhir_read(:patient, '1')

--- a/spec/inferno/dsl/http_client_spec.rb
+++ b/spec/inferno/dsl/http_client_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Inferno::DSL::HTTPClient do
         runnable = test.new(inputs: { foo: 'BLAH' })
         request =
           stub_request(:get, base_url)
-            .with(headers: { 'Authorization' => "Basic BLAH" })
+            .with(headers: { 'Authorization' => 'Basic BLAH' })
             .to_return(status: 200, body: FHIR::Patient.new(id: 1).to_json)
 
         runnable.get


### PR DESCRIPTION
# Summary
FHIR/HTTP clients were incorrectly using `call` instead of `send` when delegating methods to the runnable in which they are defined.

# Testing Guidance
The unit tests are adequate to demonstrate this failure. Check out `958ef0d28b431d2d01d7cb651d503182b2e8f37b` to see the tests fail.