### PR TITLE
FI-3756: Add suite option default

### DIFF
--- a/dev_suites/dev_options_suite/options_suite.rb
+++ b/dev_suites/dev_options_suite/options_suite.rb
@@ -127,6 +127,7 @@ module OptionsSuite
     suite_option :ig_version,
                  title: 'IG Version',
                  description: 'Which IG Version should be used',
+                 default: '2',
                  list_options: [
                    {
                      label: 'v1',

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -601,11 +601,18 @@ definitions:
         type: "string"
   SuiteOption:
     type: "object"
+    required:
+    - "id"
+    - "title"
+    - "list_options"
     properties:
       id:
         type: "string"
         readOnly: true
       title:
+        type: "string"
+        readOnly: true
+      default:
         type: "string"
         readOnly: true
       description:

--- a/lib/inferno/apps/web/serializers/suite_option.rb
+++ b/lib/inferno/apps/web/serializers/suite_option.rb
@@ -6,6 +6,7 @@ module Inferno
       class SuiteOption < Serializer
         identifier :id
         field :title, if: :field_present?
+        field :default, if: :field_present?
         field :description, if: :field_present?
         field :list_options, if: :field_present?
         field :value, if: :field_present?

--- a/lib/inferno/dsl/suite_option.rb
+++ b/lib/inferno/dsl/suite_option.rb
@@ -11,6 +11,7 @@ module Inferno
       ATTRIBUTES = [
         :id,
         :title,
+        :default,
         :description,
         :list_options,
         :value
@@ -20,6 +21,7 @@ module Inferno
 
       # @!attribute [rw] id
       # @!attribute [rw] title
+      # @!attribute [rw] default
       # @!attribute [rw] description
       # @!attribute [rw] list_options
       # @!attribute [rw] value

--- a/spec/inferno/web/serializers/suite_option_spec.rb
+++ b/spec/inferno/web/serializers/suite_option_spec.rb
@@ -1,0 +1,26 @@
+require_relative '../../../../lib/inferno/apps/web/serializers/suite_option'
+
+RSpec.describe Inferno::Web::Serializers::SuiteOption do
+  let(:params) do
+    {
+      id: :id,
+      default: 'VALUE1',
+      description: 'DESCRIPTION',
+      list_options: [
+        { label: 'LABEL1', value: 'VALUE1' },
+        { label: 'LABEL2', value: 'VALUE2' },
+        { label: 'LABEL3', value: 'VALUE3' }
+      ],
+      value: 'VALUE3'
+    }
+  end
+  let(:suite_option) { Inferno::DSL::SuiteOption.new(params) }
+
+  it 'includes all fields' do
+    serialized_result = JSON.parse(described_class.render(suite_option))
+
+    expected_result = JSON.parse(params.to_json)
+
+    expect(serialized_result).to eq(expected_result)
+  end
+end


### PR DESCRIPTION
# Summary
This branch adds the ability to assign a default value to suite options.

# Testing Guidance
The new unit test verifies that the default value is serialized.

If you make a request to `http://localhost:4567/inferno/api/test_suites/options`, you will see that a default value is transmitted via the JSON API.