### PR TITLE
FI-3223: Ensure Request Entity Verb Is Always Downcased

### DIFF
--- a/lib/inferno/entities/request.rb
+++ b/lib/inferno/entities/request.rb
@@ -181,7 +181,7 @@ module Inferno
               .map { |header_name, value| Header.new(name: header_name.downcase, value:, type: 'response') }
 
           new(
-            verb: response.env.method,
+            verb: response.env.method.downcase,
             url: response.env.url.to_s,
             direction:,
             name:,
@@ -210,7 +210,7 @@ module Inferno
             end
 
           new(
-            verb: request[:method],
+            verb: request[:method].downcase,
             url: request[:url],
             direction:,
             name:,


### PR DESCRIPTION
# Summary

This PR ensures that the verb attribute of the Request entity is consistently converted to lowercase during instantiation from all sources (Hamani, HTTP responses, or FHIR client).
