### PR TITLE
FI-3178: Validate Resource Without Validation Messages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -331,6 +331,7 @@ PLATFORMS
   arm64-darwin-23
   x86_64-darwin-20
   x86_64-darwin-22
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/inferno/dsl/fhir_resource_validation.rb
+++ b/lib/inferno/dsl/fhir_resource_validation.rb
@@ -157,7 +157,7 @@ module Inferno
         end
 
         # @see Inferno::DSL::FHIRResourceValidation#resource_is_valid?
-        def resource_is_valid?(resource, profile_url, runnable, log_messages: true) # rubocop:disable Metrics/CyclomaticComplexity
+        def resource_is_valid?(resource, profile_url, runnable, add_messages_to_runnable: true) # rubocop:disable Metrics/CyclomaticComplexity
           profile_url ||= FHIR::Definitions.resource_definition(resource.resourceType).url
 
           begin
@@ -173,7 +173,7 @@ module Inferno
 
           message_hashes = message_hashes_from_outcome(outcome, resource, profile_url)
 
-          if log_messages
+          if add_messages_to_runnable
             message_hashes
               .each { |message_hash| runnable.add_message(message_hash[:type], message_hash[:message]) }
           end

--- a/lib/inferno/dsl/fhir_resource_validation.rb
+++ b/lib/inferno/dsl/fhir_resource_validation.rb
@@ -157,7 +157,7 @@ module Inferno
         end
 
         # @see Inferno::DSL::FHIRResourceValidation#resource_is_valid?
-        def resource_is_valid?(resource, profile_url, runnable)
+        def resource_is_valid?(resource, profile_url, runnable, log_messages: true) # rubocop:disable Metrics/CyclomaticComplexity
           profile_url ||= FHIR::Definitions.resource_definition(resource.resourceType).url
 
           begin
@@ -173,8 +173,10 @@ module Inferno
 
           message_hashes = message_hashes_from_outcome(outcome, resource, profile_url)
 
-          message_hashes
-            .each { |message_hash| runnable.add_message(message_hash[:type], message_hash[:message]) }
+          if log_messages
+            message_hashes
+              .each { |message_hash| runnable.add_message(message_hash[:type], message_hash[:message]) }
+          end
 
           unless response.status == 200
             raise Inferno::Exceptions::ErrorInValidatorException,

--- a/lib/inferno/dsl/fhir_validation.rb
+++ b/lib/inferno/dsl/fhir_validation.rb
@@ -30,10 +30,13 @@ module Inferno
       # @param resource [FHIR::Model]
       # @param profile_url [String]
       # @param validator [Symbol] the name of the validator to use
-      # @param log_messages [Boolean] whether to log validation messages or not
+      # @param add_messages_to_runnable [Boolean] whether to add validation messages to runnable or not
       # @return [Boolean] whether the resource is valid
-      def resource_is_valid?(resource: self.resource, profile_url: nil, validator: :default, log_messages: true)
-        find_validator(validator).resource_is_valid?(resource, profile_url, self, log_messages:)
+      def resource_is_valid?(
+        resource: self.resource, profile_url: nil,
+        validator: :default, add_messages_to_runnable: true
+      )
+        find_validator(validator).resource_is_valid?(resource, profile_url, self, add_messages_to_runnable:)
       end
 
       # Find a particular validator. Looks through a runnable's parents up to
@@ -114,7 +117,7 @@ module Inferno
         end
 
         # @see Inferno::DSL::FHIRValidation#resource_is_valid?
-        def resource_is_valid?(resource, profile_url, runnable, log_messages: true) # rubocop:disable Metrics/CyclomaticComplexity
+        def resource_is_valid?(resource, profile_url, runnable, add_messages_to_runnable: true) # rubocop:disable Metrics/CyclomaticComplexity
           profile_url ||= FHIR::Definitions.resource_definition(resource.resourceType).url
 
           begin
@@ -129,7 +132,7 @@ module Inferno
 
           message_hashes = message_hashes_from_outcome(outcome, resource, profile_url)
 
-          if log_messages
+          if add_messages_to_runnable
             message_hashes
               .each { |message_hash| runnable.add_message(message_hash[:type], message_hash[:message]) }
           end

--- a/lib/inferno/dsl/fhir_validation.rb
+++ b/lib/inferno/dsl/fhir_validation.rb
@@ -30,6 +30,7 @@ module Inferno
       # @param resource [FHIR::Model]
       # @param profile_url [String]
       # @param validator [Symbol] the name of the validator to use
+      # @param log_messages [Boolean] whether to log validation messages or not
       # @return [Boolean] whether the resource is valid
       def resource_is_valid?(resource: self.resource, profile_url: nil, validator: :default, log_messages: true)
         find_validator(validator).resource_is_valid?(resource, profile_url, self, log_messages:)

--- a/spec/inferno/dsl/fhir_resource_validation_spec.rb
+++ b/spec/inferno/dsl/fhir_resource_validation_spec.rb
@@ -153,11 +153,22 @@ RSpec.describe Inferno::DSL::FHIRResourceValidation do
           .to_return(status: 200, body: invalid_outcome)
       end
 
-      it 'includes resourceType/id in error message' do
-        result = validator.resource_is_valid?(resource2, profile_url, runnable)
+      context 'when log_messages is set to true' do
+        it 'includes resourceType/id in error message' do
+          result = validator.resource_is_valid?(resource2, profile_url, runnable)
 
-        expect(result).to be(false)
-        expect(runnable.messages.first[:message]).to start_with("#{resource2.resourceType}/#{resource2.id}:")
+          expect(result).to be(false)
+          expect(runnable.messages.first[:message]).to start_with("#{resource2.resourceType}/#{resource2.id}:")
+        end
+      end
+
+      context 'when log_messages is set to false' do
+        it 'does not log messages' do
+          result = validator.resource_is_valid?(resource2, profile_url, runnable, log_messages: false)
+
+          expect(result).to be(false)
+          expect(runnable.messages).to be_empty
+        end
       end
     end
 

--- a/spec/inferno/dsl/fhir_resource_validation_spec.rb
+++ b/spec/inferno/dsl/fhir_resource_validation_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe Inferno::DSL::FHIRResourceValidation do
           .to_return(status: 200, body: invalid_outcome)
       end
 
-      context 'when log_messages is set to true' do
+      context 'when add_messages_to_runnable is set to true' do
         it 'includes resourceType/id in error message' do
           result = validator.resource_is_valid?(resource2, profile_url, runnable)
 
@@ -162,9 +162,9 @@ RSpec.describe Inferno::DSL::FHIRResourceValidation do
         end
       end
 
-      context 'when log_messages is set to false' do
+      context 'when add_messages_to_runnable is set to false' do
         it 'does not log messages' do
-          result = validator.resource_is_valid?(resource2, profile_url, runnable, log_messages: false)
+          result = validator.resource_is_valid?(resource2, profile_url, runnable, add_messages_to_runnable: false)
 
           expect(result).to be(false)
           expect(runnable.messages).to be_empty

--- a/spec/inferno/dsl/fhir_validation_spec.rb
+++ b/spec/inferno/dsl/fhir_validation_spec.rb
@@ -114,19 +114,31 @@ RSpec.describe Inferno::DSL::FHIRValidation do
           .to_return(status: 200, body: invalid_outcome)
       end
 
-      it 'includes resourceType/id in error message' do
-        result = validator.resource_is_valid?(resource, profile_url, runnable)
+      context 'when log_messages is set to true' do
+        it 'includes resourceType/id in error message' do
+          result = validator.resource_is_valid?(resource, profile_url, runnable)
 
-        expect(result).to be(false)
-        expect(runnable.messages.first[:message]).to start_with("#{resource.resourceType}/#{resource.id}:")
+          expect(result).to be(false)
+          expect(runnable.messages.first[:message]).to start_with("#{resource.resourceType}/#{resource.id}:")
+        end
+
+        it 'includes resourceType in error message if resource.id is nil' do
+          resource.id = nil
+          result = validator.resource_is_valid?(resource, profile_url, runnable)
+
+          expect(result).to be(false)
+          expect(runnable.messages.first[:message]).to start_with("#{resource.resourceType}:")
+        end
       end
 
-      it 'includes resourceType in error message if resource.id is nil' do
-        resource.id = nil
-        result = validator.resource_is_valid?(resource, profile_url, runnable)
+      context 'when log_messages is set to false' do
+        it 'does not log messages' do
+          resource.id = nil
+          result = validator.resource_is_valid?(resource, profile_url, runnable, log_messages: false)
 
-        expect(result).to be(false)
-        expect(runnable.messages.first[:message]).to start_with("#{resource.resourceType}:")
+          expect(result).to be(false)
+          expect(runnable.messages).to be_empty
+        end
       end
     end
 

--- a/spec/inferno/dsl/fhir_validation_spec.rb
+++ b/spec/inferno/dsl/fhir_validation_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Inferno::DSL::FHIRValidation do
           .to_return(status: 200, body: invalid_outcome)
       end
 
-      context 'when log_messages is set to true' do
+      context 'when add_messages_to_runnable is set to true' do
         it 'includes resourceType/id in error message' do
           result = validator.resource_is_valid?(resource, profile_url, runnable)
 
@@ -131,10 +131,10 @@ RSpec.describe Inferno::DSL::FHIRValidation do
         end
       end
 
-      context 'when log_messages is set to false' do
+      context 'when add_messages_to_runnable is set to false' do
         it 'does not log messages' do
           resource.id = nil
-          result = validator.resource_is_valid?(resource, profile_url, runnable, log_messages: false)
+          result = validator.resource_is_valid?(resource, profile_url, runnable, add_messages_to_runnable: false)
 
           expect(result).to be(false)
           expect(runnable.messages).to be_empty


### PR DESCRIPTION
# Summary

This branch updates the existing method `resource_is_valid?` to conditionally log in messages to runnable to accomodate scenario where the user may not want to log validation messages. The method was updated by adding an additional parameter `add_messages_to_runnable` with a default value of true, that can be toggle off or on depending on the use case.

