### PR TITLE
FI-3550: Handle optional waiting results

### DIFF
--- a/lib/inferno/result_summarizer.rb
+++ b/lib/inferno/result_summarizer.rb
@@ -12,6 +12,8 @@ module Inferno
     end
 
     def summarize
+      return 'wait' if results.any? { |result| result.result == 'wait' }
+
       return 'pass' if optional_results_passing_criteria_met?
 
       prioritized_result_strings.find { |result_string| unique_result_strings.include? result_string }

--- a/spec/inferno/result_summarizer_spec.rb
+++ b/spec/inferno/result_summarizer_spec.rb
@@ -3,6 +3,7 @@ require_relative '../../lib/inferno/result_summarizer'
 RSpec.describe Inferno::ResultSummarizer do
   let(:passing_result) { repo_create(:result, result: 'pass') }
   let(:failing_result) { repo_create(:result, result: 'fail') }
+  let(:waiting_result) { repo_create(:result, result: 'wait') }
 
   context 'when all results are required' do
     it 'returns the highest priority result' do
@@ -28,6 +29,13 @@ RSpec.describe Inferno::ResultSummarizer do
       result = described_class.new([passing_result, failing_result]).summarize
 
       expect(result).to eq('pass')
+    end
+
+    it 'returns "wait" if an optional result is waiting' do
+      allow(waiting_result).to receive(:optional?).and_return(true)
+      result = described_class.new([passing_result, waiting_result]).summarize
+
+      expect(result).to eq('wait')
     end
   end
 end


### PR DESCRIPTION
# Summary
This branch fixes the result summarizer to properly handle optional tests with wait results.

# Testing Guidance
Load up a test kit with an optional wait test, and it should behave properly on this branch.