### PR TITLE
FI-3731: Modify cursor behavior to allow tooltips in report

### DIFF
--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupListItem/TestGroupListItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupListItem/TestGroupListItem.tsx
@@ -112,11 +112,12 @@ const TestGroupListItem: FC<TestGroupListItemProps> = ({
       disableGutters
       elevation={0}
       className={classes.accordion}
-      sx={view === 'report' ? { pointerEvents: 'none' } : {}}
       expanded={expanded}
       onChange={() => {
-        setExpanded(!expanded);
-        setManualExpand(!expanded);
+        if (view !== 'report') {
+          setExpanded(!expanded);
+          setManualExpand(!expanded);
+        }
       }}
       slotProps={{ transition: { unmountOnExit: true } }}
       onMouseEnter={() => setGroupMouseHover(true)}
@@ -128,6 +129,7 @@ const TestGroupListItem: FC<TestGroupListItemProps> = ({
         aria-controls={`${testGroup.id}-detail`}
         className={classes.accordionSummary}
         expandIcon={view === 'run' && <ExpandMoreIcon tabIndex={0} aria-hidden="false" />}
+        sx={view === 'report' ? { cursor: 'default !important' } : {}}
       >
         <Box display="flex" alignItems="center" width="100%">
           <Box display="inline-flex">

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
@@ -204,8 +204,10 @@ const TestListItem: FC<TestListItemProps> = ({
   };
 
   const handleAccordionClick = () => {
-    setTabIndex(findPopulatedTabIndex());
-    setOpen(!open);
+    if (view !== 'report') {
+      setTabIndex(findPopulatedTabIndex());
+      setOpen(!open);
+    }
   };
 
   return (
@@ -213,7 +215,6 @@ const TestListItem: FC<TestListItemProps> = ({
       disableGutters
       elevation={0}
       className={classes.accordion}
-      sx={view === 'report' ? { pointerEvents: 'none' } : {}}
       expanded={open}
       slotProps={{ transition: { unmountOnExit: true } }}
       onClick={handleAccordionClick}
@@ -247,6 +248,7 @@ const TestListItem: FC<TestListItemProps> = ({
             setOpen(!open);
           }
         }}
+        sx={view === 'report' ? { cursor: 'default !important' } : {}}
       >
         <Box display="flex" alignItems="center" width="100%">
           {resultIcon}


### PR DESCRIPTION
# Summary

Refactors cursor behavior to allow tooltips on hover. Also removes the ability for expansion to be modified via tab-through keyboard events. Changes cursor to default instead of pointer in this use case.

# Testing Guidance

Mouse over icons in report view -- tooltips should appear.
Click expansion and tab-through keyboard expansion of accordion items should be disabled.