### PR TITLE
FI-3367 Patch execute rollup

### DIFF
--- a/lib/inferno/apps/cli/execute.rb
+++ b/lib/inferno/apps/cli/execute.rb
@@ -3,6 +3,7 @@ require 'active_support'
 require_relative '../../utils/verify_runnable'
 require_relative '../../utils/persist_inputs'
 require_relative 'execute/console_outputter'
+require_relative '../../result_summarizer'
 
 module Inferno
   module CLI
@@ -63,7 +64,8 @@ module Inferno
         outputter.print_results(options, results)
         outputter.print_end_message(options)
 
-        exit(0) if results.all? { |result| result.result == 'pass' }
+        # TODO: respect customized rollups
+        exit(0) if Inferno::ResultSummarizer.new(results).summarize == 'pass'
 
         # exit(1) is for Thor failures
         # exit(2) is for shell builtin failures

--- a/lib/inferno/apps/cli/main.rb
+++ b/lib/inferno/apps/cli/main.rb
@@ -76,6 +76,8 @@ module Inferno
 
         Examples:
 
+            (These examples only work from within the inferno_core directory).
+
             `bundle exec inferno execute --suite dev_validator \
                                         --inputs "url:https://hapi.fhir.org/baseR4" \
                                                  patient_id:1234321`


### PR DESCRIPTION
# Summary

I realized execute was not respecting result summarizer rollup behavior at all, and with this PR it will at least respect the old behavior. Customized rollup behavior is still not supported (because the children of custom rollup groups make their way into the results array). I'll patch that bug in a future PR and ticket. 

This PR along with inferno-framework/tls-test-kit#20 and onc-health/onc-certification-g10-test-kit#577 is blocking inferno-framework/inferno-reference-server#182, which is succesfully running g10 in CI.

# Testing Guidance

Just see the working CI run: <https://github.com/inferno-framework/inferno-reference-server/actions/runs/11524446739/job/32084615655?pr=182>
