### PR TITLE
FI-3588: Use git for files in test kit gemspecs

### DIFF
--- a/lib/inferno/apps/cli/new.rb
+++ b/lib/inferno/apps/cli/new.rb
@@ -108,7 +108,7 @@ module Inferno
       end
 
       def initialize_git_repo
-        run 'git init && git add . && git commit -am "initial commit"'
+        run 'git init -q && git add . && git commit -aqm "initial commit"'
       end
 
       def load_igs

--- a/lib/inferno/apps/cli/new.rb
+++ b/lib/inferno/apps/cli/new.rb
@@ -71,6 +71,7 @@ module Inferno
         inside(root_name) do
           bundle_install
           inferno_migrate
+          initialize_git_repo
           load_igs
         end
 
@@ -104,6 +105,10 @@ module Inferno
         return if options['skip_bundle']
 
         run 'bundle exec inferno migrate', verbose: !options['quiet'], capture: options['quiet']
+      end
+
+      def initialize_git_repo
+        run 'git init && git add . && git commit -am "initial commit"'
       end
 
       def load_igs

--- a/lib/inferno/apps/cli/templates/%library_name%.gemspec.tt
+++ b/lib/inferno/apps/cli/templates/%library_name%.gemspec.tt
@@ -21,13 +21,7 @@ Gem::Specification.new do |spec|
   spec.metadata['inferno_test_kit'] = 'true'
   # spec.metadata['homepage_uri'] = spec.homepage
   # spec.metadata['source_code_uri'] = 'TODO'
-  spec.files = [
-    Dir['lib/**/*.rb'],
-    Dir['lib/**/*.json'],
-    Dir['config/presets/*.json'],
-    Dir['config/presets/*.json.erb'],
-    'LICENSE'
-  ].flatten
+  spec.files         = `[ -d .git ] && git ls-files -z lib config/presets LICENSE`.split("\x0")
 
   spec.require_paths = ['lib']
 end

--- a/spec/inferno/cli/new_spec.rb
+++ b/spec/inferno/cli/new_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Inferno::CLI::New do
       expect { described_class.start(cli_args) }.to_not raise_error
 
       expect(Dir).to exist('test-fhir-app')
+      expect(Dir).to exist('test-fhir-app/.git')
       expect(File).to exist('test-fhir-app/Gemfile')
       expect(File).to exist('test-fhir-app/test_fhir_app.gemspec')
       expect(File).to exist('test-fhir-app/lib/test_fhir_app.rb')


### PR DESCRIPTION
# Summary
This branch updates the gemspec in the template to include files based on what is committed to git. This will help avoid the issue where a test kit gem is published but new files are not included because they do not meet the criteria for inclusion in the gemspec.

# Testing Guidance
- `bundle exec bin/inferno new my_test_kit`
- `cd my-test-kit`
- `mkdir config/presets`
- `touch config/presets/my_preset.json`
- `git add config`
- `git commit -m "add preset"`
- `gem build my_test_kit.gemspec`
- `mkdir gem`
- `mv my_test_kit-0.0.0.gem gem`
- `cd gem`
- `tar -xvf my_test_kit-0.0.0.gem`
- `tar -xvzf data.tar.gz`
You should see all of the expected files (everything in lib and the preset).