### PR TITLE
FI-2697: Ignore Unresolved URL Error Messages from Validator

### DIFF
--- a/lib/inferno/dsl/fhir_resource_validation.rb
+++ b/lib/inferno/dsl/fhir_resource_validation.rb
@@ -194,7 +194,13 @@ module Inferno
         end
 
         # @private
+        def exclude_unresolved_url_message
+          proc { |message| message.message.match?(/could not be resolved/i) }
+        end
+
+        # @private
         def filter_messages(message_hashes)
+          message_hashes.reject! { |message| exclude_unresolved_url_message.call(Entities::Message.new(message)) }
           message_hashes.reject! { |message| exclude_message.call(Entities::Message.new(message)) } if exclude_message
         end
 

--- a/lib/inferno/dsl/fhir_validation.rb
+++ b/lib/inferno/dsl/fhir_validation.rb
@@ -153,7 +153,13 @@ module Inferno
         end
 
         # @private
+        def exclude_unresolved_url_message
+          proc { |message| message.message.match?(/could not be resolved/i) }
+        end
+
+        # @private
         def filter_messages(message_hashes)
+          message_hashes.reject! { |message| exclude_unresolved_url_message.call(Entities::Message.new(message)) }
           message_hashes.reject! { |message| exclude_message.call(Entities::Message.new(message)) } if exclude_message
         end
 

--- a/spec/inferno/dsl/fhir_resource_validation_spec.rb
+++ b/spec/inferno/dsl/fhir_resource_validation_spec.rb
@@ -123,26 +123,43 @@ RSpec.describe Inferno::DSL::FHIRResourceValidation do
     context 'with invalid resource' do
       let(:invalid_outcome) do
         {
-          outcomes: [{
-            fileInfo: {
-              fileName: 'Patient/0000.json',
-              fileContent: resource_string.to_json,
-              fileType: 'json'
-            },
-            issues: [{
-              source: 'InstanceValidator',
-              line: 4,
-              col: 4,
-              location: 'Patient.identifier[0]',
-              message: 'Identifier.system must be an absolute reference, not a local reference',
-              messageId: 'Type_Specific_Checks_DT_Identifier_System',
-              type: 'CODEINVALID',
-              level: 'ERROR',
-              html: 'Identifier.system must be an absolute reference, not a local reference',
-              display: 'ERROR: Patient.identifier[0]: Identifier.system must be an absolute reference, ',
-              error: true
-            }]
-          }],
+          outcomes: [
+            {
+              fileInfo: {
+                fileName: 'Patient/0000.json',
+                fileContent: resource_string.to_json,
+                fileType: 'json'
+              },
+              issues: [
+                {
+                  source: 'InstanceValidator',
+                  line: 4,
+                  col: 4,
+                  location: 'Patient.identifier[0]',
+                  message: 'Identifier.system must be an absolute reference, not a local reference',
+                  messageId: 'Type_Specific_Checks_DT_Identifier_System',
+                  type: 'CODEINVALID',
+                  level: 'ERROR',
+                  html: 'Identifier.system must be an absolute reference, not a local reference',
+                  display: 'ERROR: Patient.identifier[0]: Identifier.system must be an absolute reference, ',
+                  error: true
+                },
+                {
+                  source: 'InstanceValidator',
+                  line: 5,
+                  col: 5,
+                  location: 'Organization.type',
+                  message: 'The valueSet reference https://example.org could not be resolved',
+                  messageId: 'Type_Specific_Checks_DT_Identifier_System',
+                  type: 'CODEINVALID',
+                  level: 'ERROR',
+                  html: 'The valueSet reference https://example.org could not be resolved',
+                  display: 'ERROR: Organization.type: The valueSet reference https://example.org could not be resolved',
+                  error: true
+                }
+              ]
+            }
+          ],
           sessionId: 'b8cf5547-1dc7-4714-a797-dc2347b93fe2'
         }.to_json
       end
@@ -159,6 +176,13 @@ RSpec.describe Inferno::DSL::FHIRResourceValidation do
 
           expect(result).to be(false)
           expect(runnable.messages.first[:message]).to start_with("#{resource2.resourceType}/#{resource2.id}:")
+        end
+
+        it 'excludes the unresolved url message' do
+          result = validator.resource_is_valid?(resource2, profile_url, runnable)
+
+          expect(result).to be(false)
+          expect(runnable.messages).to all(satisfy { |message| !message[:message].match?(/could not be resolved/i) })
         end
       end
 

--- a/spec/inferno/dsl/fhir_validation_spec.rb
+++ b/spec/inferno/dsl/fhir_validation_spec.rb
@@ -103,6 +103,17 @@ RSpec.describe Inferno::DSL::FHIRValidation do
                 'Patient.identifier[0]',
                 'Line 14, Col 10'
               ]
+            },
+            {
+              severity: 'error',
+              code: 'processing',
+              details: {
+                text: 'The valueSet reference https://example.org could not be resolved'
+              },
+              location: [
+                'Organization.type',
+                'Line 14, Col 10'
+              ]
             }
           ]
         }.to_json
@@ -128,6 +139,13 @@ RSpec.describe Inferno::DSL::FHIRValidation do
 
           expect(result).to be(false)
           expect(runnable.messages.first[:message]).to start_with("#{resource.resourceType}:")
+        end
+
+        it 'excludes the unresolved url message' do
+          result = validator.resource_is_valid?(resource, profile_url, runnable)
+
+          expect(result).to be(false)
+          expect(runnable.messages).to all(satisfy { |message| !message[:message].match?(/could not be resolved/i) })
         end
       end
 


### PR DESCRIPTION
This update modifies message filtering to ignore url `could not be resolved` errors from the validator. 

