### PR TITLE
Remove ReactMarkdown in Inputs/Outputs

### DIFF
--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/InputOutputList.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/InputOutputList.tsx
@@ -42,7 +42,7 @@ const InputOutputList: FC<InputOutputListProps> = ({
             </Typography>
           </TableCell>
           <TableCell className={classes.inputOutputsValue}>
-          <Typography variant="subtitle2" component="p">
+            <Typography variant="subtitle2" component="p">
               {(inputOutputs?.value as string) || ''}
             </Typography>
           </TableCell>

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/InputOutputList.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/InputOutputList.tsx
@@ -2,8 +2,6 @@ import React, { FC } from 'react';
 import useStyles from './styles';
 import { Table, TableBody, TableRow, TableCell, Typography, TableHead, Box } from '@mui/material';
 import { TestInput, TestOutput } from '~/models/testSuiteModels';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
 
 interface InputOutputListProps {
   inputOutputs: TestInput[] | TestOutput[];
@@ -44,9 +42,9 @@ const InputOutputList: FC<InputOutputListProps> = ({
             </Typography>
           </TableCell>
           <TableCell className={classes.inputOutputsValue}>
-            <ReactMarkdown remarkPlugins={[remarkGfm]} className={classes.wordWrap}>
+          <Typography variant="subtitle2" component="p">
               {(inputOutputs?.value as string) || ''}
-            </ReactMarkdown>
+            </Typography>
           </TableCell>
         </TableRow>
       );


### PR DESCRIPTION
# Summary

Original issue: https://oncprojectracking.healthit.gov/support/browse/FI-2724

Problem: contents in Inputs and Outputs are converted to markdown. Though it's useful for styles, can cause problems when strings like URLs are broken by that.

Fix: removed React Markdown in the HTML.

# Testing Guidance

1. Run Inferno core
2. Try markdown contents in entry (e.g. bearer_token: `~~SAMPLE_TOKEN~~`)
3. In the results, contents SHOULD NOT be converted into markdown.

# Consideration

`react-markdown` is being used as below. Further investigation needs to figure out whether markdown is being used unnecessarily.

<img width="796" alt="Screenshot 2024-06-21 at 2 00 08 PM" src="https://github.com/inferno-framework/inferno-core/assets/105247995/38d922f2-5886-43f8-a36c-974b5d587178">

