### PR TITLE
FI-3487: Fix response content types

### DIFF
--- a/lib/inferno/apps/web/controllers/controller.rb
+++ b/lib/inferno/apps/web/controllers/controller.rb
@@ -20,7 +20,9 @@ module Inferno
           # Hanami Controller 2.0.0 removes the ability to set a default
           # Content-Type response header, so set it manually if it hasn't been
           # set.
-          subclass.after { |_req, res| res.format = :json if res.format == :all && res.body&.first&.first == '{' }
+          subclass.after do |_req, res|
+            res.format = :json if res.format == :all
+          end
         end
 
         def self.resource_name


### PR DESCRIPTION
# Summary
This branch fixes some JSON API responses which didn't have a JSON content-type. It also fixes the content-type in a few other routes.

# Testing Guidance
Open the network tab in your browser inspector. On main, you will see that the responses to some api requests have a content-type of plain or octet-stream. On this branch, the responses should all have correct content types.