### PR TITLE
FI-3678: Update runnable context to support use when describing non-runnables

### DIFF
--- a/spec/runnable_context.rb
+++ b/spec/runnable_context.rb
@@ -16,12 +16,13 @@ RSpec.shared_context('when testing a runnable') do
   def run(runnable, inputs = {})
     test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
     test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
-    inputs.each do |name, value|
+    inputs.each do |original_name, value|
+      name = runnable.config.input_name(original_name).presence || original_name
       session_data_repo.save(
         test_session_id: test_session.id,
         name:,
         value:,
-        type: runnable.config.input_type(name)
+        type: runnable.available_inputs[name.to_sym]&.type
       )
     end
 

--- a/spec/runnable_context.rb
+++ b/spec/runnable_context.rb
@@ -5,7 +5,10 @@ RSpec.shared_context('when testing a runnable') do
   let(:test_session) { repo_create(:test_session, test_suite_id: suite_id) }
 
   before do
-    allow(described_class).to receive(:suite).and_return(suite) if described_class.parent.nil?
+    if !(described_class.singleton_class < Inferno::DSL::Runnable) ||
+       described_class.parent.nil?
+      allow(described_class).to receive(:suite).and_return(suite)
+    end
   rescue NameError
     raise StandardError, "No suite id defined. Add `let(:suite_id) { 'your_suite_id' }` to the spec"
   end

--- a/spec/runnable_context.rb
+++ b/spec/runnable_context.rb
@@ -5,8 +5,7 @@ RSpec.shared_context('when testing a runnable') do
   let(:test_session) { repo_create(:test_session, test_suite_id: suite_id) }
 
   before do
-    if !(described_class.singleton_class < Inferno::DSL::Runnable) ||
-       described_class.parent.nil?
+    if described_class.respond_to?(:parent) && described_class.parent.nil?
       allow(described_class).to receive(:suite).and_return(suite)
     end
   rescue NameError


### PR DESCRIPTION
This branch updates the runnable context to support using the runnable spec helpers when describing a non-runnable (e.g., a module that is included in runnables).