### PR TITLE
FI-3275 debug: inferno execute input validation

### DIFF
--- a/lib/inferno/apps/cli/execute.rb
+++ b/lib/inferno/apps/cli/execute.rb
@@ -89,7 +89,7 @@ module Inferno
 
       def run_one(runnable)
         verify_runnable(
-          suite,
+          runnable,
           thor_hash_to_inputs_array(options[:inputs]),
           test_session.suite_options
         )


### PR DESCRIPTION
# Summary

Found a bug on inferno execute where it was requiring inputs that should not be required. The diff will explain a lot.

# Testing Guidance

1. Checkout this branch
2. Make a new branch: `git checkout -b bug-execute-input-validation-test`
3. Merge PR #540: `git merge origin/fi-3182-clean-diff`
4. Run this, which fails on main and fi-3182-clean-diff, but should succeed now:
```
bundle exec inferno execute --suite infra_test -g 1 -t 4.01 --inputs suite_input:a outer_group_input:b inner_group_input:c test_input:d
```

Have to do it this way because #540 includes another bug fix, but I feel that this bug fix should get merged separately and sooner.

