### PR TITLE
FI-2910: Host JWKS for Client Assertion

### DIFF
--- a/lib/inferno/apps/web/router.rb
+++ b/lib/inferno/apps/web/router.rb
@@ -54,7 +54,7 @@ module Inferno
       # This could be investigated and likely removed if addressed properly elsewhere.
       get '/', to: ->(_env) { [200, { 'Content-Type' => 'text/html' }, [client_page]] }
       get '/jwks.json', to: lambda { |_env|
-                              [200, { 'Content-Type' => 'application/json' }, [Inferno::DSL::JWKS.jwks_json]]
+                              [200, { 'Content-Type' => 'application/json' }, [Inferno::JWKS.jwks_json]]
                             }, as: :jwks
 
       Inferno.routes.each do |route|

--- a/lib/inferno/apps/web/router.rb
+++ b/lib/inferno/apps/web/router.rb
@@ -53,6 +53,9 @@ module Inferno
       # Should not need Content-Type header but GitHub Codespaces will not work without them.
       # This could be investigated and likely removed if addressed properly elsewhere.
       get '/', to: ->(_env) { [200, { 'Content-Type' => 'text/html' }, [client_page]] }
+      get '/jwks.json', to: lambda { |_env|
+                              [200, { 'Content-Type' => 'application/json' }, [Inferno::DSL::JWKS.jwks_json]]
+                            }, as: :jwks
 
       Inferno.routes.each do |route|
         cleaned_id = route[:suite].id.gsub(/[^a-zA-Z\d\-._~]/, '_')

--- a/lib/inferno/config/application.rb
+++ b/lib/inferno/config/application.rb
@@ -13,6 +13,7 @@ module Inferno
     raw_js_host = ENV.fetch('JS_HOST', '')
     base_path = ENV.fetch('BASE_PATH', '')
     public_path = base_path.blank? ? '/public' : "/#{base_path}/public"
+    jwks_path = base_path.blank? ? '/jwks.json' : "/#{base_path}/jwks.json"
     js_host = raw_js_host.present? ? "#{raw_js_host}/public" : public_path
 
     Application.register('js_host', js_host)
@@ -21,6 +22,7 @@ module Inferno
     Application.register('async_jobs', ENV['ASYNC_JOBS'] != 'false')
     Application.register('inferno_host', ENV.fetch('INFERNO_HOST', 'http://localhost:4567'))
     Application.register('base_url', URI.join(Application['inferno_host'], base_path).to_s)
+    Application.register('jwks_url', URI.join(Application['inferno_host'], jwks_path).to_s)
     Application.register('cache_bust_token', SecureRandom.uuid)
 
     configure do |config|

--- a/lib/inferno/dsl/auth_info.rb
+++ b/lib/inferno/dsl/auth_info.rb
@@ -271,7 +271,7 @@ module Inferno
           'alg' => encryption_algorithm,
           'kid' => private_key['kid'],
           'typ' => 'JWT',
-          'jku' => "#{Inferno::Application['base_url']}/jwks.json"
+          'jku' => Inferno::Application['jwks_url']
         }
       end
 

--- a/lib/inferno/dsl/auth_info.rb
+++ b/lib/inferno/dsl/auth_info.rb
@@ -270,7 +270,8 @@ module Inferno
         {
           'alg' => encryption_algorithm,
           'kid' => private_key['kid'],
-          'typ' => 'JWT'
+          'typ' => 'JWT',
+          'jku' => "#{Inferno::Application['base_url']}/jwks.json"
         }
       end
 

--- a/spec/fixtures/auth_info_constants.rb
+++ b/spec/fixtures/auth_info_constants.rb
@@ -24,7 +24,7 @@ module AuthInfoConstants
         pkce_support: 'enabled',
         pkce_code_challenge_method: 'S256',
         auth_request_method: 'GET'
-      }.merge(token_info).freeze
+      }.merge(token_info)
     end
 
     def symmetric_confidential_access_default
@@ -39,7 +39,7 @@ module AuthInfoConstants
         pkce_code_challenge_method: 'S256',
         auth_request_method: 'POST',
         use_discovery: 'false'
-      }.merge(token_info).freeze
+      }.merge(token_info)
     end
 
     def asymmetric_confidential_access_default
@@ -53,7 +53,7 @@ module AuthInfoConstants
         encryption_algorithm: ENCRYPTION_ALGORITHM,
         jwks: JWKS,
         kid: KID
-      }.merge(token_info).freeze
+      }.merge(token_info)
     end
 
     def backend_services_access_default
@@ -65,7 +65,7 @@ module AuthInfoConstants
         encryption_algorithm: ENCRYPTION_ALGORITHM,
         jwks: JWKS,
         kid: KID
-      }.merge(token_info).freeze
+      }.merge(token_info)
     end
   end
 end

--- a/spec/fixtures/auth_info_constants.rb
+++ b/spec/fixtures/auth_info_constants.rb
@@ -24,7 +24,7 @@ module AuthInfoConstants
         pkce_support: 'enabled',
         pkce_code_challenge_method: 'S256',
         auth_request_method: 'GET'
-      }.merge(token_info)
+      }.merge(token_info).freeze
     end
 
     def symmetric_confidential_access_default
@@ -39,7 +39,7 @@ module AuthInfoConstants
         pkce_code_challenge_method: 'S256',
         auth_request_method: 'POST',
         use_discovery: 'false'
-      }.merge(token_info)
+      }.merge(token_info).freeze
     end
 
     def asymmetric_confidential_access_default
@@ -53,7 +53,7 @@ module AuthInfoConstants
         encryption_algorithm: ENCRYPTION_ALGORITHM,
         jwks: JWKS,
         kid: KID
-      }.merge(token_info)
+      }.merge(token_info).freeze
     end
 
     def backend_services_access_default
@@ -65,7 +65,7 @@ module AuthInfoConstants
         encryption_algorithm: ENCRYPTION_ALGORITHM,
         jwks: JWKS,
         kid: KID
-      }.merge(token_info)
+      }.merge(token_info).freeze
     end
   end
 end

--- a/spec/inferno/dsl/auth_info_spec.rb
+++ b/spec/inferno/dsl/auth_info_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Inferno::DSL::AuthInfo do
-  let(:auth_url) { 'https://inferno-qa.healthit.gov/reference-server/oauth/authorization' }
-  let(:token_url) { 'https://inferno-qa.healthit.gov/reference-server/oauth/token' }
+  let(:auth_url) { 'http://example.com/authorization' }
+  let(:token_url) { 'http://example.com/token' }
   let(:requested_scopes) { 'launch/patient openid fhirUser patient/*.*' }
   let(:encryption_algorithm) { 'ES384' }
   let(:kid) { '4b49a739d1eb115b3225f4cf9beb6d1b' }
@@ -52,10 +52,10 @@ RSpec.describe Inferno::DSL::AuthInfo do
       refresh_token: 'REFRESH_TOKEN',
       issue_time: Time.now.iso8601,
       expires_in: 3600,
-      token_url: 'http://example.com/token',
+      token_url:,
       client_id: 'CLIENT_ID',
       client_secret: 'CLIENT_SECRET',
-      auth_url: 'http://example.com/authorization',
+      auth_url:,
       requested_scopes: 'launch/patient openid fhirUser patient/*.*',
       pkce_support: 'enabled',
       pkce_code_challenge_method: 'S256',

--- a/spec/inferno/dsl/auth_info_spec.rb
+++ b/spec/inferno/dsl/auth_info_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Inferno::DSL::AuthInfo do
   let(:asymmetric_auth_info) { described_class.new(asymmetric_confidential_access_default) }
   let(:backend_services_auth_info) { described_class.new(backend_services_access_default) }
   let(:client) { FHIR::Client.new('http://example.com') }
+  let(:jwks_url) { "#{Inferno::Application['base_url']}/jwks.json" }
 
   describe '.new' do
     it 'raises an error if an invalid key is provided' do
@@ -229,6 +230,7 @@ RSpec.describe Inferno::DSL::AuthInfo do
 
         expect(header['alg']).to eq(asymmetric_auth_info.encryption_algorithm)
         expect(header['typ']).to eq('JWT')
+        expect(header['jku']).to eq(jwks_url)
         expect(header['kid']).to eq(asymmetric_auth_info.kid)
         expect(claims['iss']).to eq(asymmetric_auth_info.client_id)
         expect(claims['aud']).to eq(asymmetric_auth_info.token_url)
@@ -246,6 +248,7 @@ RSpec.describe Inferno::DSL::AuthInfo do
 
         expect(header['alg']).to eq(asymmetric_auth_info.encryption_algorithm)
         expect(header['typ']).to eq('JWT')
+        expect(header['jku']).to eq(jwks_url)
         expect(header['kid']).to be_present
         expect(claims['iss']).to eq(asymmetric_auth_info.client_id)
         expect(claims['aud']).to eq(asymmetric_auth_info.token_url)

--- a/spec/inferno/dsl/auth_info_spec.rb
+++ b/spec/inferno/dsl/auth_info_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Inferno::DSL::AuthInfo do
   let(:asymmetric_auth_info) { described_class.new(asymmetric_confidential_access_default) }
   let(:backend_services_auth_info) { described_class.new(backend_services_access_default) }
   let(:client) { FHIR::Client.new('http://example.com') }
-  let(:jwks_url) { "#{Inferno::Application['base_url']}/jwks.json" }
+  let(:jwks_url) { Inferno::Application['jwks_url'] }
 
   describe '.new' do
     it 'raises an error if an invalid key is provided' do

--- a/spec/inferno/dsl/auth_info_spec.rb
+++ b/spec/inferno/dsl/auth_info_spec.rb
@@ -1,4 +1,51 @@
 RSpec.describe Inferno::DSL::AuthInfo do
+  let(:auth_url) { 'https://inferno-qa.healthit.gov/reference-server/oauth/authorization' }
+  let(:token_url) { 'https://inferno-qa.healthit.gov/reference-server/oauth/token' }
+  let(:requested_scopes) { 'launch/patient openid fhirUser patient/*.*' }
+  let(:encryption_algorithm) { 'ES384' }
+  let(:kid) { '4b49a739d1eb115b3225f4cf9beb6d1b' }
+  let(:jwks) do
+    {
+      keys:
+       [
+         {
+           kty: 'EC',
+           crv: 'P-384',
+           x: 'JQKTsV6PT5Szf4QtDA1qrs0EJ1pbimQmM2SKvzOlIAqlph3h1OHmZ2i7MXahIF2C',
+           y: 'bRWWQRJBgDa6CTgwofYrHjVGcO-A7WNEnu4oJA5OUJPPPpczgx1g2NsfinK-D2Rw',
+           use: 'sig',
+           key_ops: [
+             'verify'
+           ],
+           ext: true,
+           kid: '4b49a739d1eb115b3225f4cf9beb6d1b',
+           alg: 'ES384'
+         },
+         {
+           kty: 'EC',
+           crv: 'P-384',
+           d: 'kDkn55p7gryKk2tj6z2ij7ExUnhi0ngxXosvqa73y7epwgthFqaJwApmiXXU2yhK',
+           x: 'JQKTsV6PT5Szf4QtDA1qrs0EJ1pbimQmM2SKvzOlIAqlph3h1OHmZ2i7MXahIF2C',
+           y: 'bRWWQRJBgDa6CTgwofYrHjVGcO-A7WNEnu4oJA5OUJPPPpczgx1g2NsfinK-D2Rw',
+           key_ops: [
+             'sign'
+           ],
+           ext: true,
+           kid: '4b49a739d1eb115b3225f4cf9beb6d1b',
+           alg: 'ES384'
+         }
+       ]
+    }.to_json
+  end
+  let(:issue_time) { Time.now.iso8601 }
+  let(:token_info) do
+    {
+      access_token: 'SAMPLE_TOKEN',
+      refresh_token: 'SAMPLE_REFRESH_TOKEN',
+      expires_in: '3600',
+      issue_time:
+    }
+  end
   let(:full_params) do
     {
       access_token: 'ACCESS_TOKEN',

--- a/spec/inferno/dsl/auth_info_spec.rb
+++ b/spec/inferno/dsl/auth_info_spec.rb
@@ -1,61 +1,14 @@
 RSpec.describe Inferno::DSL::AuthInfo do
-  let(:auth_url) { 'http://example.com/authorization' }
-  let(:token_url) { 'http://example.com/token' }
-  let(:requested_scopes) { 'launch/patient openid fhirUser patient/*.*' }
-  let(:encryption_algorithm) { 'ES384' }
-  let(:kid) { '4b49a739d1eb115b3225f4cf9beb6d1b' }
-  let(:jwks) do
-    {
-      keys:
-       [
-         {
-           kty: 'EC',
-           crv: 'P-384',
-           x: 'JQKTsV6PT5Szf4QtDA1qrs0EJ1pbimQmM2SKvzOlIAqlph3h1OHmZ2i7MXahIF2C',
-           y: 'bRWWQRJBgDa6CTgwofYrHjVGcO-A7WNEnu4oJA5OUJPPPpczgx1g2NsfinK-D2Rw',
-           use: 'sig',
-           key_ops: [
-             'verify'
-           ],
-           ext: true,
-           kid: '4b49a739d1eb115b3225f4cf9beb6d1b',
-           alg: 'ES384'
-         },
-         {
-           kty: 'EC',
-           crv: 'P-384',
-           d: 'kDkn55p7gryKk2tj6z2ij7ExUnhi0ngxXosvqa73y7epwgthFqaJwApmiXXU2yhK',
-           x: 'JQKTsV6PT5Szf4QtDA1qrs0EJ1pbimQmM2SKvzOlIAqlph3h1OHmZ2i7MXahIF2C',
-           y: 'bRWWQRJBgDa6CTgwofYrHjVGcO-A7WNEnu4oJA5OUJPPPpczgx1g2NsfinK-D2Rw',
-           key_ops: [
-             'sign'
-           ],
-           ext: true,
-           kid: '4b49a739d1eb115b3225f4cf9beb6d1b',
-           alg: 'ES384'
-         }
-       ]
-    }.to_json
-  end
-  let(:issue_time) { Time.now.iso8601 }
-  let(:token_info) do
-    {
-      access_token: 'SAMPLE_TOKEN',
-      refresh_token: 'SAMPLE_REFRESH_TOKEN',
-      expires_in: '3600',
-      issue_time:
-    }
-  end
   let(:full_params) do
     {
       access_token: 'ACCESS_TOKEN',
       refresh_token: 'REFRESH_TOKEN',
       issue_time: Time.now.iso8601,
       expires_in: 3600,
-      token_url:,
+      token_url: 'http://example.com/token',
       client_id: 'CLIENT_ID',
       client_secret: 'CLIENT_SECRET',
-      auth_url:,
+      auth_url: 'http://example.com/authorization',
       requested_scopes: 'launch/patient openid fhirUser patient/*.*',
       pkce_support: 'enabled',
       pkce_code_challenge_method: 'S256',

--- a/spec/requests/jwks_spec.rb
+++ b/spec/requests/jwks_spec.rb
@@ -2,7 +2,7 @@ require 'request_helper'
 
 RSpec.describe '/jwks.json' do
   let(:router) { Inferno::Web::Router }
-  let(:parsed_response) { JSON.parse(Inferno::DSL::JWKS.jwks_json) }
+  let(:parsed_response) { JSON.parse(Inferno::JWKS.jwks_json) }
 
   describe '/jwks.json' do
     it 'renders the Inferno Core JWKS as json' do

--- a/spec/requests/jwks_spec.rb
+++ b/spec/requests/jwks_spec.rb
@@ -1,0 +1,15 @@
+require 'request_helper'
+
+RSpec.describe '/jwks.json' do
+  let(:router) { Inferno::Web::Router }
+  let(:parsed_response) { JSON.parse(Inferno::DSL::JWKS.jwks_json) }
+
+  describe '/jwks.json' do
+    it 'renders the Inferno Core JWKS as json' do
+      get router.path(:jwks)
+
+      expect(last_response.status).to eq(200)
+      expect(parsed_body).to eq(parsed_response)
+    end
+  end
+end


### PR DESCRIPTION
# Summary
This branch hosts the JWKS used for signing client assertions in core, and populate the `jku` field in the client assertion with the JWKS url.

# Testing Guidance
- Run unit tests and ensure passing
- Start Inferno and ensure http://localhost:4567/inferno/jwks.json resolves, returning the JWKS in json.

