### PR TITLE
FI-2765: Automatically run migrations

### DIFF
--- a/lib/inferno/apps/cli/main.rb
+++ b/lib/inferno/apps/cli/main.rb
@@ -11,6 +11,7 @@ module Inferno
     class Main < Thor
       desc 'console', 'Start an interactive console session with Inferno'
       def console
+        Migration.new.run(Logger::INFO)
         Console.new.run
       end
 
@@ -25,6 +26,7 @@ module Inferno
              type: :boolean,
              desc: 'Automatically restart Inferno when a file is changed.'
       def start
+        Migration.new.run(Logger::INFO)
         command = 'foreman start --env=/dev/null'
         if `gem list -i foreman`.chomp == 'false'
           puts "You must install foreman with 'gem install foreman' prior to running Inferno."

--- a/lib/inferno/apps/cli/migration.rb
+++ b/lib/inferno/apps/cli/migration.rb
@@ -3,9 +3,9 @@ require_relative '../../utils/migration'
 module Inferno
   module CLI
     class Migration
-      def run
+      def run(log_level = Logger::DEBUG)
         Inferno::Application.start(:logging)
-        Inferno::Application['logger'].level = Logger::DEBUG
+        Inferno::Application['logger'].level = log_level
 
         Utils::Migration.new.run
       end


### PR DESCRIPTION
# Summary
Automatically run migrations when using `inferno start` or `inferno console`.

# Testing Guidance
Delete `data/inferno_development.db`, then run `bin/inferno start`. The migrations should run and inferno should start.