### PR TITLE
FI-3112: Fixed JWKS Template Path Used in Unit Tests

### DIFF
--- a/spec/fixtures/auth_info_constants.rb
+++ b/spec/fixtures/auth_info_constants.rb
@@ -4,7 +4,7 @@ module AuthInfoConstants
   REQUESTED_SCOPES = 'launch/patient openid fhirUser patient/*.*'.freeze
   ENCRYPTION_ALGORITHM = 'ES384'.freeze
   KID = '4b49a739d1eb115b3225f4cf9beb6d1b'.freeze
-  JWKS = File.read(File.join('lib', 'inferno', 'dsl', 'jwks.json')).freeze
+  JWKS = File.read(Inferno::JWKS.jwks_path).freeze
   class << self
     def token_info
       {


### PR DESCRIPTION
# Summary
Reading the `jwks.json` template in spec using relative path raised a  no file error when using the gem in test kit test environment. This PR updates the jwks path to the correct absolute path.

# Testing Guidance
Test by pointing inferno_core gem to this branch and ensure no error when executing rspec.
