### PR TITLE
FI-3023: Add default env vars and documentation to validator dockerfile

### DIFF
--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -1,9 +1,13 @@
 # This Dockerfile is based on the Dockerfile for org.hl7.fhir.validator-wrapper
 # https://github.com/hapifhir/org.hl7.fhir.validator-wrapper/blob/master/Dockerfile
-# with 3 key differences:
+# with the following differences:
 # 1. It fetches the built JAR from GitHub instead of locally, or building from source
 # 2. It adds MITRE certs, for ease of use by the MITRE development team
 # 3. It uses an Ubuntu-based base image instead of Alpine to support both AMD64 and ARM architectures
+# 4. It defaults the following environment variables:
+#    - SESSION_CACHE_IMPLEMENTATION=PassiveExpiringSessionCache
+#    - SESSION_CACHE_DURATION=-1
+#      - These enable the old session cache implementation, and configure the session cache to never expire sessions.
 #
 # The software release to use is based on the PROJECT_VERSION build argument (required)
 
@@ -15,7 +19,7 @@ RUN wget https://gitlab.mitre.org/mitre-scripts/mitre-pki/-/raw/master/os_script
 ARG PROJECT_VERSION
 RUN echo "Project version set to -> ${PROJECT_VERSION}"
 
-ENV APPLICATION_USER ktor
+ENV APPLICATION_USER=ktor
 RUN adduser $APPLICATION_USER
 
 RUN mkdir /app
@@ -28,7 +32,9 @@ WORKDIR /app
 RUN wget -O validator-wrapper.jar "https://github.com/hapifhir/org.hl7.fhir.validator-wrapper/releases/download/${PROJECT_VERSION}/validator_cli.jar"
 
 # Environment vars here
-ENV ENVIRONMENT prod
+ENV ENVIRONMENT=prod
+ENV SESSION_CACHE_IMPLEMENTATION=PassiveExpiringSessionCache
+ENV SESSION_CACHE_DURATION=-1
 
 EXPOSE 3500
 

--- a/validator/README.md
+++ b/validator/README.md
@@ -1,14 +1,26 @@
 # infernocommunity/inferno-resource-validator
 
-This Dockerfile is based on the Dockerfile for org.hl7.fhir.validator-wrapper (see https://github.com/hapifhir/org.hl7.fhir.validator-wrapper/blob/master/Dockerfile ) with 3 key differences relevant to Inferno:
+This Dockerfile is based on the Dockerfile for org.hl7.fhir.validator-wrapper (see https://github.com/hapifhir/org.hl7.fhir.validator-wrapper/blob/master/Dockerfile ) with the following differences relevant to Inferno:
 1. It fetches the built JAR from GitHub instead of locally, or building from source
 2. It adds MITRE certs, for ease of use by the MITRE development team
 3. It uses an Ubuntu-based base image instead of Alpine to support both AMD64 and ARM architectures
+4. It defaults the following environment variables:
+   - SESSION_CACHE_IMPLEMENTATION=PassiveExpiringSessionCache
+   - SESSION_CACHE_DURATION=-1
+     - These enable the old session cache implementation, and configure the session cache to never expire sessions.
 
-It is intended to be a drop-in replacement for the official image; i.e., if you don't need features 2 & 3 above you can use the same version of `markiantorno/validator-wrapper` with all the same settings, environment variables, etc. Version numbers of this image should match the version number of the official image.
+It is intended to be a drop-in replacement for the official image; i.e., if you don't need features 2 & 3 above you can use the same version of `markiantorno/validator-wrapper`. Version numbers of this image should match the version number of the official image. The only difference is you will need to set the environment variables as mentioned in (4) above, depending on which behavior you want.
 
 In addition to the above differences, published versions of this image have been tested by the Inferno team and are known to be compatible with Inferno test kits.
 
+## Recommended release sequence
+Since there are many test kits that depend on this validator service, the following sequence is recommended:
+
+1. Watch https://github.com/hapifhir/org.hl7.fhir.validator-wrapper for new releases.
+2. When there is a new release, build this dockerfile locally and test g10 (all versions of US Core) against it by updating the version in `docker-compose.background.yml`
+3. If there are changes needed to this dockerfile, submit that PR first.
+4. Publish a new version of this image once it's ready. IMPORTANT: any test kit that doesn't pin a specific version of the validator will now use that latest.
+5. Submit a PR on g10 to update the the version in `docker-compose.background.yml` and `lib/onc_certification_g10_test_kit/configuration_checker.rb`, and update the message filters if necessary.
 
 ## Publishing a new version
 A script `build_and_push.sh` is provided to assist with publishing a new version. The version of the wrapper service to use must be provided as the first command-line argument (required).


### PR DESCRIPTION
# Summary
In anticipation of inferno-resource-validator v1.0.58, this sets two new environment variable defaults in the docker image:
 - `SESSION_CACHE_IMPLEMENTATION=PassiveExpiringSessionCache`
   - Previously the PassiveExpiringSessionCache was the only implementation but then a different session cache was added, without support for a "never expire" value
 - `SESSION_CACHE_DURATION=-1`
   - Sets the session cache to "never expire". This is set on every test kit currently, but it makes more sense to keep these defaults here so we don't have to update dozens of test kits if things change behind the scenes like this.
  
And adds documentation explaining these variables plus the recommended update sequence when there's a new version.

Note I added the `=` to the other env var lines because I got warnings like this from the build otherwise:
``` 
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 20)
```   


# Testing Guidance
To build the image for 1.0.58 and load it locally without pushing to docker hub, run:
```
docker buildx build --platform linux/arm64 --build-arg "PROJECT_VERSION=1.0.58" --tag "infernocommunity/inferno-resource-validator:1.0.58" --load .
```
(this is the same as the build script in the same folder, but with `--load` instead of `--push` and only building for arm64)

After that, this can be tested directly against g10 by running this branch: https://github.com/onc-healthit/onc-certification-g10-test-kit/pull/592
