### PR TITLE
have gemspec include dotfiles from lib/inferno/apps/cli/templates/

### DIFF
--- a/inferno_core.gemspec
+++ b/inferno_core.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |spec|
     'LICENSE',
     Dir['lib/inferno/**/*.rb'],
     Dir['lib/inferno/**/*.erb'],
-    Dir['lib/inferno/apps/cli/templates/**/*'],
+    Dir['lib/inferno/apps/cli/templates/**/{*,.*}'],
     'bin/inferno',
     Dir['lib/inferno/public/*.png'],
     Dir['lib/inferno/public/*.ico'],


### PR DESCRIPTION
# Summary

The line `Dir[lib/inferno/apps/cli/templates/**/*]` excludes all dotfiles from shipping to RubyGems, so it was missing .keep files and .env files. I'm now using `**/{*,.*}` to capture all dotfiles. Using `Dir.glob('**/*', File::FNM_DOTMATCH)` includes `.` and `..` files and I'm not sure how RubyGems will react to that. 

# Testing Guidance

1. `npm run build && gem build inferno_core.gemspec`
2. Move and extract the new gem
3. Run `bin/inferno new foo` 

The golden test will be when someone else pulls it from RubyGems and it works. In the meantime I'll keep tabs on it.