### PR TITLE
FI-2554: Remove trailing slash

### DIFF
--- a/lib/inferno/dsl/fhir_client_builder.rb
+++ b/lib/inferno/dsl/fhir_client_builder.rb
@@ -48,7 +48,7 @@ module Inferno
             runnable.send(url)
           else
             url
-          end
+          end&.chomp('/')
       end
 
       # Define the bearer token for a client. A string or symbol can be provided.

--- a/spec/inferno/dsl/fhir_client_spec.rb
+++ b/spec/inferno/dsl/fhir_client_spec.rb
@@ -110,26 +110,6 @@ RSpec.describe Inferno::DSL::FHIRClient do
   end
 
   describe '#fhir_client' do
-    context 'without an argument' do
-      it 'returns the default FHIR client' do
-        expect(group.fhir_client).to eq(default_client)
-      end
-
-      it 'raises an error if no default FHIR client has been created'
-    end
-
-    context 'with an argument' do
-      it 'returns the specified FHIR client' do
-        name = :other_client
-        other_client = FHIR::Client.new('http://www.example.com/fhir/r4')
-        group.fhir_clients[name] = other_client
-
-        expect(group.fhir_client(name)).to eq(other_client)
-      end
-
-      it 'raises an error if the FHIR client is not known'
-    end
-
     context 'with a base url that causes a non-TCP error' do
       before do
         allow_any_instance_of(FHIR::Client)

--- a/spec/inferno/dsl/fhir_client_spec.rb
+++ b/spec/inferno/dsl/fhir_client_spec.rb
@@ -28,6 +28,10 @@ class FHIRClientDSLTestClass
       )
     )
   end
+
+  fhir_client :client_with_trailing_slash do
+    url 'http://www.example.com/fhir/'
+  end
 end
 
 RSpec.describe Inferno::DSL::FHIRClient do
@@ -137,6 +141,20 @@ RSpec.describe Inferno::DSL::FHIRClient do
         expect(request).to have_been_made.once
       end
     end
+
+    context 'with a base_url with a trailing slash' do
+      it 'strips the trailing slash' do
+        runnable = FHIRClientDSLTestClass.new
+
+        request =
+          stub_request(:get, "#{base_url}/Patient/1")
+            .to_return(status: 200, body: FHIR::Patient.new(id: 1).to_json)
+
+        runnable.fhir_read(:patient, '1', client: :client_with_trailing_slash)
+
+        expect(request).to have_been_made.once
+      end
+    end
   end
 
   describe '#body_to_path' do
@@ -185,6 +203,20 @@ RSpec.describe Inferno::DSL::FHIRClient do
 
       expect(group.requests).to include(result)
       expect(group.request).to eq(result)
+    end
+
+    context 'with a url with a trailing slash' do
+      it 'performs a post without the trailing slash' do
+        group.fhir_operation(path, client: :client_with_trailing_slash)
+
+        expect(stub_operation_request).to have_been_made.once
+      end
+
+      it 'performs a get without the trailing slash' do
+        group.fhir_operation(path, operation_method: :get, client: :client_with_trailing_slash)
+
+        expect(stub_operation_get_request).to have_been_made.once
+      end
     end
 
     context 'with a body of parameters' do

--- a/spec/inferno/dsl/http_client_spec.rb
+++ b/spec/inferno/dsl/http_client_spec.rb
@@ -58,8 +58,6 @@ RSpec.describe Inferno::DSL::HTTPClient do
       it 'returns the default HTTP client' do
         expect(group.http_client).to eq(default_client)
       end
-
-      it 'raises an error if no default HTTP client has been created'
     end
 
     context 'with an argument' do
@@ -69,8 +67,6 @@ RSpec.describe Inferno::DSL::HTTPClient do
 
         expect(group.http_client(name)).to eq(other_client)
       end
-
-      it 'raises an error if the HTTP client is not known'
     end
 
     context 'with a base url that causes a TCP error' do

--- a/spec/inferno/dsl/http_client_spec.rb
+++ b/spec/inferno/dsl/http_client_spec.rb
@@ -8,6 +8,10 @@ class HTTPClientDSLTestClass
   def test_session_id
     nil
   end
+
+  http_client :client_with_trailing_slash do
+    url 'http://www.example.com/'
+  end
 end
 
 RSpec.describe Inferno::DSL::HTTPClient do
@@ -349,6 +353,19 @@ RSpec.describe Inferno::DSL::HTTPClient do
         expect(request.url).to eq(new_url)
         expect(request.status).to eq(200)
         expect(request.response_body).to eq('BODY')
+      end
+    end
+
+    context 'with a base url with a trailing slash' do
+      it 'does not include an extra slash in requests' do
+        path = '/abc'
+        stubbed_request =
+          stub_request(:get, "#{base_url}#{path}")
+            .to_return(status: 200, body: response_body, headers: {})
+
+        group.get(path, client: :client_with_trailing_slash)
+
+        expect(stubbed_request).to have_been_made.once
       end
     end
   end


### PR DESCRIPTION
# Summary
This branch fixes FHIR operations to avoid double slashes when the base url includes a trailing slash. It was not an issue with the other FHIR interactions or with http client methods.