### PR TITLE
FI-3338: Create common test kit specs

### DIFF
--- a/inferno_core.gemspec
+++ b/inferno_core.gemspec
@@ -57,6 +57,7 @@ Gem::Specification.new do |spec|
     'spec/support/factory_bot.rb',
     Dir['spec/factories/**/*.rb'],
     Dir['spec/fixtures/**/*.rb'],
+    Dir['spec/shared/**/*.rb'],
     Dir['spec/*.rb']
   ].flatten
 

--- a/lib/inferno/spec_support.rb
+++ b/lib/inferno/spec_support.rb
@@ -7,11 +7,13 @@ module Inferno
     FACTORY_PATH = File.expand_path('../../spec/factories', __dir__).freeze
     REQUEST_HELPER_PATH = File.expand_path('../../spec/request_helper', __dir__).freeze
     RUNNABLE_HELPER_PATH = File.expand_path('../../spec/runnable_helper', __dir__).freeze
+    TEST_KIT_SPEC = File.expand_path('../../spec/shared/test_kit_examples', __dir__).freeze
 
     def self.require_helpers
       require FACTORY_BOT_SUPPORT_PATH
       require RUNNABLE_HELPER_PATH
       require REQUEST_HELPER_PATH
+      require TEST_KIT_SPEC
     end
   end
 end

--- a/spec/shared/test_kit_examples.rb
+++ b/spec/shared/test_kit_examples.rb
@@ -37,7 +37,7 @@ RSpec.shared_examples 'deployable_test_kit' do
           'its version can now be determined by the version of its Test Kit.' \
           "Remove the `version` method call in the suite definition.\n"
 
-        expect(suite).to_not match(%r{^\s+version(\s|\()\S+\)?}), error_message
+        expect(suite).to_not match(/^\s+version(\s|\()\S+\)?/), error_message
       end
     end
 
@@ -52,7 +52,7 @@ RSpec.shared_examples 'deployable_test_kit' do
       ]
 
       required_fields.each do |field_name|
-        expect(test_kit).send(field_name).to be_present
+        expect(test_kit.send(field_name)).to be_present
       end
     end
 
@@ -66,7 +66,7 @@ RSpec.shared_examples 'deployable_test_kit' do
     end
 
     it 'has a maturity of "Low", "Medium", or "High"' do
-      expect(['Low', 'Medium', 'High']).to include(test_kit.maturity)
+      expect(['Low', 'Medium', 'High']).to include(test_kit.maturity) # rubocop:disable RSpec/ExpectActual
     end
   end
 

--- a/spec/shared/test_kit_examples.rb
+++ b/spec/shared/test_kit_examples.rb
@@ -23,12 +23,12 @@ RSpec.shared_examples 'platform_deployable_test_kit' do
 
       expect { described_class.const_get('Metadata') }.to_not raise_error(NameError), error_message
 
-      expect(described_class.const_get('Metadata')).to be_a(Inferno::Entities::TestKit)
+      expect(described_class.const_get('Metadata') < Inferno::Entities::TestKit).to eq(true)
     end
 
     it 'relies on the test kit version rather than defining the version in the suites' do
       suites = test_kit.suite_ids.map { |id| Inferno::Repositories::TestSuites.new.find(id) }
-      suite_paths = suites.map { |suite| Object.const_source_location(suite.name) }
+      suite_paths = suites.map { |suite| Object.const_source_location(suite.name).first }
       suite_contents = suite_paths.map { |path| File.read(path) }
 
       suite_contents.each_with_index do |suite, i|

--- a/spec/shared/test_kit_examples.rb
+++ b/spec/shared/test_kit_examples.rb
@@ -1,4 +1,4 @@
-RSpec.shared_examples 'deployable_test_kit' do
+RSpec.shared_examples 'platform_deployable_test_kit' do
   let(:test_kit_location) do
     Object.const_source_location(described_class.name).first
   end

--- a/spec/shared/test_kit_examples.rb
+++ b/spec/shared/test_kit_examples.rb
@@ -75,9 +75,15 @@ RSpec.shared_examples 'deployable_test_kit' do
       presets = Dir[
         File.join(base_path, 'config', 'presets', '*.json'),
         File.join(base_path, 'config', 'presets', '*.json.erb')
-      ]
+      ].map { |file_path| file_path.delete_prefix "#{Dir.pwd}/" }
 
-      expect(test_kit_gem.files).to include(*presets)
+      missing_presets = presets - test_kit_gem.files
+
+      error_message =
+        "The following presets are not included in the gem: #{missing_presets.join(', ')}\n" \
+        "Ensure that config/presets is included in spec.files in #{test_kit_gem.name}.gemspec"
+
+      expect(missing_presets).to be_empty, error_message
     end
   end
 
@@ -91,6 +97,13 @@ RSpec.shared_examples 'deployable_test_kit' do
         "spec.files = `[ -d .git ] && git ls-files -z lib config/presets LICENSE`.split(\"\\x0\")\n"
 
       expect(gemspec_contents).to include('[ -d .git ] && git ls-files'), error_message
+    end
+
+    it 'includes the inferno test kit metadata tag' do
+      error_message =
+        %(Add "spec.metadata['inferno_test_kit'] = 'true'" to #{test_kit_gem.name}.gemspec)
+
+      expect(test_kit_gem.metadata['inferno_test_kit']).to eq('true'), error_message
     end
   end
 end

--- a/spec/shared/test_kit_examples.rb
+++ b/spec/shared/test_kit_examples.rb
@@ -23,7 +23,7 @@ RSpec.shared_examples 'platform_deployable_test_kit' do
 
       expect { described_class.const_get('Metadata') }.to_not raise_error(NameError), error_message
 
-      expect(described_class.const_get('Metadata') < Inferno::Entities::TestKit).to eq(true)
+      expect(described_class.const_get('Metadata') < Inferno::Entities::TestKit).to be(true)
     end
 
     it 'relies on the test kit version rather than defining the version in the suites' do

--- a/spec/shared/test_kit_examples.rb
+++ b/spec/shared/test_kit_examples.rb
@@ -1,23 +1,29 @@
-Rspec.shared_examples 'deployable_test_kit' do
+RSpec.shared_examples 'deployable_test_kit' do
+  let(:test_kit_location) do
+    Object.const_source_location(described_class.name).first
+  end
+  let(:test_kit_gem) do
+    Bundler.definition.specs.find { |gem| test_kit_location.start_with? gem.full_gem_path }
+  end
+  let(:base_path) do
+    test_kit_gem.full_gem_path
+  end
+  let(:test_kit) do
+    described_class.const_get('Metadata')
+  rescue NameError
+    skip 'TestKit must be defined first'
+  end
+
   describe 'TestKit' do
-    let(:test_kit_location) do
-      Object.const_source_location(described_class.name)
-    end
-    let(:test_kit_gem) do
-      Bundler.definition.specs.find { |gem| test_kit_location.start_with? gem.full_gem_path }
-    end
-    let(:base_path) { test_git_gem.full_gem_path }
-    let(:test_kit) { described_class.const_get('Metadata') }
-
     it 'defines test kit in the Metadata class' do
-      error_message = <<~MESSAGE
-        Define #{described_class.name}::Metadata at
-        lib/#{described_class.name.underscore}/metadata.rb and require it in
-        lib/#{described_class.name.underscore}.rb
-      MESSAGE
-      expect { test_kit }.to_not raise(NameError), error_message
+      error_message =
+        "Define #{described_class.name}::Metadata at " \
+        "lib/#{described_class.name.underscore}/metadata.rb and require it in " \
+        "lib/#{described_class.name.underscore}.rb\n"
 
-      expect(test_kit).to be_a(Inferno::Entities::TestKit)
+      expect { described_class.const_get('Metadata') }.to_not raise_error(NameError), error_message
+
+      expect(described_class.const_get('Metadata')).to be_a(Inferno::Entities::TestKit)
     end
 
     it 'relies on the test kit version rather than defining the version in the suites' do
@@ -26,11 +32,10 @@ Rspec.shared_examples 'deployable_test_kit' do
       suite_contents = suite_paths.map { |path| File.read(path) }
 
       suite_contents.each_with_index do |suite, i|
-        error_message = <<~MESSAGE
-          Suite at #{suite_paths[i]} should not explicitly declare a version, as
-          its version can now be determined by the version of its Test Kit.
-          Remove the `version` method call in the suite definition.
-        MESSAGE
+        error_message =
+          "Suite at #{suite_paths[i]} should not explicitly declare a version, as " \
+          'its version can now be determined by the version of its Test Kit.' \
+          "Remove the `version` method call in the suite definition.\n"
 
         expect(suite).to_not match(%r{^\s+version(\s|\()\S+\)?}), error_message
       end
@@ -52,11 +57,10 @@ Rspec.shared_examples 'deployable_test_kit' do
     end
 
     it 'has a description with a <!-- break -->' do
-      error_message = <<~MESSAGE
-        The test kit description must begin with one paragraph followed by "<!--
-        break -->". The portion of the description above the break is displayed
-        on the test kit listing page.
-      MESSAGE
+      error_message =
+        'The test kit description must begin with one paragraph followed by "<!-- ' \
+        'break -->". The portion of the description above the break is displayed ' \
+        "on the test kit listing page.\n"
 
       expect(test_kit.description).to include('<!-- break -->'), error_message
     end
@@ -81,11 +85,10 @@ Rspec.shared_examples 'deployable_test_kit' do
     it 'uses git to determine files to include in the gem' do
       gemspec_contents = File.read(File.join(base_path, "#{test_kit_gem.name}.gemspec"))
 
-      error_message = <<~MESSAGE
-        Use git to determine which files to include in the gem. In
-        #{test_kit_gem.name}.gemspec, use:
-        spec.files = `[ -d .git ] && git ls-files -z lib config/presets LICENSE`.split("\x0")
-      MESSAGE
+      error_message =
+        'Use git to determine which files to include in the gem. In ' \
+        "#{test_kit_gem.name}.gemspec, use: " \
+        "spec.files = `[ -d .git ] && git ls-files -z lib config/presets LICENSE`.split(\"\\x0\")\n"
 
       expect(gemspec_contents).to include('[ -d .git ] && git ls-files'), error_message
     end

--- a/spec/shared/test_kit_examples.rb
+++ b/spec/shared/test_kit_examples.rb
@@ -10,11 +10,30 @@ Rspec.shared_examples 'deployable_test_kit' do
     let(:test_kit) { described_class.const_get('Metadata') }
 
     it 'defines test kit in the Metadata class' do
+      error_message = <<~MESSAGE
+        Define #{described_class.name}::Metadata at
+        lib/#{described_class.name.underscore}/metadata.rb and require it in
+        lib/#{described_class.name.underscore}.rb
+      MESSAGE
+      expect { test_kit }.to_not raise(NameError), error_message
+
       expect(test_kit).to be_a(Inferno::Entities::TestKit)
     end
 
     it 'relies on the test kit version rather than defining the version in the suites' do
-      # TODO
+      suites = test_kit.suite_ids.map { |id| Inferno::Repositories::TestSuites.new.find(id) }
+      suite_paths = suites.map { |suite| Object.const_source_location(suite.name) }
+      suite_contents = suite_paths.map { |path| File.read(path) }
+
+      suite_contents.each_with_index do |suite, i|
+        error_message = <<~MESSAGE
+          Suite at #{suite_paths[i]} should not explicitly declare a version, as
+          its version can now be determined by the version of its Test Kit.
+          Remove the `version` method call in the suite definition.
+        MESSAGE
+
+        expect(suite).to_not match(%r{^\s+version(\s|\()\S+\)?}), error_message
+      end
     end
 
     it 'defines all required fields' do
@@ -33,11 +52,42 @@ Rspec.shared_examples 'deployable_test_kit' do
     end
 
     it 'has a description with a <!-- break -->' do
-      expect(test_kit.description).to include('<!-- break -->')
+      error_message = <<~MESSAGE
+        The test kit description must begin with one paragraph followed by "<!--
+        break -->". The portion of the description above the break is displayed
+        on the test kit listing page.
+      MESSAGE
+
+      expect(test_kit.description).to include('<!-- break -->'), error_message
     end
 
     it 'has a maturity of "Low", "Medium", or "High"' do
       expect(['Low', 'Medium', 'High']).to include(test_kit.maturity)
+    end
+  end
+
+  describe 'presets' do
+    it 'includes presets in the gem' do
+      presets = Dir[
+        File.join(base_path, 'config', 'presets', '*.json'),
+        File.join(base_path, 'config', 'presets', '*.json.erb')
+      ]
+
+      expect(test_kit_gem.files).to include(*presets)
+    end
+  end
+
+  describe 'gemspec' do
+    it 'uses git to determine files to include in the gem' do
+      gemspec_contents = File.read(File.join(base_path, "#{test_kit_gem.name}.gemspec"))
+
+      error_message = <<~MESSAGE
+        Use git to determine which files to include in the gem. In
+        #{test_kit_gem.name}.gemspec, use:
+        spec.files = `[ -d .git ] && git ls-files -z lib config/presets LICENSE`.split("\x0")
+      MESSAGE
+
+      expect(gemspec_contents).to include('[ -d .git ] && git ls-files'), error_message
     end
   end
 end

--- a/spec/shared/test_kit_examples.rb
+++ b/spec/shared/test_kit_examples.rb
@@ -1,0 +1,43 @@
+Rspec.shared_examples 'deployable_test_kit' do
+  describe 'TestKit' do
+    let(:test_kit_location) do
+      Object.const_source_location(described_class.name)
+    end
+    let(:test_kit_gem) do
+      Bundler.definition.specs.find { |gem| test_kit_location.start_with? gem.full_gem_path }
+    end
+    let(:base_path) { test_git_gem.full_gem_path }
+    let(:test_kit) { described_class.const_get('Metadata') }
+
+    it 'defines test kit in the Metadata class' do
+      expect(test_kit).to be_a(Inferno::Entities::TestKit)
+    end
+
+    it 'relies on the test kit version rather than defining the version in the suites' do
+      # TODO
+    end
+
+    it 'defines all required fields' do
+      required_fields = [
+        :id,
+        :title,
+        :description,
+        :suite_ids,
+        :version,
+        :maturity
+      ]
+
+      required_fields.each do |field_name|
+        expect(test_kit).send(field_name).to be_present
+      end
+    end
+
+    it 'has a description with a <!-- break -->' do
+      expect(test_kit.description).to include('<!-- break -->')
+    end
+
+    it 'has a maturity of "Low", "Medium", or "High"' do
+      expect(['Low', 'Medium', 'High']).to include(test_kit.maturity)
+    end
+  end
+end


### PR DESCRIPTION
# Summary
This branch creates a set of shared examples which test kits can import to ensure that they meet the requirements to be deployed on inferno.healthit.gov.

# Testing Guidance
Check out the `fi-3338-test` branch in the US Core Test Kit, `bundle`, and `bundle exec rake` to run these tests.
