### PR TITLE
Add markdown formatting to input descriptions.

### DIFF
--- a/dev_suites/dev_demo_ig_stu1/groups/demo_group.rb
+++ b/dev_suites/dev_demo_ig_stu1/groups/demo_group.rb
@@ -6,17 +6,17 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
     title 'Demo Group'
 
     description %(
-    # This is a markdown header
-    **Inferno** [github](https://github.com/inferno-framework/inferno-core)
+      # This is a markdown header
+      **Inferno** [github](https://github.com/inferno-framework/inferno-core)
 
-    Below is a markdown table
-    | Column 1 | Column 2 | Column 3 |
-    | :--- | :---: | ---: |
-    | Entry 1 | Entry 2 | Entry 3|
-    | Entry 4 | Entry 5 | Entry 6 |
+      Below is a markdown table
+      | Column 1 | Column 2 | Column 3 |
+      | :--- | :---: | ---: |
+      | Entry 1 | Entry 2 | Entry 3|
+      | Entry 4 | Entry 5 | Entry 6 |
 
-    This is a dummy canonical link http://hl7.org/fhir/ValueSet/my-valueset|0.8 that should not be
-    interpreted as a table
+      This is a dummy canonical link http://hl7.org/fhir/ValueSet/my-valueset|0.8 that should not be
+      interpreted as a table
     )
 
     # Inputs and outputs
@@ -26,9 +26,13 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
     # while also allowing type hints at a higher level.
 
     input :url, title: 'URL', description: 'Insert url of FHIR server', default: 'https://inferno.healthit.gov/reference-server/r4'
-    input :patient_id, title: 'Patient ID', description: %(
-### This is a markdown description.
-This is a new line.), default: '85'
+    input :patient_id,
+      title: 'Patient ID',
+      default: '85',
+      description: %(
+        ### This is a markdown description.
+        This is a new line.
+      )
     input :bearer_token, optional: true, default: 'SAMPLE_TOKEN'
 
     output :observation_id,

--- a/dev_suites/dev_infrastructure_test/serializer_group.rb
+++ b/dev_suites/dev_infrastructure_test/serializer_group.rb
@@ -10,6 +10,14 @@ module InfrastructureTest
           description: 'INPUT3_DESCRIPTION',
           default: 'INPUT3_DEFAULT',
           type: 'text'
+    input :markdown_input,
+          description: %(
+            # Markdown Title
+            
+            Markdown description
+          ),
+          default: 'INPUT3_DEFAULT',
+          type: 'text'
 
     output :output3
 

--- a/lib/inferno/apps/web/serializers/input.rb
+++ b/lib/inferno/apps/web/serializers/input.rb
@@ -1,3 +1,4 @@
+require_relative 'markdown_extractor'
 require_relative 'serializer'
 
 module Inferno
@@ -7,7 +8,7 @@ module Inferno
         identifier :name
 
         field :title, if: :field_present?
-        field :description, if: :field_present?
+        field :description, extractor: MarkdownExtractor, if: :field_present?
         field :type, if: :field_present?
         field :default, if: :field_present?
         field :optional, if: :field_present?

--- a/lib/inferno/apps/web/serializers/markdown_extractor.rb
+++ b/lib/inferno/apps/web/serializers/markdown_extractor.rb
@@ -1,0 +1,17 @@
+require 'blueprinter'
+require_relative '../../../utils/markdown_formatter'
+
+module Inferno
+  module Web
+    module Serializers
+      class MarkdownExtractor < Blueprinter::Extractor
+
+        include Inferno::Utils::MarkdownFormatter
+
+        def extract(field_name, object, _local_options, _options = {})
+          format_markdown(object.send(field_name))
+        end
+      end
+    end
+  end
+end

--- a/spec/inferno/utils/preset_template_generator_spec.rb
+++ b/spec/inferno/utils/preset_template_generator_spec.rb
@@ -15,8 +15,9 @@ RSpec.describe Inferno::Utils::PresetTemplateGenerator do
           value: 'https://inferno.healthit.gov/reference-server/r4'
         },
         { name: 'patient_id', _type: 'text', _title: 'Patient ID', _description: %(
-### This is a markdown description.
-This is a new line.),  value: '85' },
+        ### This is a markdown description.
+        This is a new line.
+      ),  value: '85' },
         { name: 'bearer_token', _type: 'text', _optional: true, value: 'SAMPLE_TOKEN' },
         { name: 'textarea', _type: 'textarea', _title: 'Textarea Input Example',
           _description: 'Insert something like a patient resource json here', _optional: true, value: nil },

--- a/spec/inferno/web/serializers/test_group_spec.rb
+++ b/spec/inferno/web/serializers/test_group_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../../lib/inferno/apps/web/serializers/test_group'
+require_relative '../../../../lib/inferno/utils/markdown_formatter'
 
 RSpec.describe Inferno::Web::Serializers::TestGroup do
+
+  include Inferno::Utils::MarkdownFormatter
   let(:group) { InfrastructureTest::SerializerGroup }
 
   before do
@@ -46,7 +49,10 @@ RSpec.describe Inferno::Web::Serializers::TestGroup do
 
       input = Inferno::Entities::Input.new(**raw_input)
 
-      expect(input).to eq(definition)
+      expect(input.name).to eq(definition.name)
+      expect(input.type).to eq(definition.type)
+      expect(input.default).to eq(definition.default)
+      expect(input.description).to eq(format_markdown(definition.description))
     end
 
     group.output_definitions.each_value do |definition|


### PR DESCRIPTION
# Summary

This adds some logic that formats input description markdown in the serializer.  This implementation assumes our eventual movement of unindenting texts automatically at the serialization level instead of earlier in the process.

I put this in another PR to merge into the base PR because I would like @Jammjammjamm to review and decide if we should just shelve this until a bigger refactor later, or if it is clean enough to get into the other markdown PR so we can fully 'ship' an input markdown feature without having the test writer unindent manually for this specific case.

# Testing Guidance

`Demo Suite > Demo Group 1 > Demo Group Instance 1` should have proper markdown description in the group, as well as in one of the inputs when you 'Run' it.  

<img width="1327" alt="Screenshot 2024-11-22 at 12 18 33 PM" src="https://github.com/user-attachments/assets/4d5b28c1-aa0e-4a2f-99ad-c5f6b24ceb67">

