### PR TITLE
FI-3188: Update documentation on cli_context options.

### DIFF
--- a/lib/inferno/dsl/fhir_resource_validation.rb
+++ b/lib/inferno/dsl/fhir_resource_validation.rb
@@ -74,18 +74,10 @@ module Inferno
         #
         # @example
         #   fhir_resource_validator do
-        #     url 'http://example.com/validator'
-        #     cli_context do
-        #       noExtensibleBindingMessages true
-        #       txServer nil
-        #     end
-        #   end
-        #
-        # @example
-        #   fhir_resource_validator do
         #     url 'http://example.org/validator'
         #     cli_context({
         #       noExtensibleBindingMessages: true,
+        # .     allowExampleUrls: true,
         #       txServer: nil
         #     })
         #   end

--- a/lib/inferno/dsl/fhir_resource_validation.rb
+++ b/lib/inferno/dsl/fhir_resource_validation.rb
@@ -312,6 +312,7 @@ module Inferno
         # @private
         def operation_outcome_from_validator_response(response, runnable)
           sanitized_body = remove_invalid_characters(response.body)
+
           operation_outcome_from_hl7_wrapped_response(JSON.parse(sanitized_body))
         rescue JSON::ParserError
           runnable.add_message('error', "Validator Response: HTTP #{response.status}\n#{sanitized_body}")

--- a/lib/inferno/dsl/fhir_resource_validation.rb
+++ b/lib/inferno/dsl/fhir_resource_validation.rb
@@ -73,11 +73,23 @@ module Inferno
         # there is no check that the fields are correct.
         #
         # @example
+        #   # Passing fields in a block
+        #   fhir_resource_validator do
+        #     url 'http://example.com/validator'
+        #     cli_context do
+        #       noExtensibleBindingMessages true
+        # .     allowExampleUrls true
+        #       txServer nil
+        #     end
+        #   end
+        #
+        # @example
+        #   # Passing fields in a Hash
         #   fhir_resource_validator do
         #     url 'http://example.org/validator'
         #     cli_context({
         #       noExtensibleBindingMessages: true,
-        # .     allowExampleUrls: true,
+        #       allowExampleUrls: true,
         #       txServer: nil
         #     })
         #   end
@@ -300,7 +312,6 @@ module Inferno
         # @private
         def operation_outcome_from_validator_response(response, runnable)
           sanitized_body = remove_invalid_characters(response.body)
-
           operation_outcome_from_hl7_wrapped_response(JSON.parse(sanitized_body))
         rescue JSON::ParserError
           runnable.add_message('error', "Validator Response: HTTP #{response.status}\n#{sanitized_body}")

--- a/lib/inferno/dsl/fhir_resource_validation.rb
+++ b/lib/inferno/dsl/fhir_resource_validation.rb
@@ -78,7 +78,7 @@ module Inferno
         #     url 'http://example.com/validator'
         #     cli_context do
         #       noExtensibleBindingMessages true
-        # .     allowExampleUrls true
+        #       allowExampleUrls true
         #       txServer nil
         #     end
         #   end


### PR DESCRIPTION
# Summary

Updates [docs](https://inferno-framework.github.io/inferno-core/docs/Inferno/DSL/FHIRResourceValidation/Validator.html) to remove redundant example that is also bad ruby.  I believe we had already gotten the bad ruby example fixed on the framework site but didn't get it fixed here.

Also, figured we might as well include the exampleURL flag as an example because that was the one I actually wanted to use when i was looking at this documentation.

# Testing Guidance

I suppose you could regenerate the docs as explained in the readme.  Also, I haven't tried out that example url flag technically, but [grabbed it from the  wrapper UI config](https://github.com/hapifhir/org.hl7.fhir.validator-wrapper/blob/0093f0b02b9b88c86cf4e1da75d4aed410acf8d5/src/commonMain/resources/static-content/openapi.yml#L218C13-L218C29) so it should work.

