### PR TITLE
fi-3227 Add docs to template.

### DIFF
--- a/lib/inferno/apps/cli/templates/.github/workflows/publish-docs-wiki.yml
+++ b/lib/inferno/apps/cli/templates/.github/workflows/publish-docs-wiki.yml
@@ -1,0 +1,31 @@
+# This workflow publishes documentation to the GitHub wiki, which provides a better
+# user experience than browsing files in the repository.
+
+# To enable this workflow, you need to first create a GitHub wiki for your repository.
+
+# This workflow will publish the docs to the wiki when a push is made to the
+# main branch.  This workflow can also be manually triggered against a PR branch
+# as a method to preview updates prior to merge.
+
+name: Publish Docs Wiki
+description: Publish documentation from /docs to the GitHub repository's wiki.
+on:
+  push:
+    branches: [main]
+    paths:
+      - docs/**
+  workflow_dispatch:
+concurrency:
+  group: publish-docs-wiki
+  cancel-in-progress: true
+permissions:
+  contents: write
+jobs:
+  publish-docs-wiki:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Andrew-Chen-Wang/github-wiki-action@86138cbd6328b21d759e89ab6e6dd6a139b22270
+        with:
+          path: docs
+          strategy: init

--- a/lib/inferno/apps/cli/templates/README.md.tt
+++ b/lib/inferno/apps/cli/templates/README.md.tt
@@ -3,6 +3,16 @@
 <%= human_name %> [Inferno](https://github.com/inferno-community/inferno-core) Test Kit
 for FHIR testing.
 
+## Getting Started
+
+The quickest way to run this test kit locally is with [Docker](https://www.docker.com/).
+
+- Install Docker
+- Clone this repository, or download an [official release](/releases) if available.
+- Run `./setup.sh` within the test kit directory to download necessary dependencies
+- Run `./run.sh` within the test kit directory to start the application
+- Navigate to `http://localhost`
+
 ## Instructions for Developing Your Test Kit
 
 Refer to the Inferno documentation for information about [setting up

--- a/lib/inferno/apps/cli/templates/docs/Overview.md
+++ b/lib/inferno/apps/cli/templates/docs/Overview.md
@@ -1,0 +1,7 @@
+This file was generated from the Inferno template to demonstrate providing
+documentation across multiple files, and has not yet customized for this test
+kit.
+
+For examples of test kit documentation, refer to the [US Core Test
+Kit](/inferno-framework/us-core-test-kit/wiki) and the [ONC Certification
+(g)(10) Test Kit](/inferno-framework/onc-certification-g10-test-kit/wiki).

--- a/lib/inferno/apps/cli/templates/docs/README.md.tt
+++ b/lib/inferno/apps/cli/templates/docs/README.md.tt
@@ -1,0 +1,10 @@
+<%= human_name %> documentation. This file has been generated from the Inferno
+test kit template and has not yet been customized for this test kit.
+
+*Note to developer: After customizing this documentation, initialize a GitHub
+wiki within this repository to enable automatic publishing to the wiki via the
+included Publish Docs Wiki action.*
+
+## Using this Test Kit (example)
+* [Getting Started](../?tab=readme-ov-file#getting-started): Installation instructions for this test kit.
+* [Test Kit Overview](Overview.md): An overview of the test kit and its tests.

--- a/lib/inferno/apps/cli/templates/docs/_Footer.md
+++ b/lib/inferno/apps/cli/templates/docs/_Footer.md
@@ -1,0 +1,5 @@
+_Test kit documentation is stored within the [./docs](../tree/main/docs) folder of
+this repository and is automatically synchronized to this wiki with each update
+to the `main` branch using the [Publish Docs Wiki
+workflow](../actions/workflows/publish-docs-wiki.yml).  Do not change content
+within this wiki directly as changes will be overwritten._

--- a/lib/inferno/apps/cli/templates/docs/_Sidebar.md
+++ b/lib/inferno/apps/cli/templates/docs/_Sidebar.md
@@ -1,0 +1,5 @@
+**[Documentation Home](Home)**
+
+**Using this Test Kit**
+  - [Getting Started](../?tab=readme-ov-file#getting-started)
+  - [Test Kit Overview](Overview.md)


### PR DESCRIPTION
# Summary

This adds basic docs to the template.  I put a preview of what it should look like when you generate it over [here](/arscan/inferno-template).

Note that the workflow action will not work until you create a Wiki for the repo in GitHub (go to `Wiki` and just click a button).  I don't love having a failing thing by default, but it will only get run when users change `./docs`, and I expect once they change it they will see the instructions to create the wiki, so I do not expect any more than 1 failing run of this thing (at most; maybe even 0).

Once merged, we need to update /inferno-framework/inferno-template; that's quite far behind which is why I didn't bother showing this off on a branch over there.

