### PR TITLE
FI-3643: Check input components for auth

### DIFF
--- a/client/src/components/InputsModal/AuthSettings.ts
+++ b/client/src/components/InputsModal/AuthSettings.ts
@@ -77,6 +77,7 @@ export const getAuthFields = (
     },
     {
       name: 'requested_scopes',
+      type: 'textarea',
       title: 'Scopes',
       description: 'OAuth 2.0 scopes needed to enable all required functionality',
     },

--- a/client/src/components/InputsModal/AuthTypeSelector.tsx
+++ b/client/src/components/InputsModal/AuthTypeSelector.tsx
@@ -10,8 +10,12 @@ export interface InputAccessProps {
 }
 
 const AuthTypeSelector: FC<InputAccessProps> = ({ input, index, inputsMap, setInputsMap }) => {
-  const selectorSettings = input.options?.components
-    ? input.options?.components[0]
+  const authComponent = input.options?.components?.find(
+    (component) => component.name === 'auth_type',
+  );
+
+  const selectorSettings = authComponent
+    ? authComponent
     : // Default auth type settings
       {
         name: 'auth_type',

--- a/client/src/components/InputsModal/InputAccess.tsx
+++ b/client/src/components/InputsModal/InputAccess.tsx
@@ -26,7 +26,7 @@ const InputAccess: FC<InputAccessProps> = ({ input, index, inputsMap, setInputsM
     (component) => component.name === 'auth_type',
   );
   const [authType, setAuthType] = React.useState<string>(
-    authComponent ? (authComponent.default as string) : 'public',
+    authComponent?.default ? (authComponent.default as string) : 'public',
   );
 
   const [accessFields, setAccessFields] = React.useState<TestInput[]>(

--- a/client/src/components/InputsModal/InputAccess.tsx
+++ b/client/src/components/InputsModal/InputAccess.tsx
@@ -22,9 +22,13 @@ const InputAccess: FC<InputAccessProps> = ({ input, index, inputsMap, setInputsM
   const [accessValuesPopulated, setAccessValuesPopulated] = React.useState<boolean>(false);
 
   // Default auth type settings
-  const [authType, setAuthType] = React.useState<string>(
-    input.options?.components ? (input.options?.components[0].default as string) : 'public',
+  const authComponent = input.options?.components?.find(
+    (component) => component.name === 'auth_type',
   );
+  const [authType, setAuthType] = React.useState<string>(
+    authComponent ? (authComponent.default as string) : 'public',
+  );
+
   const [accessFields, setAccessFields] = React.useState<TestInput[]>(
     getAccessFields(authType as AuthType, accessValues, input.options?.components || []),
   );

--- a/client/src/components/InputsModal/InputAccess.tsx
+++ b/client/src/components/InputsModal/InputAccess.tsx
@@ -22,11 +22,17 @@ const InputAccess: FC<InputAccessProps> = ({ input, index, inputsMap, setInputsM
   const [accessValuesPopulated, setAccessValuesPopulated] = React.useState<boolean>(false);
 
   // Default auth type settings
-  const authComponent = input.options?.components?.find(
+  const authComponentDefault = input.options?.components?.find(
     (component) => component.name === 'auth_type',
-  );
+  )?.default;
+
+  const firstListOption =
+    input.options?.list_options && input.options?.list_options?.length > 0
+      ? input.options?.list_options[0]
+      : undefined;
+
   const [authType, setAuthType] = React.useState<string>(
-    authComponent?.default ? (authComponent.default as string) : 'public',
+    (authComponentDefault || firstListOption || 'public') as string,
   );
 
   const [accessFields, setAccessFields] = React.useState<TestInput[]>(

--- a/client/src/components/InputsModal/InputAccess.tsx
+++ b/client/src/components/InputsModal/InputAccess.tsx
@@ -22,17 +22,17 @@ const InputAccess: FC<InputAccessProps> = ({ input, index, inputsMap, setInputsM
   const [accessValuesPopulated, setAccessValuesPopulated] = React.useState<boolean>(false);
 
   // Default auth type settings
-  const authComponentDefault = input.options?.components?.find(
+  const authComponent = input.options?.components?.find(
     (component) => component.name === 'auth_type',
-  )?.default;
+  );
 
   const firstListOption =
-    input.options?.list_options && input.options?.list_options?.length > 0
-      ? input.options?.list_options[0]
+    authComponent?.options?.list_options && authComponent?.options?.list_options?.length > 0
+      ? authComponent?.options?.list_options[0].value
       : undefined;
 
   const [authType, setAuthType] = React.useState<string>(
-    (authComponentDefault || firstListOption || 'public') as string,
+    (authComponent?.default || firstListOption || 'public') as string,
   );
 
   const [accessFields, setAccessFields] = React.useState<TestInput[]>(

--- a/client/src/components/InputsModal/InputAuth.tsx
+++ b/client/src/components/InputsModal/InputAuth.tsx
@@ -25,7 +25,7 @@ const InputAuth: FC<InputAuthProps> = ({ input, index, inputsMap, setInputsMap }
     (component) => component.name === 'auth_type',
   );
   const [authType, setAuthType] = React.useState<string>(
-    authComponent ? (authComponent.default as string) : 'public',
+    authComponent?.default ? (authComponent.default as string) : 'public',
   );
 
   const [authFields, setAuthFields] = React.useState<TestInput[]>(

--- a/client/src/components/InputsModal/InputAuth.tsx
+++ b/client/src/components/InputsModal/InputAuth.tsx
@@ -20,9 +20,13 @@ const InputAuth: FC<InputAuthProps> = ({ input, index, inputsMap, setInputsMap }
   const [authValues, setAuthValues] = React.useState<Map<string, unknown>>(new Map());
   const [authValuesPopulated, setAuthValuesPopulated] = React.useState<boolean>(false);
 
+  const authComponent = input.options?.components?.find(
+    (component) => component.name === 'auth_type',
+  );
+
   // Default auth type settings
   const [authType, setAuthType] = React.useState<string>(
-    input.options?.components ? (input.options?.components[0].default as string) : 'public',
+    authComponent ? (authComponent.default as string) : 'public',
   );
 
   const [authFields, setAuthFields] = React.useState<TestInput[]>(

--- a/client/src/components/InputsModal/InputAuth.tsx
+++ b/client/src/components/InputsModal/InputAuth.tsx
@@ -21,17 +21,17 @@ const InputAuth: FC<InputAuthProps> = ({ input, index, inputsMap, setInputsMap }
   const [authValuesPopulated, setAuthValuesPopulated] = React.useState<boolean>(false);
 
   // Default auth type settings
-  const authComponentDefault = input.options?.components?.find(
+  const authComponent = input.options?.components?.find(
     (component) => component.name === 'auth_type',
-  )?.default;
+  );
 
   const firstListOption =
-    input.options?.list_options && input.options?.list_options?.length > 0
-      ? input.options?.list_options[0]
+    authComponent?.options?.list_options && authComponent?.options?.list_options?.length > 0
+      ? authComponent?.options?.list_options[0].value
       : undefined;
 
   const [authType, setAuthType] = React.useState<string>(
-    (authComponentDefault || firstListOption || 'public') as string,
+    (authComponent?.default || firstListOption || 'public') as string,
   );
 
   const [authFields, setAuthFields] = React.useState<TestInput[]>(

--- a/client/src/components/InputsModal/InputAuth.tsx
+++ b/client/src/components/InputsModal/InputAuth.tsx
@@ -21,11 +21,17 @@ const InputAuth: FC<InputAuthProps> = ({ input, index, inputsMap, setInputsMap }
   const [authValuesPopulated, setAuthValuesPopulated] = React.useState<boolean>(false);
 
   // Default auth type settings
-  const authComponent = input.options?.components?.find(
+  const authComponentDefault = input.options?.components?.find(
     (component) => component.name === 'auth_type',
-  );
+  )?.default;
+
+  const firstListOption =
+    input.options?.list_options && input.options?.list_options?.length > 0
+      ? input.options?.list_options[0]
+      : undefined;
+
   const [authType, setAuthType] = React.useState<string>(
-    authComponent?.default ? (authComponent.default as string) : 'public',
+    (authComponentDefault || firstListOption || 'public') as string,
   );
 
   const [authFields, setAuthFields] = React.useState<TestInput[]>(

--- a/client/src/components/InputsModal/InputAuth.tsx
+++ b/client/src/components/InputsModal/InputAuth.tsx
@@ -20,11 +20,10 @@ const InputAuth: FC<InputAuthProps> = ({ input, index, inputsMap, setInputsMap }
   const [authValues, setAuthValues] = React.useState<Map<string, unknown>>(new Map());
   const [authValuesPopulated, setAuthValuesPopulated] = React.useState<boolean>(false);
 
+  // Default auth type settings
   const authComponent = input.options?.components?.find(
     (component) => component.name === 'auth_type',
   );
-
-  // Default auth type settings
   const [authType, setAuthType] = React.useState<string>(
     authComponent ? (authComponent.default as string) : 'public',
   );


### PR DESCRIPTION
# Summary

Bug fix for the following: 

**Current behavior:** Auth inputs check first component provided for default selection settings. If another component is provided, inputs break.

**Expected behavior:** Inputs should find first component with type auth

_See branch fi-3093-debug_

# Testing Guidance

Pull this branch into fi-3093-debug -- should be able to open inputs without errors. Check auth inputs, access inputs, and type selector; all should work.

Cases to check: 

1. `components` is empty and/or undefined -- AuthInfo Suite
2. `components` has only `auth_type` -- AuthInfo Suite
3. `components` has only something else -- SMART STU1
4. `components` has something else and `auth_type` -- add the following to `InputAuth.tsx` on line 22:

`input.options?.components?.push({
    name: 'auth_type',
    default: 'symmetric',
  });`

Selector should show Confidential Symmetric.