### PR TITLE
FI-3637: Add fetch bundle resources to core

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -331,6 +331,7 @@ PLATFORMS
   arm64-darwin-23
   x86_64-darwin-20
   x86_64-darwin-22
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
# Summary
This PR adds the `fetch_all_bundled_resources` method to the  FHIR Client DSL, to retrieve FHIR resources from a given bundle. A shared example spec has also been added to ensure method integrity by verifying that `fetch_all_bundled_resources` is not overridden in subclasses. This helps maintain consistency and prevents unintended redefinition of the method in test kits.

# Testing Guidance

