### PR TITLE
FI-3286: Rename Auth Type dropdown input

### DIFF
--- a/client/src/components/InputsModal/AuthTypeSelector.tsx
+++ b/client/src/components/InputsModal/AuthTypeSelector.tsx
@@ -26,7 +26,7 @@ const AuthTypeSelector: FC<InputAccessProps> = ({
   const selectorModel: TestInput = {
     name: 'auth_type',
     type: 'select',
-    title: `${requirement.name} Auth Type`,
+    title: 'Auth Type',
     description: requirement.description,
     default: selectorSettings.default || 'public',
     optional: selectorSettings.optional,

--- a/client/src/components/InputsModal/__tests__/Inputs.test.tsx
+++ b/client/src/components/InputsModal/__tests__/Inputs.test.tsx
@@ -185,7 +185,7 @@ describe('Input Components', () => {
       </ThemeProvider>,
     );
 
-    const inputText = screen.getByText('authInput Auth Type (required)');
+    const inputText = screen.getByText('Auth Type (required)');
     expect(inputText).toBeVisible();
   });
 


### PR DESCRIPTION
# Summary

Updates Auth Type input title to remove parent input name.

# Testing Guidance

Check that Auth Type only has the title `Auth Type`.