### PR TITLE
Fix typo 'requests' in inferno template

### DIFF
--- a/lib/inferno/apps/cli/templates/lib/%library_name%.rb.tt
+++ b/lib/inferno/apps/cli/templates/lib/%library_name%.rb.tt
@@ -21,7 +21,7 @@ module <%= module_name %>
       oauth_credentials :credentials
     end
 
-    # All FHIR validation requsets will use this FHIR validator
+    # All FHIR validation requests will use this FHIR validator
     fhir_resource_validator do
       # igs 'identifier#version' # Use this method for published IGs/versions
       # igs 'igs/filename.tgz'   # Use this otherwise


### PR DESCRIPTION
# Summary

Fix typo

# Testing Guidance

1. Checkout this branch
2. cd tmp
3. ../bin/inferno new test_template
4. Make sure the new test suite works. Typo fix is in lib/test_template.rb line 24.

I'll run `./scripts/publish_template` after this is merged to update inferno template repository.