### PR TITLE
Fix Inferno::Entities::TestSession docs

### DIFF
--- a/lib/inferno/entities/test_session.rb
+++ b/lib/inferno/entities/test_session.rb
@@ -11,14 +11,11 @@ module Inferno
     # @!attribute test_suite_id
     #   @return [String] id of the `TestSuite` being run in this session
     # @!attribute test_suite
-    #   @return [Inferno::Entities::TestSuite] the `TestSuite` being run in this
-    #   session
+    #   @return [Inferno::Entities::TestSuite] the `TestSuite` being run in this session
     # @!attribute test_runs
-    #   @return [Array<Inferno::Entities::TestRun>] the `TestRuns` associated
-    #   with this session
+    #   @return [Array<Inferno::Entities::TestRun>] the `TestRuns` associated with this session
     # @!attribute results
-    #   @return [Array<Inferno::Entities::TestResult>] the `TestResults`
-    #   associated with this session
+    #   @return [Array<Inferno::Entities::TestResult>] the `TestResults` associated with this session
     # @!attribute suite_options
     #   @return [Hash] the suite options associated with this session
     class TestSession < Entity

--- a/lib/inferno/entities/test_session.rb
+++ b/lib/inferno/entities/test_session.rb
@@ -11,11 +11,14 @@ module Inferno
     # @!attribute test_suite_id
     #   @return [String] id of the `TestSuite` being run in this session
     # @!attribute test_suite
-    #   @return [Inferno::Entities::TestSuite] the `TestSuite` being run in this session
+    #   @return [Inferno::Entities::TestSuite] the `TestSuite` being run in this
+    #     session
     # @!attribute test_runs
-    #   @return [Array<Inferno::Entities::TestRun>] the `TestRuns` associated with this session
+    #   @return [Array<Inferno::Entities::TestRun>] the `TestRuns` associated
+    #     with this session
     # @!attribute results
-    #   @return [Array<Inferno::Entities::TestResult>] the `TestResults` associated with this session
+    #   @return [Array<Inferno::Entities::TestResult>] the `TestResults`
+    #     associated with this session
     # @!attribute suite_options
     #   @return [Hash] the suite options associated with this session
     class TestSession < Entity


### PR DESCRIPTION
# Summary

I suspect rubocop broke it here: https://inferno-framework.github.io/inferno-core/docs/Inferno/Entities/TestSession.html#test_suite-instance_method


