### PR TITLE
Release v0.4.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 0.4.35
+
+* Bump follow-redirects from 1.15.5 to 1.15.6 by @dependabot in https://github.com/inferno-framework/inferno-core/pull/479
+* Bump express from 4.18.3 to 4.19.2 by @dependabot in https://github.com/inferno-framework/inferno-core/pull/480
+* Bump webpack-dev-middleware from 5.3.3 to 5.3.4 by @dependabot in https://github.com/inferno-framework/inferno-core/pull/481
+* Bump vite by @dependabot in https://github.com/inferno-framework/inferno-core/pull/482
+* Add note about replication error to DB docs by @dehall in https://github.com/inferno-framework/inferno-core/pull/484
+* FI-2554: Remove trailing slash by @Jammjammjamm in https://github.com/inferno-framework/inferno-core/pull/485
+* FI-2539: Add JSON and YAML file input options by @AlyssaWang in https://github.com/inferno-framework/inferno-core/pull/466
+* FI-2538: Create new docs 404 page by @AlyssaWang in https://github.com/inferno-framework/inferno-core/pull/486
+* FI-2540: Make input label sizes consistent by @AlyssaWang in https://github.com/inferno-framework/inferno-core/pull/469
+* FI-2608: Update ctrl + enter run test hotkey by @AlyssaWang in https://github.com/inferno-framework/inferno-core/pull/483
+
 # 0.4.34
 * New template wording fix by @Shaumik-Ashraf in https://github.com/inferno-framework/inferno-core/pull/475
 * Fi 2432 Sync Inferno Template by @Shaumik-Ashraf in https://github.com/inferno-framework/inferno-core/pull/439

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    inferno_core (0.4.34)
+    inferno_core (0.4.35)
       activesupport (~> 6.1.7.5)
       base62-rb (= 0.3.1)
       blueprinter (= 0.25.2)
@@ -45,6 +45,7 @@ GEM
     base64 (0.2.0)
     bcp47 (0.3.3)
       i18n
+    bigdecimal (3.1.7)
     blueprinter (0.25.2)
     byebug (11.1.3)
     codecov (0.5.2)
@@ -185,7 +186,8 @@ GEM
     mime-types-data (3.2024.0305)
     minitest (5.18.0)
     multi_json (1.15.0)
-    multi_xml (0.6.0)
+    multi_xml (0.7.1)
+      bigdecimal (~> 3.1)
     multipart-post (2.4.0)
     mustermann (1.1.2)
       ruby2_keywords (~> 0.0.1)
@@ -194,11 +196,11 @@ GEM
       mustermann (= 1.1.2)
     netrc (0.11.0)
     nio4r (2.7.1)
-    nokogiri (1.16.3-arm64-darwin)
+    nokogiri (1.16.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.3-x86_64-darwin)
+    nokogiri (1.16.4-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.3-x86_64-linux)
+    nokogiri (1.16.4-x86_64-linux)
       racc (~> 1.4)
     oauth2 (1.4.11)
       faraday (>= 0.17.3, < 3.0)

--- a/lib/inferno/version.rb
+++ b/lib/inferno/version.rb
@@ -1,4 +1,4 @@
 module Inferno
   # Standard patterns for gem versions: https://guides.rubygems.org/patterns/
-  VERSION = '0.4.34'.freeze
+  VERSION = '0.4.35'.freeze
 end


### PR DESCRIPTION
* Bump follow-redirects from 1.15.5 to 1.15.6 by @dependabot in https://github.com/inferno-framework/inferno-core/pull/479
* Bump express from 4.18.3 to 4.19.2 by @dependabot in https://github.com/inferno-framework/inferno-core/pull/480
* Bump webpack-dev-middleware from 5.3.3 to 5.3.4 by @dependabot in https://github.com/inferno-framework/inferno-core/pull/481
* Bump vite by @dependabot in https://github.com/inferno-framework/inferno-core/pull/482
* Add note about replication error to DB docs by @dehall in https://github.com/inferno-framework/inferno-core/pull/484
* FI-2554: Remove trailing slash by @Jammjammjamm in https://github.com/inferno-framework/inferno-core/pull/485
* FI-2539: Add JSON and YAML file input options by @AlyssaWang in https://github.com/inferno-framework/inferno-core/pull/466
* FI-2538: Create new docs 404 page by @AlyssaWang in https://github.com/inferno-framework/inferno-core/pull/486
* FI-2540: Make input label sizes consistent by @AlyssaWang in https://github.com/inferno-framework/inferno-core/pull/469
* FI-2608: Update ctrl + enter run test hotkey by @AlyssaWang in https://github.com/inferno-framework/inferno-core/pull/483