### PR TITLE
FI-2664: Prevent validator sessions from being created in test environment

### DIFF
--- a/lib/inferno/config/boot/validator.rb
+++ b/lib/inferno/config/boot/validator.rb
@@ -6,6 +6,8 @@ Inferno::Application.boot(:validator) do
     # so skipping it on workers will start it only once from the "web" process
     next if Sidekiq.server?
 
+    next if ENV['APP_ENV'] == 'test'
+
     Inferno::Repositories::TestSuites.new.all.each do |suite|
       suite.fhir_validators.each do |name, validators|
         validators.each_with_index do |validator, index|


### PR DESCRIPTION
This prevents validator sessions from being created in the test environment. The validator is not expected to be running during unit tests, so it will not be reachable. By default, the validator is going to be using a docker hostname, which causes a DNS error when trying to create a session, preventing unit tests from running in test kits which use the new validator. This happens when Inferno boots (i.e. prior to unit test execution), so this can't be handled by stubbing the requests.