### PR TITLE
FI-2753: Add hover effect to request details

### DIFF
--- a/client/src/components/RequestDetailModal/CodeBlock.tsx
+++ b/client/src/components/RequestDetailModal/CodeBlock.tsx
@@ -7,6 +7,7 @@ import CopyButton from '~/components/_common/CopyButton';
 
 import { formatBodyIfJSON } from './helpers';
 import useStyles from './styles';
+import lightTheme from '~/styles/theme';
 
 export interface CodeBlockProps {
   body?: string | null;
@@ -27,10 +28,10 @@ const CodeBlock: FC<CodeBlockProps> = ({ body, headers, title }) => {
 
   if (body && body.length > 0) {
     return (
-      <Card variant="outlined" className={classes.codeblock} data-testid="code-block">
+      <Card variant="outlined" className={classes.codeBlock} data-testid="code-block">
         <CardHeader
           title={title || 'Code'}
-          titleTypographyProps={{ sx: { fontSize: 20, cursor: 'pointer' } }}
+          titleTypographyProps={{ sx: { fontSize: 20 } }}
           action={
             <Box display="flex">
               <CopyButton copyText={jsonBody} />
@@ -38,6 +39,10 @@ const CodeBlock: FC<CodeBlockProps> = ({ body, headers, title }) => {
             </Box>
           }
           onClick={() => setCollapsed(!collapsed)}
+          className={classes.codeBlockHeader}
+          sx={{
+            backgroundColor: collapsed ? 'unset' : lightTheme.palette.common.blueLightest,
+          }}
         />
         <Collapse in={!collapsed}>
           <Divider />

--- a/client/src/components/RequestDetailModal/styles.tsx
+++ b/client/src/components/RequestDetailModal/styles.tsx
@@ -1,5 +1,6 @@
 import { Theme } from '@mui/material/styles';
 import { makeStyles } from 'tss-react/mui';
+import lightTheme from '~/styles/theme';
 
 export default makeStyles()((_theme: Theme) => ({
   modalTitle: {
@@ -17,10 +18,16 @@ export default makeStyles()((_theme: Theme) => ({
   headerName: {
     fontWeight: 600,
   },
-  codeblock: {
+  codeBlock: {
     overflow: 'auto',
     fontSize: 'small',
     marginTop: '16px',
+  },
+  codeBlockHeader: {
+    cursor: 'pointer',
+    ':hover': {
+      backgroundColor: lightTheme.palette.common.blueLightest,
+    },
   },
   code: {
     textWrap: 'wrap',


### PR DESCRIPTION
# Summary

Change color of code block header on hover in the request details modal.

<img src="https://github.com/inferno-framework/inferno-core/assets/11209247/6d7539cf-d5a4-450a-acea-8c98ba831abc" width="600">

# Testing Guidance

Check that hover effect appears, header should maintain effect while accordion is open. 

Q: Should test list items also have this effect?