### PR TITLE
New template wording fix

### DIFF
--- a/lib/inferno/apps/cli/new.rb
+++ b/lib/inferno/apps/cli/new.rb
@@ -74,7 +74,7 @@ module Inferno
           load_igs
         end
 
-        say_unless_quiet "Created #{root_name} Inferno test kit!", :green
+        say_unless_quiet "Created #{root_name} Inferno Test Kit!", :green
 
         return unless options['pretend']
 

--- a/lib/inferno/apps/cli/templates/lib/%library_name%.rb.tt
+++ b/lib/inferno/apps/cli/templates/lib/%library_name%.rb.tt
@@ -4,7 +4,7 @@ module <%= module_name %>
   class Suite < Inferno::TestSuite
     id :<%= test_suite_id %>
     title '<%= title_name %> Test Suite'
-    description 'Inferno <%= human_name.downcase %> test suite for FHIR'
+    description '<%= human_name %> test suite for FHIR'
 
     # These inputs will be available to all tests in this suite
     input :url,

--- a/lib/inferno/apps/cli/templates/lib/%library_name%.rb.tt
+++ b/lib/inferno/apps/cli/templates/lib/%library_name%.rb.tt
@@ -4,7 +4,7 @@ module <%= module_name %>
   class Suite < Inferno::TestSuite
     id :<%= test_suite_id %>
     title '<%= title_name %> Test Suite'
-    description '<%= human_name %> test suite for FHIR'
+    description '<%= human_name %> test suite.'
 
     # These inputs will be available to all tests in this suite
     input :url,


### PR DESCRIPTION
# Summary

Fixes some wording in the Inferno template resulting from `inferno new ...`. See [this comment](https://github.com/inferno-framework/inferno-core/pull/439#issuecomment-2038229755).

# Testing Guidance

You can checkout this branch and the project folder run `bundle exec bin/inferno new my_kit` to run `inferno new` with the wording fixes. Contextless `inferno new` will only work after the next deploy.
