### PR TITLE
FI-2791: Revert resume test route refactor

### DIFF
--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -343,7 +343,7 @@ module Inferno
         route_class = Class.new(ResumeTestRoute) do |klass|
           klass.singleton_class.instance_variable_set(:@test_run_identifier_block, block)
           klass.singleton_class.instance_variable_set(:@tags, tags)
-          klass.singleton_class.instance_variable_set(:@new_result, result)
+          klass.singleton_class.instance_variable_set(:@result, result)
         end
 
         route(method, path, route_class)

--- a/lib/inferno/dsl/suite_endpoint.rb
+++ b/lib/inferno/dsl/suite_endpoint.rb
@@ -244,7 +244,7 @@ module Inferno
 
       # @private
       def resume_test_run?
-        find_result&.result != 'waiting'
+        find_result&.result != 'wait'
       end
 
       # @private


### PR DESCRIPTION
# Summary
When there are multiple consecutive wait tests, there is a race condition which can put Inferno into a state where it fails to resume the test run. This branch reverts `resume_test_route` to no longer be based on suite endpoints which should prevent Inferno from getting into that bad state.

# Testing Guidance
Locally in the PAS test kit, run `bundle update inferno_core`, which should bump core to `0.4.37`. In the client suite, run the `Demonstrate Workflow Support` group, which should end up in a bad state:

![Screenshot 2024-05-30 at 9 39 09 AM](https://github.com/inferno-framework/inferno-core/assets/15969967/c671901f-f599-4dd9-a713-0fac31ce5d62)

This change was released as `0.4.37.dev` so that we could use it in the connectathon. If you set core's version to `0.4.37.dev` in the PAS test kit, or run the same tests on QA, they should no longer hang at this point.