### PR TITLE
FI-3475: Unit testing improvements

### DIFF
--- a/inferno_core.gemspec
+++ b/inferno_core.gemspec
@@ -56,7 +56,8 @@ Gem::Specification.new do |spec|
     'lib/inferno/public/assets.json',
     'spec/support/factory_bot.rb',
     Dir['spec/factories/**/*.rb'],
-    Dir['spec/fixtures/**/*.rb']
+    Dir['spec/fixtures/**/*.rb'],
+    Dir['spec/*.rb']
   ].flatten
 
   spec.bindir        = 'bin'

--- a/lib/inferno/apps/cli/templates/Gemfile.tt
+++ b/lib/inferno/apps/cli/templates/Gemfile.tt
@@ -7,3 +7,7 @@ gemspec
 group :development, :test do
   gem 'debug'
 end
+
+group :test do
+  gem 'rack-test'
+end

--- a/lib/inferno/apps/cli/templates/spec/%library_name%/patient_group_spec.rb.tt
+++ b/lib/inferno/apps/cli/templates/spec/%library_name%/patient_group_spec.rb.tt
@@ -1,8 +1,6 @@
 RSpec.describe <%= module_name %>::PatientGroup do
-  let(:suite) { Inferno::Repositories::TestSuites.new.find('<%= test_suite_id %>') }
+  let(:suite_id) { '<%= test_suite_id %>' }
   let(:group) { suite.groups[1] }
-  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
-  let(:test_session) { repo_create(:test_session, test_suite_id: '<%= test_suite_id %>') }
   let(:url) { 'http://example.com/fhir' }
   let(:success_outcome) do
     {
@@ -23,15 +21,6 @@ RSpec.describe <%= module_name %>::PatientGroup do
       }],
       sessionId: ''
     }
-  end
-
-  def run(runnable, inputs = {})
-    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
-    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
-    inputs.each do |name, value|
-      session_data_repo.save(test_session_id: test_session.id, name: name, value: value, type: 'text')
-    end
-    Inferno::TestRunner.new(test_session: test_session, test_run: test_run).run(runnable)
   end
 
   describe 'read test' do

--- a/lib/inferno/apps/cli/templates/spec/spec_helper.rb.tt
+++ b/lib/inferno/apps/cli/templates/spec/spec_helper.rb.tt
@@ -127,7 +127,7 @@ Inferno::Utils::Migration.new.run
 require 'inferno'
 Inferno::Application.finalize!
 
-require Inferno::SpecSupport::FACTORY_BOT_SUPPORT_PATH
+Inferno::SpecSupport.require_helpers
 
 FactoryBot.definition_file_paths = [
   Inferno::SpecSupport::FACTORY_PATH

--- a/lib/inferno/dsl/resume_test_route.rb
+++ b/lib/inferno/dsl/resume_test_route.rb
@@ -72,7 +72,7 @@ module Inferno
 
       # @private
       def resume_ui_at_id(test_run, test)
-        test_run.test_suite_id || test_run.test_group_id || test.parent.id
+        test_run.test_suite_id || test_run.test_group_id || test.parent&.id || test.id
       end
 
       # @private

--- a/lib/inferno/spec_support.rb
+++ b/lib/inferno/spec_support.rb
@@ -5,5 +5,13 @@ module Inferno
   module SpecSupport
     FACTORY_BOT_SUPPORT_PATH = File.expand_path('../../spec/support/factory_bot', __dir__).freeze
     FACTORY_PATH = File.expand_path('../../spec/factories', __dir__).freeze
+    REQUEST_HELPER_PATH = File.expand_path('../../spec/request_helper', __dir__).freeze
+    RUNNABLE_HELPER_PATH = File.expand_path('../../spec/runnable_helper', __dir__).freeze
+
+    def self.require_helpers
+      require FACTORY_BOT_SUPPORT_PATH
+      require RUNNABLE_HELPER_PATH
+      require REQUEST_HELPER_PATH
+    end
   end
 end

--- a/spec/inferno/entities/test_group_spec.rb
+++ b/spec/inferno/entities/test_group_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Inferno::Entities::TestGroup do
+  let(:suite_id) { 'basic' }
+
   describe '.group' do
     let!(:subgroup_class) { Class.new(described_class) }
     let!(:group_class) { Class.new(described_class) }

--- a/spec/inferno/entities/test_suite_spec.rb
+++ b/spec/inferno/entities/test_suite_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe Inferno::Entities::TestSuite do
   let!(:suite_class) { Class.new(described_class) }
+  let(:suite_id) { 'basic' }
 
   describe '.group' do
     let!(:group_class) { Class.new(Inferno::Entities::TestGroup) }

--- a/spec/runnable_context.rb
+++ b/spec/runnable_context.rb
@@ -1,0 +1,43 @@
+RSpec.shared_context('when testing a runnable') do
+  let(:suite) { Inferno::Repositories::TestSuites.new.find(suite_id) }
+  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
+  let(:validation_url) { "#{ENV.fetch('FHIR_RESOURCE_VALIDATOR_URL')}/validate" }
+  let(:test_session) { repo_create(:test_session, test_suite_id: suite_id) }
+
+  before do
+    allow(described_class).to receive(:suite).and_return(suite) if described_class.parent.nil?
+  rescue NameError
+    raise StandardError, "No suite id defined. Add `let(:suite_id) { 'your_suite_id' }` to the spec"
+  end
+
+  def run(runnable, inputs = {})
+    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
+    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
+    inputs.each do |name, value|
+      session_data_repo.save(
+        test_session_id: test_session.id,
+        name:,
+        value:,
+        type: runnable.config.input_type(name)
+      )
+    end
+
+    Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
+  end
+
+  # depth-first search looking for a runnable with a runtime id
+  # (prefixed with the ancestor suite / group ids) that ends
+  # with the provided suffix. It can be the test's id if unique, or
+  # can include some ancestor context if needed to identify the
+  # correct test. The first matching test found will be returned.
+  def find_test(runnable, id_suffix)
+    return runnable if runnable.id.ends_with?(id_suffix)
+
+    runnable.children.each do |entity|
+      found = find_test(entity, id_suffix)
+      return found unless found.nil?
+    end
+
+    nil
+  end
+end

--- a/spec/runnable_helper.rb
+++ b/spec/runnable_helper.rb
@@ -1,0 +1,11 @@
+require_relative 'runnable_context'
+
+RSpec.configure do |config|
+  config.define_derived_metadata do |metadata|
+    if metadata[:described_class].present? && metadata[:described_class].is_a?(Inferno::DSL::Runnable)
+      metadata[:runnable] = true
+    end
+  end
+
+  config.include_context 'when testing a runnable', runnable: true
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -139,7 +139,7 @@ require_relative '../lib/inferno/utils/migration'
 Inferno::Utils::Migration.new.run
 Inferno::Application.finalize!
 
-require_relative 'support/factory_bot'
+Inferno::SpecSupport.require_helpers
 
 RSpec::Matchers.define_negated_matcher :exclude, :include
 require 'fhir_client'


### PR DESCRIPTION
This branch factors out common unit testing behaviors. For a demonstration of a test kit using this functionality, see https://github.com/inferno-framework/subscriptions-test-kit/pull/13

The template has also been updated to use these shared behaviors. If you generate a new test kit, comment out the inferno_core requirement in the gemspec, and point at this inferno_core branch in the Gemfile, the unit tests should pass in the created test kit.