### PR TITLE
FI-2688: Migrate template to HL7 validator wrapper

### DIFF
--- a/lib/inferno/apps/cli/templates/.env.development
+++ b/lib/inferno/apps/cli/templates/.env.development
@@ -1,2 +1,2 @@
-VALIDATOR_URL=http://localhost/validatorapi
+FHIR_RESOURCE_VALIDATOR_URL=http://localhost/hl7validatorapi
 REDIS_URL=redis://localhost:6379/0

--- a/lib/inferno/apps/cli/templates/.env.production
+++ b/lib/inferno/apps/cli/templates/.env.production
@@ -1,2 +1,2 @@
 REDIS_URL=redis://redis:6379/0
-VALIDATOR_URL=http://validator_service:4567
+FHIR_RESOURCE_VALIDATOR_URL=http://hl7_validator_service:3500

--- a/lib/inferno/apps/cli/templates/.env.test
+++ b/lib/inferno/apps/cli/templates/.env.test
@@ -1,2 +1,2 @@
-VALIDATOR_URL=https://example.com/validatorapi
+FHIR_RESOURCE_VALIDATOR_URL=https://example.com/validatorapi
 ASYNC_JOBS=false

--- a/lib/inferno/apps/cli/templates/config/nginx.background.conf.tt
+++ b/lib/inferno/apps/cli/templates/config/nginx.background.conf.tt
@@ -82,5 +82,21 @@ http {
 
       proxy_pass http://validator_service:4567/;
     }
+
+    location /hl7validatorapi/ {
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Port $server_port;
+      proxy_redirect off;
+      proxy_set_header Connection '';
+      proxy_http_version 1.1;
+      chunked_transfer_encoding off;
+      proxy_buffering off;
+      proxy_cache off;
+      proxy_read_timeout 600s;
+
+      proxy_pass http://hl7_validator_service:3500/;
+    }
   }
 }

--- a/lib/inferno/apps/cli/templates/config/nginx.conf.tt
+++ b/lib/inferno/apps/cli/templates/config/nginx.conf.tt
@@ -97,5 +97,21 @@ http {
 
       proxy_pass http://validator_service:4567/;
     }
+
+    location /hl7validatorapi/ {
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Port $server_port;
+      proxy_redirect off;
+      proxy_set_header Connection '';
+      proxy_http_version 1.1;
+      chunked_transfer_encoding off;
+      proxy_buffering off;
+      proxy_cache off;
+      proxy_read_timeout 600s;
+
+      proxy_pass http://hl7_validator_service:3500/;
+    }
   }
 }

--- a/lib/inferno/apps/cli/templates/docker-compose.background.yml.tt
+++ b/lib/inferno/apps/cli/templates/docker-compose.background.yml.tt
@@ -1,5 +1,16 @@
 version: '3'
 services:
+  hl7_validator_service:
+    image: infernocommunity/inferno-resource-validator
+    environment:
+      # Defines how long validator sessions last if unused, in minutes:
+      # Negative values mean sessions never expire, 0 means sessions immediately expire
+      SESSION_CACHE_DURATION: -1
+    volumes:
+      - ./<%= ig_path %>:/app/igs
+      # To let the service share your local FHIR package cache,
+      # uncomment the below line
+      # - ~/.fhir:/home/ktor/.fhir
   validator_service:
     image: infernocommunity/fhir-validator-service
     # Update this path to match your directory structure

--- a/lib/inferno/apps/cli/templates/docker-compose.yml.tt
+++ b/lib/inferno/apps/cli/templates/docker-compose.yml.tt
@@ -15,6 +15,10 @@ services:
     command: bundle exec sidekiq -r ./worker.rb
     depends_on:
       - redis
+  hl7_validator_service:
+    extends:
+      file: docker-compose.background.yml
+      service: hl7_validator_service
   validator_service:
     extends:
       file: docker-compose.background.yml

--- a/lib/inferno/apps/cli/templates/lib/%library_name%.rb.tt
+++ b/lib/inferno/apps/cli/templates/lib/%library_name%.rb.tt
@@ -22,8 +22,13 @@ module <%= module_name %>
     end
 
     # All FHIR validation requsets will use this FHIR validator
-    validator do
-      url ENV.fetch('VALIDATOR_URL')
+    fhir_resource_validator do
+      # igs 'identifier#version' # Use this method for published IGs/versions
+      # igs 'igs/filename.tgz'   # Use this otherwise
+
+      exclude_message do |message|
+        message.message.match?(/\A\S+: \S+: URL value '.*' does not resolve/)
+      end
     end
 
     # Tests and TestGroups can be defined inline

--- a/lib/inferno/apps/cli/templates/lib/%library_name%/igs/README.md
+++ b/lib/inferno/apps/cli/templates/lib/%library_name%/igs/README.md
@@ -1,0 +1,21 @@
+# Note on this IGs folder
+
+There are three reasons why it would be necessary to put an IG package.tgz in this folder. If none of these apply, you do not need to put any files here, or can consider removing any existing files to make it clear they are unused.
+
+## 1. Generated Test Suites
+Some test kits use a "generator" to automatically generate the contents of a test suite for an IG. The IG files are required every time the test suites need to be regenerated. Examples of test kits that use this approach are the US Core Test Kit and CARIN IG for Blue Button® Test Kit.
+
+
+## 2. Non-published IG
+If your IG, or the specific version of the IG you want to test against, is not published, then the validator service needs to load the IG from file in order to be able to validate resources with it. The IG must be referenced in the `fhir_resource_validator` block in the test suite definition by filename, ie:
+
+```ruby
+      fhir_resource_validator do
+        igs 'igs/filename.tgz'
+
+        ...
+      end
+```
+
+## 3. Inferno Validator UI
+The Inferno Validator UI is configured to auto-load any IGs present in the igs folder and include them in all validations. In general, the Inferno team is currently leaving IGs in this folder even if not otherwise necessary to make it easy to re-enable the validator UI.

--- a/lib/inferno/apps/cli/templates/spec/%library_name%/patient_group_spec.rb.tt
+++ b/lib/inferno/apps/cli/templates/spec/%library_name%/patient_group_spec.rb.tt
@@ -4,7 +4,26 @@ RSpec.describe <%= module_name %>::PatientGroup do
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:test_session) { repo_create(:test_session, test_suite_id: '<%= test_suite_id %>') }
   let(:url) { 'http://example.com/fhir' }
-  let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
+  let(:success_outcome) do
+    {
+      outcomes: [{
+        issues: []
+      }],
+      sessionId: ''
+    }
+  end
+  let(:error_outcome) do
+    {
+      outcomes: [{
+        issues: [{
+          location: 'Patient.identifier[0]',
+          message: 'Identifier.system must be an absolute reference, not a local reference',
+          level: 'ERROR'
+        }]
+      }],
+      sessionId: ''
+    }
+  end
 
   def run(runnable, inputs = {})
     test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
@@ -67,9 +86,9 @@ RSpec.describe <%= module_name %>::PatientGroup do
     let(:test) { group.tests.last }
 
     it 'passes if the resource is valid' do
-      stub_request(:post, "#{ENV.fetch('VALIDATOR_URL')}/validate")
+      stub_request(:post, "#{ENV.fetch('FHIR_RESOURCE_VALIDATOR_URL')}/validate")
         .with(query: hash_including({}))
-        .to_return(status: 200, body: FHIR::OperationOutcome.new.to_json)
+        .to_return(status: 200, body: success_outcome.to_json)
 
       resource = FHIR::Patient.new
       repo_create(
@@ -79,13 +98,13 @@ RSpec.describe <%= module_name %>::PatientGroup do
         response_body: resource.to_json
       )
 
-      result = run(test)
+      result = run(test, url: url)
 
       expect(result.result).to eq('pass')
     end
 
     it 'fails if the resource is not valid' do
-      stub_request(:post, "#{ENV.fetch('VALIDATOR_URL')}/validate")
+      stub_request(:post, "#{ENV.fetch('FHIR_RESOURCE_VALIDATOR_URL')}/validate")
         .with(query: hash_including({}))
         .to_return(status: 200, body: error_outcome.to_json)
 
@@ -97,7 +116,7 @@ RSpec.describe <%= module_name %>::PatientGroup do
         response_body: resource.to_json
       )
 
-      result = run(test)
+      result = run(test, url: url)
 
       expect(result.result).to eq('fail')
     end


### PR DESCRIPTION
# Summary
Update the "inferno new" template to use the HL7 validator wrapper, as in all of our test kits. One notable difference here is the inferno validator-wrapper and validator UI are not commented out, they are left as-is, so this is mostly just addition other than changing the test suite validator block to `fhir_resource_validator`.

Corresponding changes to the docs are at: https://github.com/inferno-framework/inferno-framework.github.io/pull/32

# Testing Guidance
Re-generate the template with `bundle exec inferno new inferno-template --author "Inferno Template"` and it will be in `./inferno-template`
Sample patient tests should pass, the validator UI should still work as well at http://localhost/validator/ .
YAML to run against reference server:

```yml
- name: url
  title: FHIR Server Base Url
  type: text
  value: https://inferno.healthit.gov/reference-server/r4
- name: credentials
  optional: true
  title: OAuth Credentials
  type: oauth_credentials
  value:
    access_token: SAMPLE_TOKEN
    refresh_token: ''
    expires_in: ''
    client_id: ''
    client_secret: ''
    token_url: ''
- name: patient_id
  title: Patient ID
  type: text
  value: '85'
```