### PR TITLE
FI-3653: Lock auth inputs if parent is locked

### DIFF
--- a/client/src/components/InputsModal/Auth/AuthSettings.ts
+++ b/client/src/components/InputsModal/Auth/AuthSettings.ts
@@ -52,6 +52,7 @@ export const getAuthFields = (
   authType: AuthType,
   authValues: Map<string, unknown>,
   components: TestInput[],
+  lockedInput: boolean,
 ): TestInput[] => {
   const fields = [
     {
@@ -59,6 +60,7 @@ export const getAuthFields = (
       type: 'checkbox',
       title: 'Populate fields from discovery',
       optional: true,
+      locked: lockedInput,
       default: 'true',
     },
     {
@@ -66,6 +68,7 @@ export const getAuthFields = (
       title: 'Authorization URL',
       description: "URL of the server's authorization endpoint",
       optional: true,
+      locked: lockedInput,
       hide: authValues?.get('use_discovery') === 'true',
     },
     {
@@ -73,6 +76,7 @@ export const getAuthFields = (
       title: 'Token URL',
       description: "URL of the authorization server's token endpoint",
       optional: true,
+      locked: lockedInput,
       hide: authValues?.get('use_discovery') === 'true',
     },
     {
@@ -80,21 +84,25 @@ export const getAuthFields = (
       type: 'textarea',
       title: 'Scopes',
       description: 'OAuth 2.0 scopes needed to enable all required functionality',
+      locked: lockedInput,
     },
     {
       name: 'client_id',
       title: 'Client ID',
       description: 'Client ID provided during registration of Inferno',
+      locked: lockedInput,
     },
     {
       name: 'client_secret',
       title: 'Client Secret',
       description: 'Client secret provided during registration of Inferno',
+      locked: lockedInput,
     },
     {
       name: 'pkce_support',
       type: 'radio',
       title: 'Proof Key for Code Exchange (PKCE)',
+      locked: lockedInput,
       options: {
         list_options: [
           {
@@ -113,6 +121,7 @@ export const getAuthFields = (
       type: 'radio',
       title: 'PKCE Code Challenge Method',
       optional: true,
+      locked: lockedInput,
       options: {
         list_options: [
           {
@@ -131,6 +140,7 @@ export const getAuthFields = (
       name: 'auth_request_method',
       type: 'radio',
       title: 'Authorization Request Method',
+      locked: lockedInput,
       options: {
         list_options: [
           {
@@ -148,6 +158,7 @@ export const getAuthFields = (
       name: 'encryption_algorithm',
       type: 'radio',
       title: 'Encryption Algorithm',
+      locked: lockedInput,
       options: {
         list_options: [
           {
@@ -167,6 +178,7 @@ export const getAuthFields = (
       description:
         'Key ID of the JWKS private key used to sign the client assertion. If blank, the first key for the selected encryption algorithm will be used.',
       optional: true,
+      locked: lockedInput,
     },
     {
       name: 'jwks',
@@ -175,6 +187,7 @@ export const getAuthFields = (
       description:
         "The JWKS (including private keys) which will be used to sign the client assertion. If blank, Inferno's default JWKS will be used.",
       optional: true,
+      locked: lockedInput,
     },
   ] as TestInput[];
 
@@ -234,6 +247,7 @@ export const getAccessFields = (
   authType: AuthType,
   accessValues: Map<string, unknown>,
   components: TestInput[],
+  lockedInput: boolean,
 ): TestInput[] => {
   const tokenDoesNotExist =
     authType === 'backend_services'
@@ -244,17 +258,20 @@ export const getAccessFields = (
     {
       name: 'access_token',
       title: 'Access Token',
+      locked: lockedInput,
     },
     {
       name: 'refresh_token',
       title: 'Refresh Token (will automatically refresh if available)',
       optional: true,
+      locked: lockedInput,
     },
     {
       name: 'client_id',
       title: 'Client ID',
       description: 'Client ID provided during registration of Inferno',
       optional: true,
+      locked: lockedInput,
       hide: tokenDoesNotExist,
     },
     {
@@ -262,6 +279,7 @@ export const getAccessFields = (
       title: 'Client Secret',
       description: 'Client secret provided during registration of Inferno',
       optional: true,
+      locked: lockedInput,
       hide: !accessValues.get('refresh_token'),
     },
     {
@@ -269,12 +287,24 @@ export const getAccessFields = (
       title: 'Token URL',
       description: "URL of the authorization server's token endpoint",
       optional: true,
+      locked: lockedInput,
       hide: tokenDoesNotExist,
     },
     {
       name: 'encryption_algorithm',
       type: 'radio',
       title: 'Encryption Algorithm',
+      optional: true,
+      locked: lockedInput,
+      hide: tokenDoesNotExist,
+    },
+    {
+      name: 'kid',
+      title: 'Key ID (kid)',
+      description:
+        'Key ID of the JWKS private key used to sign the client assertion. If blank, the first key for the selected encryption algorithm will be used.',
+      optional: true,
+      locked: lockedInput,
       options: {
         list_options: [
           {
@@ -287,15 +317,6 @@ export const getAccessFields = (
           },
         ],
       },
-      optional: true,
-      hide: tokenDoesNotExist,
-    },
-    {
-      name: 'kid',
-      title: 'Key ID (kid)',
-      description:
-        'Key ID of the JWKS private key used to sign the client assertion. If blank, the first key for the selected encryption algorithm will be used.',
-      optional: true,
       hide: tokenDoesNotExist,
     },
     {
@@ -305,6 +326,7 @@ export const getAccessFields = (
       description:
         "The JWKS (including private keys) which will be used to sign the client assertion. If blank, Inferno's default JWKS will be used.",
       optional: true,
+      locked: lockedInput,
       hide: tokenDoesNotExist,
     },
     {
@@ -312,6 +334,7 @@ export const getAccessFields = (
       title: 'Access Token Issue Time',
       description: 'The time that the access token was issued in iso8601 format',
       optional: true,
+      locked: lockedInput,
       hide: tokenDoesNotExist,
     },
     {
@@ -319,6 +342,7 @@ export const getAccessFields = (
       title: 'Token Lifetime',
       description: 'The lifetime of the access token in seconds',
       optional: true,
+      locked: lockedInput,
       hide: tokenDoesNotExist,
     },
   ] as TestInput[];

--- a/client/src/components/InputsModal/Auth/AuthTypeSelector.tsx
+++ b/client/src/components/InputsModal/Auth/AuthTypeSelector.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { InputOption, TestInput } from '~/models/testSuiteModels';
+import { Auth, InputOption, TestInput } from '~/models/testSuiteModels';
 import InputCombobox from '~/components/InputsModal/InputCombobox';
 
 export interface InputAccessProps {
@@ -23,8 +23,7 @@ const AuthTypeSelector: FC<InputAccessProps> = ({ input, index, inputsMap, setIn
       };
 
   const selectorOptions: InputOption[] =
-    input.options?.components?.find((component) => component.name === 'auth_type')?.options
-      ?.list_options ||
+    authComponent?.options?.list_options ||
     ([
       {
         label: 'Public',
@@ -44,12 +43,23 @@ const AuthTypeSelector: FC<InputAccessProps> = ({ input, index, inputsMap, setIn
       },
     ] as InputOption[]);
 
+  // Fetch value from input.value field if it exists
+  // Otherwise use, in order, default, then the first available option, then 'public'
+  const getAuthStartingValue = () => {
+    let startingValue = selectorSettings.default || selectorOptions[0].value || 'public';
+    if (input.value && typeof input.value === 'string') {
+      const parsedAuth = JSON.parse(input.value) as Auth;
+      if (parsedAuth.auth_type) startingValue = parsedAuth.auth_type;
+    }
+    return startingValue;
+  };
+
   const selectorModel: TestInput = {
     name: 'auth_type',
     type: 'select',
     title: 'Auth Type',
     description: input.description,
-    default: selectorSettings.default || 'public',
+    default: getAuthStartingValue(),
     optional: selectorSettings.optional,
     locked: selectorSettings.locked,
     options: {

--- a/client/src/components/InputsModal/Auth/AuthTypeSelector.tsx
+++ b/client/src/components/InputsModal/Auth/AuthTypeSelector.tsx
@@ -61,7 +61,7 @@ const AuthTypeSelector: FC<InputAccessProps> = ({ input, index, inputsMap, setIn
     description: input.description,
     default: getAuthStartingValue(),
     optional: selectorSettings.optional,
-    locked: selectorSettings.locked,
+    locked: selectorSettings.locked || input.locked,
     options: {
       list_options: selectorOptions,
     },

--- a/client/src/components/InputsModal/Auth/InputAuth.tsx
+++ b/client/src/components/InputsModal/Auth/InputAuth.tsx
@@ -43,9 +43,19 @@ const InputAuth: FC<InputAuthProps> = ({ mode, input, index, inputsMap, setInput
   // Set fields depending on mode
   let fields: TestInput[] = [];
   if (mode === 'access') {
-    fields = getAccessFields(authType as AuthType, authValues, input.options?.components || []);
+    fields = getAccessFields(
+      authType as AuthType,
+      authValues,
+      input.options?.components || [],
+      input.locked || false,
+    );
   } else if (mode === 'auth') {
-    fields = getAuthFields(authType as AuthType, authValues, input.options?.components || []);
+    fields = getAuthFields(
+      authType as AuthType,
+      authValues,
+      input.options?.components || [],
+      input.locked || false,
+    );
   }
   const [authFields, setAuthFields] = React.useState<TestInput[]>(fields);
 
@@ -87,11 +97,21 @@ const InputAuth: FC<InputAuthProps> = ({ mode, input, index, inputsMap, setInput
     // Recalculate hidden fields
     if (mode === 'access') {
       setAuthFields(
-        getAccessFields(authType as AuthType, authValues, input.options?.components || []),
+        getAccessFields(
+          authType as AuthType,
+          authValues,
+          input.options?.components || [],
+          input.locked || false,
+        ),
       );
     } else if (mode === 'auth') {
       setAuthFields(
-        getAuthFields(authType as AuthType, authValues, input.options?.components || []),
+        getAuthFields(
+          authType as AuthType,
+          authValues,
+          input.options?.components || [],
+          input.locked || false,
+        ),
       );
     }
 

--- a/client/src/components/InputsModal/Auth/InputAuth.tsx
+++ b/client/src/components/InputsModal/Auth/InputAuth.tsx
@@ -68,9 +68,11 @@ const InputAuth: FC<InputAuthProps> = ({ mode, input, index, inputsMap, setInput
     );
 
     const combinedStartingValues = getStartingValues();
+    // After parsing JSON, set auth_type if value exists in input.value
+    setAuthType(combinedStartingValues.auth_type || authType);
 
     // Populate authValues on mount
-    authValues.set('auth_type', authType);
+    authValues.set('auth_type', combinedStartingValues.auth_type || authType);
     authFields.forEach((field: TestInput) => {
       authValues.set(field.name, combinedStartingValues[field.name as keyof Auth] || '');
     });


### PR DESCRIPTION
# Summary

Adds a property to auth input settings to determine if internal components should be locked. Also adds a check for existing default value to the auth type selector.

# Testing Guidance

Reproduction: 
There's a fi-3587-debug branch in core you can use to duplicate this error. Run g10 with US Core 3 and SMART 1, load the preset, run the standalone launch, then open the inputs for the limited access group.

Pull this branch into fi-3587-debug and check that behavior no longer occurs.