### PR TITLE
FI-3358: Check for Duplicate Ids in In-Memory Repositories

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,6 @@
 # URL for FHIR validator service
 VALIDATOR_URL=http://localhost/validatorapi
 REDIS_URL=redis://localhost:6379/0
-G10_VALIDATOR_URL=http://localhost/validatorapi
 FHIR_RESOURCE_VALIDATOR_URL=http://localhost/hl7validatorapi
 FHIRPATH_URL=http://localhost/fhirpath
 

--- a/lib/inferno/exceptions.rb
+++ b/lib/inferno/exceptions.rb
@@ -119,5 +119,11 @@ module Inferno
         super("ID '#{id}' exceeds the maximum id length of 255 characters")
       end
     end
+
+    class DuplicateEntityIdException < StandardError
+      def initialize(id)
+        super("ID '#{id}' already exists. Ensure the uniqueness of the IDs.")
+      end
+    end
   end
 end

--- a/lib/inferno/repositories/in_memory_repository.rb
+++ b/lib/inferno/repositories/in_memory_repository.rb
@@ -1,4 +1,5 @@
 require 'forwardable'
+require_relative '../exceptions'
 
 module Inferno
   module Repositories
@@ -8,6 +9,8 @@ module Inferno
       def_delegators 'self.class', :all, :all_by_id
 
       def insert(entity)
+        raise Exceptions::DuplicateEntityIdException, entity.id if id_exists?(entity.id)
+
         all << entity
         entity
       end
@@ -36,6 +39,12 @@ module Inferno
           all.each { |klass| @all_by_id[klass.id] = klass }
           @all_by_id
         end
+      end
+
+      private
+
+      def id_exists?(id)
+        all.any? { |klass| klass.id == id }
       end
     end
   end

--- a/lib/inferno/repositories/in_memory_repository.rb
+++ b/lib/inferno/repositories/in_memory_repository.rb
@@ -9,9 +9,10 @@ module Inferno
       def_delegators 'self.class', :all, :all_by_id
 
       def insert(entity)
-        raise Exceptions::DuplicateEntityIdException, entity.id if id_exists?(entity.id)
+        raise Exceptions::DuplicateEntityIdException, entity.id if exists?(entity.id)
 
         all << entity
+        all_by_id[entity.id.to_s] = entity
         entity
       end
 
@@ -20,7 +21,7 @@ module Inferno
       end
 
       def exists?(id)
-        all_by_id.include? id
+        all_by_id.key?(id.to_s)
       end
 
       class << self
@@ -31,20 +32,7 @@ module Inferno
         # @private
         def all_by_id
           @all_by_id ||= {}
-          @all_by_id.length == all.length ? @all_by_id : index_by_id
         end
-
-        def index_by_id
-          @all_by_id = {}
-          all.each { |klass| @all_by_id[klass.id] = klass }
-          @all_by_id
-        end
-      end
-
-      private
-
-      def id_exists?(id)
-        all.any? { |klass| klass.id == id }
       end
     end
   end

--- a/spec/inferno/entities/test_suite_spec.rb
+++ b/spec/inferno/entities/test_suite_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Inferno::Entities::TestSuite do
     let(:id) { 'GROUP_ID' }
 
     before do
+      suite_class.id(SecureRandom.uuid)
       allow(Class).to receive(:new).with(Inferno::Entities::TestGroup).and_return(group_class)
     end
 

--- a/spec/inferno/repositories/presets_spec.rb
+++ b/spec/inferno/repositories/presets_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Inferno::Repositories::Presets do
       File.realpath(File.join(Dir.pwd, 'spec/fixtures/simple_preset.json.erb'))
     end
 
-    let(:uuid) { 'very-random-uuid' }
+    let(:uuid) { SecureRandom.uuid }
 
     before { allow(SecureRandom).to receive(:uuid).and_return(uuid) }
 

--- a/spec/inferno/repositories/test_suites_spec.rb
+++ b/spec/inferno/repositories/test_suites_spec.rb
@@ -24,4 +24,18 @@ RSpec.describe Inferno::Repositories::TestSuites do
       expect(record).to be_nil
     end
   end
+
+  describe '#insert' do
+    it 'inserts a new suite into the repository' do
+      records = repo.all
+      new_suite = Class.new(Inferno::TestSuite)
+      new_suite.id('suite_id')
+      expect { repo.insert(new_suite) }.to change { records.size }.by(1)
+      expect(records).to include(new_suite)
+    end
+
+    it 'raises an error if the id already exist' do
+      expect { repo.insert(suite) }.to raise_error(Inferno::Exceptions::DuplicateEntityIdException, /already exists/)
+    end
+  end
 end

--- a/spec/inferno/web/serializers/test_group_spec.rb
+++ b/spec/inferno/web/serializers/test_group_spec.rb
@@ -2,10 +2,10 @@ require_relative '../../../../lib/inferno/apps/web/serializers/test_group'
 
 RSpec.describe Inferno::Web::Serializers::TestGroup do
   let(:group) { InfrastructureTest::SerializerGroup }
-  let(:test) { group.tests.first }
 
   before do
     options_multi_group = Class.new(OptionsSuite::AllVersionsGroup) do
+      id SecureRandom.uuid
       group from: :v1_group,
             required_suite_options: { ig_version: '1' }
 


### PR DESCRIPTION
# Summary
This PR addresses a performance issue in the JSON API caused by collisions of entity or runnable IDs. Duplicate IDs lead Inferno to reindex tests every time a test is fetched from the repository, significantly impacting performance. To prevent this, the PR introduces a check that detects duplicate IDs before entities are inserted into the repository. If duplicates are found, Inferno will fail to start, prompting the user to resolve the ID collisions.

# Testing Guidance
- Tested with the G10, which contains duplicate test IDs in the US Core Test Kit.
- Confirmed that Inferno fails to start due to the detected duplicates

