### PR TITLE
FI-2836: Fix double requests from suite endpoints

### DIFF
--- a/lib/inferno/dsl/suite_endpoint.rb
+++ b/lib/inferno/dsl/suite_endpoint.rb
@@ -289,7 +289,6 @@ module Inferno
           uri.query = env['rack.request.query_string'] if env['rack.request.query_string'].present?
           url = uri&.to_s
           verb = env['REQUEST_METHOD']
-          logger.info('get body')
           request_body = env['rack.input']
           request_body.rewind if env['rack.input'].respond_to? :rewind
           request_body = request_body.instance_of?(Puma::NullIO) ? nil : request_body.string

--- a/lib/inferno/utils/middleware/request_logger.rb
+++ b/lib/inferno/utils/middleware/request_logger.rb
@@ -34,7 +34,7 @@ module Inferno
 
           # rack.after_reply is handled by puma, which doesn't process requests
           # in unit tests, so we manually run them when in the test environment
-          env['rack.after_reply']&.each(&:call) if (ENV['APP_ENV'] = 'test')
+          env['rack.after_reply']&.each(&:call) if ENV['APP_ENV'] == 'test'
 
           response
         end


### PR DESCRIPTION
# Summary
I investigated the incoming requests showing up twice in the UI. I logged the stack trace where each was being persisted:
```
09:31:58 web.1    | **************************START****************************
09:31:58 web.1    | I, [2024-06-17T09:31:58.067544 #64323]  INFO -- : get body
09:31:58 web.1    | /Users/smacvicar/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/inferno_core-0.4.38/lib/inferno/utils/middleware/request_logger.rb:37:in `each'
09:31:58 web.1    | /Users/smacvicar/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/inferno_core-0.4.38/lib/inferno/utils/middleware/request_logger.rb:37:in `call'
09:31:58 web.1    | /Users/smacvicar/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/rack-2.2.9/lib/rack/static.rb:161:in `call'
09:31:58 web.1    | /Users/smacvicar/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/puma-5.6.8/lib/puma/configuration.rb:252:in `call'
09:31:58 web.1    | /Users/smacvicar/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/puma-5.6.8/lib/puma/request.rb:77:in `block in handle_request'
09:31:58 web.1    | /Users/smacvicar/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/puma-5.6.8/lib/puma/thread_pool.rb:340:in `with_force_shutdown'
09:31:58 web.1    | /Users/smacvicar/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/puma-5.6.8/lib/puma/request.rb:76:in `handle_request'
09:31:58 web.1    | /Users/smacvicar/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/puma-5.6.8/lib/puma/server.rb:443:in `process_client'
09:31:58 web.1    | /Users/smacvicar/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/puma-5.6.8/lib/puma/thread_pool.rb:147:in `block in spawn_thread'
09:31:58 web.1    | ************************** END ****************************
09:31:58 web.1    | **************************START****************************
09:31:58 web.1    | I, [2024-06-17T09:31:58.096594 #64323]  INFO -- : get body
09:31:58 web.1    | /Users/smacvicar/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/puma-5.6.8/lib/puma/request.rb:182:in `block in handle_request'
09:31:58 web.1    | /Users/smacvicar/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/puma-5.6.8/lib/puma/request.rb:182:in `each'
09:31:58 web.1    | /Users/smacvicar/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/puma-5.6.8/lib/puma/request.rb:182:in `handle_request'
09:31:58 web.1    | /Users/smacvicar/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/puma-5.6.8/lib/puma/server.rb:443:in `process_client'
09:31:58 web.1    | /Users/smacvicar/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/puma-5.6.8/lib/puma/thread_pool.rb:147:in `block in spawn_thread'
09:31:58 web.1    | ************************** END ****************************
```
The second one is correct where puma is handling the `rack.after_reply` callback. The first is because I messed up the conditional to persist these requests during testing when puma isn't running.

# Testing Guidance
In the crd test kit, run `bundle info inferno_core`. This will tell you the location of the version inferno core being used in that test kit. If you change the condition there just like in this PR, start the test kit, and run the tests, you should see that the requests are no longer duplicated.