### PR TITLE
FI-3469: Use provided auth input options

### DIFF
--- a/client/src/components/InputsModal/AuthTypeSelector.tsx
+++ b/client/src/components/InputsModal/AuthTypeSelector.tsx
@@ -1,55 +1,55 @@
 import React, { FC } from 'react';
-import { TestInput } from '~/models/testSuiteModels';
+import { InputOption, TestInput } from '~/models/testSuiteModels';
 import InputCombobox from './InputCombobox';
 
 export interface InputAccessProps {
-  requirement: TestInput;
+  input: TestInput;
   index: number;
   inputsMap: Map<string, unknown>;
   setInputsMap: (map: Map<string, unknown>, edited?: boolean) => void;
 }
 
-const AuthTypeSelector: FC<InputAccessProps> = ({
-  requirement,
-  index,
-  inputsMap,
-  setInputsMap,
-}) => {
-  const selectorSettings = requirement.options?.components
-    ? requirement.options?.components[0]
+const AuthTypeSelector: FC<InputAccessProps> = ({ input, index, inputsMap, setInputsMap }) => {
+  const selectorSettings = input.options?.components
+    ? input.options?.components[0]
     : // Default auth type settings
       {
         name: 'auth_type',
         default: 'public',
       };
 
+  const selectorOptions: InputOption[] =
+    input.options?.components?.find((component) => component.name === 'auth_type')?.options
+      ?.list_options ||
+    ([
+      {
+        label: 'Public',
+        value: 'public',
+      },
+      {
+        label: 'Confidential Symmetric',
+        value: 'symmetric',
+      },
+      {
+        label: 'Confidential Asymmetric',
+        value: 'asymmetric',
+      },
+      {
+        label: 'Backend Services',
+        value: 'backend_services',
+      },
+    ] as InputOption[]);
+
   const selectorModel: TestInput = {
     name: 'auth_type',
     type: 'select',
     title: 'Auth Type',
-    description: requirement.description,
+    description: input.description,
     default: selectorSettings.default || 'public',
     optional: selectorSettings.optional,
     locked: selectorSettings.locked,
     options: {
-      list_options: [
-        {
-          label: 'Public',
-          value: 'public',
-        },
-        {
-          label: 'Confidential Symmetric',
-          value: 'symmetric',
-        },
-        {
-          label: 'Confidential Asymmetric',
-          value: 'asymmetric',
-        },
-        {
-          label: 'Backend Services',
-          value: 'backend_services',
-        },
-      ],
+      list_options: selectorOptions,
     },
   };
 

--- a/client/src/components/InputsModal/InputAccess.tsx
+++ b/client/src/components/InputsModal/InputAccess.tsx
@@ -126,7 +126,7 @@ const InputAccess: FC<InputAccessProps> = ({ requirement, index, inputsMap, setI
           )}
           <List>
             <AuthTypeSelector
-              requirement={requirement}
+              input={requirement}
               index={index}
               inputsMap={accessValues}
               setInputsMap={updateAuthType}

--- a/client/src/components/InputsModal/InputAuth.tsx
+++ b/client/src/components/InputsModal/InputAuth.tsx
@@ -117,7 +117,7 @@ const InputAuth: FC<InputAuthProps> = ({ requirement, index, inputsMap, setInput
         )}
         <List>
           <AuthTypeSelector
-            requirement={requirement}
+            input={requirement}
             index={index}
             inputsMap={authValues}
             setInputsMap={updateAuthType}


### PR DESCRIPTION
# Summary

Options for the auth selector were previously hardcoded. This change will pull options from the provided input instead.

# Testing Guidance

Pull this branch into authinfo-flex to test
