### PR TITLE
FI-3241: Verify runnable id length

### DIFF
--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -1,6 +1,7 @@
 require_relative 'configurable'
 require_relative 'input_output_handling'
 require_relative 'resume_test_route'
+require_relative '../exceptions'
 require_relative '../utils/markdown_formatter'
 
 module Inferno
@@ -202,7 +203,7 @@ module Inferno
 
         final_id = "#{prefix}#{@base_id}"
 
-        raise StandardError, "ID '#{final_id}' exceeds the maximum id length of 255 characters" if final_id.length > 255
+        raise Exceptions::InvalidRunnableIdException, final_id if final_id.length > 255
 
         @id = final_id
       end

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -200,7 +200,11 @@ module Inferno
 
         @base_id = new_id || @base_id || default_id
 
-        @id = "#{prefix}#{@base_id}"
+        final_id = "#{prefix}#{@base_id}"
+
+        raise StandardError, "ID '#{final_id}' exceeds the maximum id length of 255 characters" if final_id.length > 255
+
+        @id = final_id
       end
 
       # Set/Get a runnable's title

--- a/lib/inferno/exceptions.rb
+++ b/lib/inferno/exceptions.rb
@@ -113,5 +113,11 @@ module Inferno
         super("Expected '#{name}' to be a #{expected_class_names}, but found a #{actual_class.name}.")
       end
     end
+
+    class InvalidRunnableIdException < StandardError
+      def initialize(id)
+        super("ID '#{id}' exceeds the maximum id length of 255 characters")
+      end
+    end
   end
 end

--- a/spec/inferno/dsl/runnable_spec.rb
+++ b/spec/inferno/dsl/runnable_spec.rb
@@ -190,7 +190,9 @@ RSpec.describe Inferno::DSL::Runnable do
 
   describe '.id' do
     it 'raises an error if the id is longer than 255 characters' do
-      expect { Class.new(Inferno::Test).id('a' * 256) }.to raise_error(StandardError, /length of 255 characters/)
+      expect do
+        Class.new(Inferno::Test).id('a' * 256)
+      end.to raise_error(Inferno::Exceptions::InvalidRunnableIdException, /length of 255 characters/)
     end
   end
 end

--- a/spec/inferno/dsl/runnable_spec.rb
+++ b/spec/inferno/dsl/runnable_spec.rb
@@ -187,4 +187,10 @@ RSpec.describe Inferno::DSL::Runnable do
       expect(run_as_group_examples.groups.second.tests.first.user_runnable?).to be(false)
     end
   end
+
+  describe '.id' do
+    it 'raises an error if the id is longer than 255 characters' do
+      expect { Class.new(Inferno::Test).id('a' * 256) }.to raise_error(StandardError, /length of 255 characters/)
+    end
+  end
 end


### PR DESCRIPTION
# Summary
Some runnable ids were becoming longer than the length limit on the columns for runnable ids in the database. SQLite doesn't actually enforce those limits, so this issue wouldn't be noticed until trying to run on QA/prod. This branch checks runnable ids on creation so that they will be noticed immediately.

# Testing Guidance
You can do something like change the id of the demo suite to `'a' * 256`, and Inferno will fail to start.