### PR TITLE
Pin concurrent-ruby to 1.3.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       activesupport (~> 6.1.7.5)
       base62-rb (= 0.3.1)
       blueprinter (= 0.25.2)
+      concurrent-ruby (= 1.3.4)
       dotenv (~> 2.7)
       dry-configurable (= 1.0.0)
       dry-container (= 0.10.0)

--- a/inferno_core.gemspec
+++ b/inferno_core.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport', '~> 6.1.7.5'
   spec.add_dependency 'base62-rb', '0.3.1'
   spec.add_dependency 'blueprinter', '0.25.2'
+  spec.add_dependency 'concurrent-ruby', '1.3.4' # Fix activesupport https://github.com/rails/rails/issues/54272
   spec.add_dependency 'dotenv', '~> 2.7'
   spec.add_dependency 'dry-configurable', '1.0.0'
   spec.add_dependency 'dry-container', '0.10.0'

--- a/lib/inferno/apps/cli/templates/Dockerfile.tt
+++ b/lib/inferno/apps/cli/templates/Dockerfile.tt
@@ -7,6 +7,7 @@ RUN mkdir -p $INSTALL_PATH
 WORKDIR $INSTALL_PATH
 
 ADD lib/<%= library_name %>/metadata.rb $INSTALL_PATH/lib/<%= library_name %>/metadata.rb
+ADD lib/<%= library_name %>/version.rb $INSTALL_PATH/lib/<%= library_name %>/version.rb
 ADD *.gemspec $INSTALL_PATH
 ADD Gemfile* $INSTALL_PATH
 RUN gem install bundler


### PR DESCRIPTION
# Summary

This PR fixes onc-healthit/onc-certification-g10-test-kit#610 and the broken `inferno new` command. The bugs are due to [activesupport and concurrent-ruby gems](https://github.com/rails/rails/issues/54272). Activesupport PR rails/rails#54264 should also fix it but has not been released yet.

# Testing Guidance
1. Checkout this branch
2. Generate a new test kit:
```
bundle exec inferno new fix-test
```
3. Add this line to `fix-test/Gemfile`:
```
gem 'inferno_core', git: 'https://github.com/inferno-framework/inferno-core', branch: 'pin-concurrent-ruby-1.3.4'
```
4. Make sure the new test kit works via Docker:
```
cd fix-test
./setup.sh
./run.sh
```
5. Clean up
```
cd ..
rm -rf fix-test
```