### PR TITLE
Fi 2576 inferno new gemspec patch

### DIFF
--- a/inferno_core.gemspec
+++ b/inferno_core.gemspec
@@ -57,6 +57,7 @@ Gem::Specification.new do |spec|
     'LICENSE',
     Dir['lib/inferno/**/*.rb'],
     Dir['lib/inferno/**/*.erb'],
+    Dir['lib/inferno/apps/cli/templates/**/*']
     'bin/inferno',
     Dir['lib/inferno/public/*.png'],
     Dir['lib/inferno/public/*.ico'],

--- a/inferno_core.gemspec
+++ b/inferno_core.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |spec|
     'LICENSE',
     Dir['lib/inferno/**/*.rb'],
     Dir['lib/inferno/**/*.erb'],
-    Dir['lib/inferno/apps/cli/templates/**/*']
+    Dir['lib/inferno/apps/cli/templates/**/*'],
     'bin/inferno',
     Dir['lib/inferno/public/*.png'],
     Dir['lib/inferno/public/*.ico'],


### PR DESCRIPTION
# Summary

It turns out RubyGems wasn't shipping the inferno new templates, so `inferno new my_test_kit` wouldn't work on fresh installs.

You can download the gem from <https://rubygems.org/downloads/inferno_core-0.4.30.gem>, rename it to a .tgz file, extract the contents, and then extract data.tar.gz to verify this.

# Testing Guidance

I ran `npm run build && gem build inferno_core.gemspec` successfully, and then extracted the gem file to make sure lib/inferno/apps/cli/templates was there. However I'm not sure how to fully test this besides waiting for the next release of inferno_core.
