### PR TITLE
fix: id should be 36 char long

### DIFF
--- a/lib/inferno/repositories/validator_sessions.rb
+++ b/lib/inferno/repositories/validator_sessions.rb
@@ -27,7 +27,7 @@ module Inferno
                     suite_options:,
                     validator_name: }
         ).insert(
-          id: "#{validator_session_id}_#{validator_name}",
+          id: SecureRandom.uuid,
           validator_session_id:,
           test_suite_id:,
           validator_name:,


### PR DESCRIPTION
# Summary
The `id` column in the table is there just so the db is satisfied that there is a unique `id` pk. It is being replaced with a `SecureRandom.uuid` so that it has a consistent length that does not exceed 36 characters.
