### PR TITLE
Make `bundle exec inferno start` work

### DIFF
--- a/lib/inferno/apps/cli/main.rb
+++ b/lib/inferno/apps/cli/main.rb
@@ -67,13 +67,16 @@ module Inferno
 
       private
 
-      def without_bundler
+      # https://github.com/rubocop/rubocop/issues/12571 - still affects Ruby 3.1 upto Rubocop 1.63
+      # rubocop:disable Naming/BlockForwarding
+      def without_bundler(&block)
         if defined?(Bundler) && ENV['BUNDLE_GEMFILE']
           Bundler.with_unbundled_env(&block)
         else
           yield
         end
       end
+      # rubocop:enable Naming/BlockForwarding
     end
   end
 end

--- a/lib/inferno/apps/cli/main.rb
+++ b/lib/inferno/apps/cli/main.rb
@@ -45,6 +45,8 @@ module Inferno
           Bundler.with_unbundled_env do
             exec command
           end
+        else
+          exec command
         end
       end
 

--- a/lib/inferno/apps/cli/main.rb
+++ b/lib/inferno/apps/cli/main.rb
@@ -67,16 +67,13 @@ module Inferno
 
       private
 
-      def without_bundler(&block)
+      def without_bundler
         if defined?(Bundler) && ENV['BUNDLE_GEMFILE']
-          Bundler.with_unbundled_env do
-            yield
-          end
+          Bundler.with_unbundled_env(&block)
         else
           yield
         end
       end
-
     end
   end
 end

--- a/lib/inferno/apps/cli/main.rb
+++ b/lib/inferno/apps/cli/main.rb
@@ -28,6 +28,7 @@ module Inferno
       def start
         Migration.new.run(Logger::INFO)
         command = 'foreman start --env=/dev/null'
+
         if `gem list -i foreman`.chomp == 'false'
           puts "You must install foreman with 'gem install foreman' prior to running Inferno."
         end
@@ -40,7 +41,11 @@ module Inferno
           command = "rerun \"#{command}\" --background"
         end
 
-        exec command
+        if defined?(Bundler) && ENV['BUNDLE_GEMFILE']
+          Bundler.with_unbundled_env do
+            exec command
+          end
+        end
       end
 
       desc 'suites', 'List available test suites'

--- a/lib/inferno/apps/cli/main.rb
+++ b/lib/inferno/apps/cli/main.rb
@@ -27,25 +27,22 @@ module Inferno
              desc: 'Automatically restart Inferno when a file is changed.'
       def start
         Migration.new.run(Logger::INFO)
-        command = 'foreman start --env=/dev/null'
 
-        if `gem list -i foreman`.chomp == 'false'
-          puts "You must install foreman with 'gem install foreman' prior to running Inferno."
-        end
+        without_bundler do
+          command = 'foreman start --env=/dev/null'
 
-        if options[:watch]
-          if `gem list -i rerun`.chomp == 'false'
-            puts "You must install 'rerun' with 'gem install rerun' to restart on file changes."
+          if `gem list -i foreman`.chomp == 'false'
+            puts "You must install foreman with 'gem install foreman' prior to running Inferno."
           end
 
-          command = "rerun \"#{command}\" --background"
-        end
+          if options[:watch]
+            if `gem list -i rerun`.chomp == 'false'
+              puts "You must install 'rerun' with 'gem install rerun' to restart on file changes."
+            end
 
-        if defined?(Bundler) && ENV['BUNDLE_GEMFILE']
-          Bundler.with_unbundled_env do
-            exec command
+            command = "rerun \"#{command}\" --background"
           end
-        else
+
           exec command
         end
       end
@@ -67,6 +64,19 @@ module Inferno
       def version
         puts "Inferno Core v#{Inferno::VERSION}"
       end
+
+      private
+
+      def without_bundler(&block)
+        if defined?(Bundler) && ENV['BUNDLE_GEMFILE']
+          Bundler.with_unbundled_env do
+            yield
+          end
+        else
+          yield
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
# Summary

IT WORKED! This is a rogue PR but please let this be a feature, maybe after the upcoming push to production. Putting up as draft (see TODOs below), but I'm not opposed to just merging it if people approve.

# Testing Guidance

1. Check out this branch
2. `bundle exec bin/inferno services`
3. `bundle exec bin/inferno start`

# Possible TODOs:

1. ~~It still outputs "You must install foreman with 'gem install foreman' prior to running Inferno" because it can't detect foreman in the bundler env, but then will still run anyways in non-bundler env. We can fix this with another `if` but I'll try to do it in a cleaner way.~~ Resolved
2. While we're doing this, do we want to handle the case of if they have foreman installed within the bundler env? IMHO that would be too opinionated.
3. Rspec it