### PR TITLE
FI-3714: Add method to remove runnables

### DIFF
--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -466,7 +466,7 @@ module Inferno
 
       # Remove a child test/group
       #
-      # @param id_to_remove (Symbol, String)
+      # @param id_to_remove [Symbol, String]
       # @example
       #   test from: :test1
       #   test from: :test2

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -464,6 +464,19 @@ module Inferno
           end
       end
 
+      # Remove a child test/group
+      #
+      # @param id_to_remove (Symbol, String)
+      # @example
+      #   test from: :test1
+      #   test from: :test2
+      #   test from: :test3
+      #
+      #   remove :test2
+      def remove(id_to_remove)
+        children.reject! { |child| child.id.to_s.end_with? id_to_remove.to_s }
+      end
+
       # @private
       def children(selected_suite_options = [])
         return all_children if selected_suite_options.blank?

--- a/spec/inferno/dsl/runnable_spec.rb
+++ b/spec/inferno/dsl/runnable_spec.rb
@@ -195,4 +195,20 @@ RSpec.describe Inferno::DSL::Runnable do
       end.to raise_error(Inferno::Exceptions::InvalidRunnableIdException, /length of 255 characters/)
     end
   end
+
+  describe '.remove' do
+    it 'removes a child' do
+      group = Class.new(Inferno::TestGroup) do
+        id :remove_group
+
+        test { id :abc }
+        test { id :def }
+        test { id :ghw }
+      end
+
+      group.remove :def
+
+      expect(group.children.length).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
# Summary
This branch adds a `remove` method which can be used to remove a child test/group.

# Testing Guidance
The unit test covers it.