### PR TITLE
FI-2961 execute preset support

### DIFF
--- a/config/presets/dev_validator_preset.json
+++ b/config/presets/dev_validator_preset.json
@@ -1,0 +1,26 @@
+{
+  "title": "Preset for Validator Suite",
+  "id": "dev_validator_preset",
+  "test_suite_id": "dev_validator",
+  "inputs": [
+    {
+      "name": "url",
+      "value": "https://hapi.fhir.org/baseR4",
+      "_title": "FHIR Server Base Url",
+      "_type": "text"
+    },
+    {
+      "name": "access_token",
+      "value": null,
+      "_title": "Bearer/Access Token",
+      "_type": "text",
+      "_optional": true
+    },
+    {
+      "name": "patient_id",
+      "value": "1234321",
+      "_title": "Patient ID",
+      "_type": "text"
+    }
+  ]
+}

--- a/lib/inferno/apps/cli/execute.rb
+++ b/lib/inferno/apps/cli/execute.rb
@@ -136,9 +136,9 @@ module Inferno
 
       def inputs_and_preset
         if preset
-          preset_inputs = preset.inputs.map do |preset_input|
-            [ preset_input[:name], preset_input[:value] ]
-          end.to_h
+          preset_inputs = preset.inputs.to_h do |preset_input|
+            [preset_input[:name], preset_input[:value]]
+          end
 
           options.fetch(:inputs, {}).merge(preset_inputs)
         else

--- a/lib/inferno/apps/cli/execute.rb
+++ b/lib/inferno/apps/cli/execute.rb
@@ -44,12 +44,12 @@ module Inferno
 
         self.options = options
 
-        outputter.print_start_message(options)
+        outputter.print_start_message(self.options)
 
         load_preset
-
+    
         results = []
-        outputter.print_around_run(options) do
+        outputter.print_around_run(self.options) do
           if all_selected_groups_and_tests.empty?
             test_run = create_test_run(suite)
             run_one(suite, test_run)
@@ -107,7 +107,9 @@ module Inferno
       def load_preset
         return unless options.key?(:preset)
 
-        preset_inputs = JSON.parse(File.read(options[:preset]))
+        preset_inputs = JSON.parse(File.read(options[:preset]))['inputs'].map do |input|
+          [input['name'], input['value']]
+        end.to_h
 
         options[:inputs] = options.fetch(:inputs, {}).deep_merge(preset_inputs)
       end

--- a/lib/inferno/apps/cli/execute.rb
+++ b/lib/inferno/apps/cli/execute.rb
@@ -105,11 +105,11 @@ module Inferno
       end
 
       def load_preset
-        if self.options.key?(:preset)
-          preset_inputs = JSON.parse(File.read(self.options[:preset]))
+        return unless options.key?(:preset)
 
-          self.options[:inputs] = self.options.fetch(:inputs, {}).deep_merge(preset_inputs)
-        end
+        preset_inputs = JSON.parse(File.read(options[:preset]))
+
+        options[:inputs] = options.fetch(:inputs, {}).deep_merge(preset_inputs)
       end
 
       def all_selected_groups_and_tests

--- a/lib/inferno/apps/cli/execute.rb
+++ b/lib/inferno/apps/cli/execute.rb
@@ -108,6 +108,8 @@ module Inferno
         return unless options[:preset_file]
         raise StandardError, 'Cannot use `--preset-id` and `--preset-file` options together' if options[:preset_id]
 
+        raise StandardError, "File #{options[:preset_file]} not found" unless File.exist? options[:preset_file]
+
         options[:preset_id] = JSON.parse(File.read(options[:preset_file]))['id']
         raise StandardError, "Preset #{options[:preset_file]} is missing id" if options[:preset_id].nil?
 

--- a/lib/inferno/apps/cli/execute.rb
+++ b/lib/inferno/apps/cli/execute.rb
@@ -114,8 +114,6 @@ module Inferno
         raise StandardError, "Preset #{options[:preset_file]} is missing id" if options[:preset_id].nil?
 
         presets_repo.insert_from_file(options[:preset_file])
-
-        test_sessions_repo.apply_preset(test_session, options[:preset_id])
       end
 
       def all_selected_groups_and_tests
@@ -140,7 +138,7 @@ module Inferno
             [preset_input[:name], preset_input[:value]]
           end
 
-          options.fetch(:inputs, {}).merge(preset_inputs)
+          options.fetch(:inputs, {}).reverse_merge(preset_inputs)
         else
           options.fetch(:inputs, {})
         end

--- a/lib/inferno/apps/cli/execute.rb
+++ b/lib/inferno/apps/cli/execute.rb
@@ -40,6 +40,8 @@ module Inferno
 
         outputter.print_start_message(options)
 
+        load_preset
+
         results = []
         outputter.print_around_run(options) do
           if all_selected_groups_and_tests.empty?
@@ -90,6 +92,14 @@ module Inferno
       def outputter
         # TODO: swap outputter based on options
         @outputter ||= Inferno::CLI::Execute::ConsoleOutputter.new
+      end
+
+      def load_preset
+        if self.options.key?(:preset)
+          preset_inputs = JSON.parse(File.read(self.options[:preset]))
+
+          self.options[:inputs] = self.options.fetch(:inputs, {}).deep_merge(preset_inputs)
+        end
       end
 
       def all_selected_groups_and_tests

--- a/lib/inferno/apps/cli/main.rb
+++ b/lib/inferno/apps/cli/main.rb
@@ -146,7 +146,7 @@ module Inferno
              desc: 'Display this message'
       def execute
         Execute.boot_full_inferno
-        Execute.new.run(options)
+        Execute.new.run(options.dup) # dup to unfreeze Thor options
       end
 
       # https://github.com/rails/thor/issues/244 - Make Thor exit(1) on Errors/Exceptions

--- a/lib/inferno/apps/cli/main.rb
+++ b/lib/inferno/apps/cli/main.rb
@@ -125,11 +125,15 @@ module Inferno
       option :inputs,
              aliases: ['-i'],
              type: :hash,
-             desc: 'Inputs (i.e: --inputs=foo:bar goo:baz)'
-      option :preset,
+             desc: 'Inputs (i.e: --inputs=foo:bar goo:baz); will merge and override preset inputs'
+      option :preset_id,
+             aliases: ['-P'],
+             type: :string,
+             desc: 'Inferno preset id; cannot be used with `--preset-file`'
+      option :preset_file,
              aliases: ['-p'],
              type: :string,
-             desc: 'Path to an Inferno preset file for inputs; `--inputs` will merge and override presets'
+             desc: 'Path to an Inferno preset file for inputs; cannot be used with `--preset-id`'
       option :outputter,
              aliases: ['-o'],
              default: 'console',

--- a/lib/inferno/apps/cli/main.rb
+++ b/lib/inferno/apps/cli/main.rb
@@ -129,7 +129,7 @@ module Inferno
       option :preset,
              aliases: ['-p'],
              type: :string,
-             desc: 'Path to an Inferno preset file for inputs; `--inputs` will merge and override presets if both are given.'
+             desc: 'Path to an Inferno preset file for inputs; `--inputs` will merge and override presets'
       option :outputter,
              aliases: ['-o'],
              default: 'console',

--- a/lib/inferno/apps/cli/main.rb
+++ b/lib/inferno/apps/cli/main.rb
@@ -116,6 +116,10 @@ module Inferno
              aliases: ['-i'],
              type: :hash,
              desc: 'Inputs (i.e: --inputs=foo:bar goo:baz)'
+      option :preset,
+             aliases: ['-p'],
+             type: :string,
+             desc: 'Path to an Inferno preset file for inputs; `--inputs` will merge and override presets if both are given.'
       option :verbose,
              aliases: ['-v'],
              type: :boolean,

--- a/lib/inferno/config/boot/executor.rb
+++ b/lib/inferno/config/boot/executor.rb
@@ -10,5 +10,6 @@ Inferno::Application.register_provider(:executor) do
     end
 
     target_container.start :suites
+    target_container.start :presets
   end
 end

--- a/spec/fixtures/dev_validator_preset_2.json
+++ b/spec/fixtures/dev_validator_preset_2.json
@@ -1,0 +1,26 @@
+{
+  "title": "Preset for Validator Suite in RSpec",
+  "id": "dev_validator_preset_2",
+  "test_suite_id": "dev_validator",
+  "inputs": [
+    {
+      "name": "url",
+      "value": "https://hapi.fhir.org/baseR4",
+      "_title": "FHIR Server Base Url",
+      "_type": "text"
+    },
+    {
+      "name": "access_token",
+      "value": null,
+      "_title": "Bearer/Access Token",
+      "_type": "text",
+      "_optional": true
+    },
+    {
+      "name": "patient_id",
+      "value": "1234321",
+      "_title": "Patient ID",
+      "_type": "text"
+    }
+  ]
+}

--- a/spec/inferno/cli/execute_spec.rb
+++ b/spec/inferno/cli/execute_spec.rb
@@ -237,12 +237,16 @@ RSpec.describe Inferno::CLI::Execute do
     end
 
     let(:inputs) { { 'url' => 'https://example.com', 'patient_id' => '1' } }
+    let(:preset_id) { 'dev_validator_preset' }
+    let(:preset_file) { Inferno::Application.root.join('config/presets/dev_validator_preset.json').to_s }
 
-    it 'works on dev_validator suite' do
+    before(:each) do
       stub_request(:post, "#{ENV.fetch('FHIR_RESOURCE_VALIDATOR_URL')}/validate")
         .with(query: hash_including({}))
         .to_return(status: 200, body: success_outcome.to_json)
+    end
 
+    it 'works on dev_validator suite' do
       stub_request(:get, 'https://example.com/Patient/1')
         .to_return(status: 200, body: FHIR::Patient.new({ name: { given: 'Smith' } }).to_json)
 
@@ -250,6 +254,26 @@ RSpec.describe Inferno::CLI::Execute do
         expect { instance.run({ suite:, inputs:, outputter: 'plain', verbose: true }) }
           .to raise_error(an_instance_of(SystemExit).and(having_attributes(status: 0)))
       end.to output(/.+/).to_stdout
+    end
+
+    it 'works with preset id' do
+      stub_request(:get, 'https://hapi.fhir.org/baseR4/Patient/1234321')
+        .to_return(status: 200, body: FHIR::Patient.new({ name: { given: 'Smith' } }).to_json)
+
+      expect do
+        expect { instance.run({ suite:, preset_id:, outputter: 'plain', verbose: true}) }
+          .to raise_error(an_instance_of(SystemExit).and(having_attributes(status: 0)))
+      end.to output(/.+/).to_stdout
+    end
+
+    it 'works with preset file' do
+      stub_request(:get, 'https://hapi.fhir.org/baseR4/Patient/1234321')
+        .to_return(status: 200, body: FHIR::Patient.new({ name: { given: 'Smith' } }).to_json)
+
+      expect do
+        expect { instance.run({ suite:, preset_file:, outputter: 'plain', verbose: true}) }
+          .to raise_error(an_instance_of(SystemExit).and(having_attributes(status: 0)))
+      end#.to output(/.+/).to_stdout
     end
   end
 end

--- a/spec/inferno/cli/execute_spec.rb
+++ b/spec/inferno/cli/execute_spec.rb
@@ -238,9 +238,9 @@ RSpec.describe Inferno::CLI::Execute do
 
     let(:inputs) { { 'url' => 'https://example.com', 'patient_id' => '1' } }
     let(:preset_id) { 'dev_validator_preset' }
-    let(:preset_file) { Inferno::Application.root.join('config/presets/dev_validator_preset.json').to_s }
+    let(:preset_file) { Inferno::Application.root.join('spec/fixtures/dev_validator_preset_2.json').to_s }
 
-    before(:each) do
+    before do
       stub_request(:post, "#{ENV.fetch('FHIR_RESOURCE_VALIDATOR_URL')}/validate")
         .with(query: hash_including({}))
         .to_return(status: 200, body: success_outcome.to_json)
@@ -261,7 +261,7 @@ RSpec.describe Inferno::CLI::Execute do
         .to_return(status: 200, body: FHIR::Patient.new({ name: { given: 'Smith' } }).to_json)
 
       expect do
-        expect { instance.run({ suite:, preset_id:, outputter: 'plain', verbose: true}) }
+        expect { instance.run({ suite:, preset_id:, outputter: 'plain', verbose: true }) }
           .to raise_error(an_instance_of(SystemExit).and(having_attributes(status: 0)))
       end.to output(/.+/).to_stdout
     end
@@ -271,9 +271,9 @@ RSpec.describe Inferno::CLI::Execute do
         .to_return(status: 200, body: FHIR::Patient.new({ name: { given: 'Smith' } }).to_json)
 
       expect do
-        expect { instance.run({ suite:, preset_file:, outputter: 'plain', verbose: true}) }
+        expect { instance.run({ suite:, preset_file:, outputter: 'plain', verbose: true }) }
           .to raise_error(an_instance_of(SystemExit).and(having_attributes(status: 0)))
-      end#.to output(/.+/).to_stdout
+      end.to output(/.+/).to_stdout
     end
   end
 end


### PR DESCRIPTION
# Summary

Adds two CLI options for `inferno execute`:
 - `--preset-id` that will load a preset by id from directories listed in [lib/inferno/config/boot/presets.rb](https://github.com/inferno-framework/inferno-core/tree/main/lib/inferno/config/boot/presets.rb). This helps test kit authors.
 - `--preset-file` that will load a preset from a given file path. This helps test kit CI users.
 - Both `--preset-id` and `--preset-file` cannot be used together. However `--inputs` can be used with either of those options, and inputs will merge with and override presets.

# Testing Guidance

1. Checkout this branch
2. Start inferno services
3. Confirm this command works:
```
bundle exec inferno execute --suite dev_validator --preset-id dev_validator_preset
```
4. Prepare another preset file, i.e: `cp config/presets/dev_validator_preset.json tmp/my_preset.json`. Edit the file to change its id to something else unique.
5. Confirm this command works (with the file name you used):
```
bundle exec inferno execute --suite dev_validator --preset-file ./tmp/my_preset.json
```
6. Confirm this command fails with patient not found, indicating inputs override preset:
```
bundle exec inferno execute -s dev_validator --preset-id dev_validator_preset -i patient_id:notfound
```