### PR TITLE
FI-2728: Prevent Test Runner from Crashing When Validator Response Contains Bad Characters

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,7 +32,7 @@ Style/BlockComments:
 
 Style/Documentation:
   Enabled: false
-    
+
 Style/FrozenStringLiteralComment:
   Enabled: false
 
@@ -81,7 +81,7 @@ RSpec/DescribeClass:
 RSpec/ExampleLength:
   Enabled: false
 
-RSpec/FilePath:
+RSpec/SpecFilePathFormat:
   CustomTransform:
     OAuthCredentials: oauth_credentials
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -81,7 +81,7 @@ RSpec/DescribeClass:
 RSpec/ExampleLength:
   Enabled: false
 
-RSpec/SpecFilePathFormat:
+RSpec/FilePath:
   CustomTransform:
     OAuthCredentials: oauth_credentials
 

--- a/lib/inferno/dsl/fhir_resource_validation.rb
+++ b/lib/inferno/dsl/fhir_resource_validation.rb
@@ -278,7 +278,7 @@ module Inferno
 
         # @private
         def operation_outcome_from_hl7_wrapped_response(response_hash)
-          if response_hash['sessionId'] != @session_id
+          if response_hash['sessionId'] && response_hash['sessionId'] != @session_id
             validator_session_repo.save(test_suite_id:, validator_session_id: response_hash['sessionId'],
                                         validator_name: name.to_s, suite_options: requirements)
             @session_id = response_hash['sessionId']

--- a/lib/inferno/dsl/fhir_resource_validation.rb
+++ b/lib/inferno/dsl/fhir_resource_validation.rb
@@ -294,9 +294,12 @@ module Inferno
 
         # @private
         def operation_outcome_from_validator_response(response, runnable)
-          operation_outcome_from_hl7_wrapped_response(JSON.parse(response.body))
+          # Sanitize the response body by removing non-printable/control characters
+          sanitized_body = response.body.gsub(/[^[:print:]\r\n]+/, '')
+
+          operation_outcome_from_hl7_wrapped_response(JSON.parse(sanitized_body))
         rescue JSON::ParserError
-          runnable.add_message('error', "Validator Response: HTTP #{response.status}\n#{response.body}")
+          runnable.add_message('error', "Validator Response: HTTP #{response.status}\n#{sanitized_body}")
           raise Inferno::Exceptions::ErrorInValidatorException,
                 'Validator response was an unexpected format. '\
                 'Review Messages tab or validator service logs for more information.'

--- a/lib/inferno/dsl/fhir_resource_validation.rb
+++ b/lib/inferno/dsl/fhir_resource_validation.rb
@@ -293,15 +293,19 @@ module Inferno
         end
 
         # @private
+        def remove_invalid_characters(string)
+          string.gsub(/[^[:print:]\r\n]+/, '')
+        end
+
+        # @private
         def operation_outcome_from_validator_response(response, runnable)
-          # Sanitize the response body by removing non-printable/control characters
-          sanitized_body = response.body.gsub(/[^[:print:]\r\n]+/, '')
+          sanitized_body = remove_invalid_characters(response.body)
 
           operation_outcome_from_hl7_wrapped_response(JSON.parse(sanitized_body))
         rescue JSON::ParserError
           runnable.add_message('error', "Validator Response: HTTP #{response.status}\n#{sanitized_body}")
           raise Inferno::Exceptions::ErrorInValidatorException,
-                'Validator response was an unexpected format. '\
+                'Validator response was an unexpected format. ' \
                 'Review Messages tab or validator service logs for more information.'
         end
       end

--- a/lib/inferno/dsl/fhir_validation.rb
+++ b/lib/inferno/dsl/fhir_validation.rb
@@ -214,9 +214,12 @@ module Inferno
 
         # @private
         def operation_outcome_from_validator_response(response, runnable)
-          FHIR::OperationOutcome.new(JSON.parse(response.body))
+          # Sanitize the response body by removing non-printable/control characters
+          sanitized_body = response.body.gsub(/[^[:print:]\r\n]+/, '')
+
+          FHIR::OperationOutcome.new(JSON.parse(sanitized_body))
         rescue JSON::ParserError
-          runnable.add_message('error', "Validator Response: HTTP #{response.status}\n#{response.body}")
+          runnable.add_message('error', "Validator Response: HTTP #{response.status}\n#{sanitized_body}")
           raise Inferno::Exceptions::ErrorInValidatorException,
                 'Validator response was an unexpected format. '\
                 'Review Messages tab or validator service logs for more information.'

--- a/lib/inferno/dsl/fhir_validation.rb
+++ b/lib/inferno/dsl/fhir_validation.rb
@@ -213,15 +213,19 @@ module Inferno
         end
 
         # @private
+        def remove_invalid_characters(string)
+          string.gsub(/[^[:print:]\r\n]+/, '')
+        end
+
+        # @private
         def operation_outcome_from_validator_response(response, runnable)
-          # Sanitize the response body by removing non-printable/control characters
-          sanitized_body = response.body.gsub(/[^[:print:]\r\n]+/, '')
+          sanitized_body = remove_invalid_characters(response.body)
 
           FHIR::OperationOutcome.new(JSON.parse(sanitized_body))
         rescue JSON::ParserError
           runnable.add_message('error', "Validator Response: HTTP #{response.status}\n#{sanitized_body}")
           raise Inferno::Exceptions::ErrorInValidatorException,
-                'Validator response was an unexpected format. '\
+                'Validator response was an unexpected format. ' \
                 'Review Messages tab or validator service logs for more information.'
         end
       end

--- a/lib/inferno/jobs/invoke_validator_session.rb
+++ b/lib/inferno/jobs/invoke_validator_session.rb
@@ -8,16 +8,15 @@ module Inferno
         suite = Inferno::Repositories::TestSuites.new.find suite_id
         validator = suite.fhir_validators[validator_name.to_sym][validator_index]
         response_body = validator.validate(FHIR::Patient.new, 'http://hl7.org/fhir/StructureDefinition/Patient')
-        if response_body.start_with? '{'
-          res = JSON.parse(response_body)
-          session_id = res['sessionId']
-          session_repo = Inferno::Repositories::ValidatorSessions.new
-          session_repo.save(test_suite_id: suite_id, validator_session_id: session_id,
-                            validator_name:, suite_options: validator.requirements)
-          validator.session_id = session_id
-        else
-          Inferno::Application['logger'].error("InvokeValidatorSession - error from validator: #{response_body}")
-        end
+        res = JSON.parse(response_body)
+        session_id = res['sessionId']
+        session_repo = Inferno::Repositories::ValidatorSessions.new
+        session_repo.save(test_suite_id: suite_id, validator_session_id: session_id,
+                          validator_name:, suite_options: validator.requirements)
+        validator.session_id = session_id
+      rescue JSON::ParserError
+        Inferno::Application['logger']
+          .error("InvokeValidatorSession - error unexpected response format from validator: #{response_body}")
       end
     end
   end

--- a/spec/inferno/dsl/fhir_resource_validation_spec.rb
+++ b/spec/inferno/dsl/fhir_resource_validation_spec.rb
@@ -177,15 +177,15 @@ RSpec.describe Inferno::DSL::FHIRResourceValidation do
         .to_return(
           status: 500,
           body: "<html><body>Internal Server Error: content#{0.chr} with non-printable#{1.chr} characters</body></html>"
-          )
+        )
 
       expect do
         validator.resource_is_valid?(resource2, profile_url, runnable)
       end.to raise_error(Inferno::Exceptions::ErrorInValidatorException)
 
       msg = runnable.messages.first[:message]
-      expect(msg).not_to include(0.chr)
-      expect(msg).not_to include(1.chr)
+      expect(msg).to_not include(0.chr)
+      expect(msg).to_not include(1.chr)
       expect(msg).to match(/Internal Server Error: content with non-printable/)
     end
   end

--- a/spec/inferno/dsl/fhir_validation_spec.rb
+++ b/spec/inferno/dsl/fhir_validation_spec.rb
@@ -183,15 +183,15 @@ RSpec.describe Inferno::DSL::FHIRValidation do
         .to_return(
           status: 500,
           body: "<html><body>Internal Server Error: content#{0.chr} with non-printable#{1.chr} characters</body></html>"
-          )
+        )
 
       expect do
         validator.resource_is_valid?(resource, profile_url, runnable)
       end.to raise_error(Inferno::Exceptions::ErrorInValidatorException)
 
       msg = runnable.messages.first[:message]
-      expect(msg).not_to include(0.chr)
-      expect(msg).not_to include(1.chr)
+      expect(msg).to_not include(0.chr)
+      expect(msg).to_not include(1.chr)
       expect(msg).to match(/Internal Server Error: content with non-printable/)
     end
   end

--- a/spec/inferno/dsl/fhir_validation_spec.rb
+++ b/spec/inferno/dsl/fhir_validation_spec.rb
@@ -176,6 +176,24 @@ RSpec.describe Inferno::DSL::FHIRValidation do
 
       expect(validator.resource_is_valid?(resource, profile_url, runnable)).to be(true)
     end
+
+    it 'removes non-printable characters from the response' do
+      stub_request(:post, "#{validation_url}/validate?profile=#{profile_url}")
+        .with(body: resource_string)
+        .to_return(
+          status: 500,
+          body: "<html><body>Internal Server Error: content#{0.chr} with non-printable#{1.chr} characters</body></html>"
+          )
+
+      expect do
+        validator.resource_is_valid?(resource, profile_url, runnable)
+      end.to raise_error(Inferno::Exceptions::ErrorInValidatorException)
+
+      msg = runnable.messages.first[:message]
+      expect(msg).not_to include(0.chr)
+      expect(msg).not_to include(1.chr)
+      expect(msg).to match(/Internal Server Error: content with non-printable/)
+    end
   end
 
   describe '.find_validator' do


### PR DESCRIPTION
# Summary
**Ticket Description**: We saw an issue where a validator response contained a null character and it crashed the test runner, so it kept spinning forever. Since we don't control the validator and especially the tx server, make sure an unexpected response doesn't crash anything.

I was able to reproduce the issue by mocking the validator service with various unexpected response formats, including non-printable/control characters, which led to crashes when the test runner attempted to persist the response. By using Mockoon to simulate these edge cases, I confirmed that the issue was specifically related to non-printable characters in the response body, which caused SQLite exceptions during persistence.

**Changes Made**:
- **Sanitized the response body**: The response body is now sanitized to remove non-printable/control characters before parsing or persisting, preventing crashes and database exceptions.
- **Improved JSON Parsing Error Handling**: The JSON parsing process has been refined, ensuring that malformed responses are caught, and users are provided with clear, actionable error messages.
- **Prevent storing null validator session**: Added a null check to prevent storing null validator session IDs (This should fix ticket FI-2914)
- Update unit tests accordingly
