### PR TITLE
FI-2990: Fix typo in Request Details Modal

### DIFF
--- a/client/src/components/RequestDetailModal/RequestDetailModal.tsx
+++ b/client/src/components/RequestDetailModal/RequestDetailModal.tsx
@@ -88,7 +88,7 @@ const RequestDetailModal: FC<RequestDetailModalProps> = ({
             </Typography>
             {timestamp && <Typography variant="overline">{timestamp.toLocaleString()}</Typography>}
             <HeaderTable headers={request.request_headers || []} />
-            {request.response_body && (
+            {request.request_body && (
               <CodeBlock
                 body={request.request_body}
                 headers={request.request_headers}


### PR DESCRIPTION
# Summary

Fixes a typo that prevented the request body from appearing properly in the RequestDetailsModal.

# Testing Guidance

For a test with a request body, check the Details modal to ensure that it appears. 