### PR TITLE
FI-3565: Upgrade validator dockerfile to match upstream

### DIFF
--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -25,6 +25,9 @@ RUN adduser $APPLICATION_USER
 RUN mkdir /app
 RUN chown -R $APPLICATION_USER /app
 
+RUN mkdir /home/$APPLICATION_USER/.fhir
+RUN chown -R $APPLICATION_USER /home/$APPLICATION_USER/.fhir
+
 USER $APPLICATION_USER
 
 # These lines copy the packaged application into the Docker image and sets the working directory to where it was copied.


### PR DESCRIPTION
# Summary
Upgrades the inferno-resource-validator Dockerfile to match the latest upstream changes in https://github.com/hapifhir/org.hl7.fhir.validator-wrapper v1.0.60

Specifically this adds a couple lines that enable the fhir package cache to work as a docker volume, from https://github.com/hapifhir/org.hl7.fhir.validator-wrapper/commit/b006e3c669584f9e06c530ea1aba3070810d2828

# Testing Guidance
To build just this image and load it locally:
```
docker buildx build --platform linux/arm64 --build-arg "PROJECT_VERSION=1.0.60" --tag "infernocommunity/inferno-resource-validator:1.0.60" --tag infernocommunity/inferno-resource-validator:latest --load .
```

Then to map a volume, uncomment this line in the docker-compose here or in your favorite test kit: https://github.com/inferno-framework/inferno-core/blob/637a014e9744d9669fe2ac6fcd8b91bba2a75400/docker-compose.background.yml#L39
There may still be some quirks to shake out but with that volume mapped, the validator service should start up and run as normal.
