### PR TITLE
FI-3732: Add scratch to runnable context

### DIFF
--- a/spec/runnable_context.rb
+++ b/spec/runnable_context.rb
@@ -12,7 +12,7 @@ RSpec.shared_context('when testing a runnable') do
     raise StandardError, "No suite id defined. Add `let(:suite_id) { 'your_suite_id' }` to the spec"
   end
 
-  def run(runnable, inputs = {})
+  def run(runnable, inputs = {}, scratch = {})
     test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
     test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
     inputs.each do |original_name, value|
@@ -25,7 +25,7 @@ RSpec.shared_context('when testing a runnable') do
       )
     end
 
-    Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
+    Inferno::TestRunner.new(test_session:, test_run:).run(runnable, scratch)
   end
 
   # depth-first search looking for a runnable with a runtime id


### PR DESCRIPTION
# Summary
This branch adds the ability to pass `scratch` to the `run` method in the runnable context.

# Testing Guidance
[This g10 branch] was updated to use this functionality, and its unit tests should pass if you point `inferno_core` it at this branch in its Gemfile, but will fail if you point it at the main branch of `inferno_core`. In [that g10 branch's last commit](https://github.com/onc-healthit/onc-certification-g10-test-kit/pull/619/commits/6a02ebcc1e0392ec920e0b2d1f8193943fd37d25#diff-840673ba113751ed304c37171e616b9d5f45487fe651890e28a3747c6fe05af4L40), you can see that a `run` method which included `scratch` was removed.