### PR TITLE
FI-2754: Add lines count to request details

### DIFF
--- a/client/src/components/RequestDetailModal/CodeBlock.tsx
+++ b/client/src/components/RequestDetailModal/CodeBlock.tsx
@@ -25,11 +25,14 @@ const CodeBlock: FC<CodeBlockProps> = ({ body, headers, title }) => {
     }
   });
 
+  const bodyLength = body?.split('\n').length || 0;
+  const fullTitle = `${title || 'Code'} (${bodyLength} line${bodyLength === 1 ? '' : 's'})`;
+
   if (body && body.length > 0) {
     return (
       <Card variant="outlined" className={classes.codeblock} data-testid="code-block">
         <CardHeader
-          title={title || 'Code'}
+          title={fullTitle}
           titleTypographyProps={{ sx: { fontSize: 20, cursor: 'pointer' } }}
           action={
             <Box display="flex">


### PR DESCRIPTION
# Summary

Adds LOC to the request details modal header.

<img src="https://github.com/inferno-framework/inferno-core/assets/11209247/0131e1ca-b6f1-45e4-8efa-7adbcddd412a" width="700">

# Testing Guidance

Check that LOC appears in request details modal.