### PR TITLE
FI-2745: Skip loading validator sessions when using inferno console

### DIFF
--- a/.env
+++ b/.env
@@ -29,3 +29,7 @@ FHIR_RESOURCE_VALIDATOR_URL=http://localhost/hl7validatorapi
 # creation in the validator is not completely thread safe, so values greater
 # than 1 could cause issues.
 # VALIDATOR_SESSIONS_CONCURRENCY=1
+
+# Set to false to skip initializing validator sessions in the hl7 validator
+# service.
+# INITIALIZE_VALIDATOR_SESSIONS=false

--- a/lib/inferno/apps/cli/console.rb
+++ b/lib/inferno/apps/cli/console.rb
@@ -4,6 +4,9 @@ module Inferno
       def run
         require_relative '../../../inferno'
 
+        ENV['ASYNC_JOBS'] = 'false'
+        ENV['INITIALIZE_VALIDATOR_SESSIONS'] = 'false'
+
         Inferno::Application.finalize!
         Pry.start
       end

--- a/lib/inferno/config/boot/validator.rb
+++ b/lib/inferno/config/boot/validator.rb
@@ -8,6 +8,8 @@ Inferno::Application.register_provider(:validator) do
 
     next if ENV['APP_ENV'] == 'test'
 
+    next if ENV.fetch('INITIALIZE_VALIDATOR_SESSIONS', 'true').casecmp?('false')
+
     Inferno::Repositories::TestSuites.new.all.each do |suite|
       suite.fhir_validators.each do |name, validators|
         validators.each_with_index do |validator, index|


### PR DESCRIPTION
# Summary
Creating validator sessions was breaking inferno console when the validator service wasn't running. This branch prevents inferno from initializing validator sessions when using the console.

# Testing Guidance
With no services running:
On main:
- Add the g10 tests following the instructions in the Gemfile
- Run `bundle exec inferno c` and it should fail
On this branch:
- Add the g10 tests following the instructions in the Gemfile
- Run `bundle exec inferno c` and it shouldn't fail