### PR TITLE
FI-3715: Add Method to Replace Runnables

### DIFF
--- a/dev_suites/dev_auth_info/auth_info_suite.rb
+++ b/dev_suites/dev_auth_info/auth_info_suite.rb
@@ -1,3 +1,5 @@
+require_relative '../dev_demo_ig_stu1/groups/demo_group'
+
 module AuthInfoConstants
   AUTH_URL = 'https://inferno-qa.healthit.gov/reference-server/oauth/authorization'.freeze
   TOKEN_URL = 'https://inferno-qa.healthit.gov/reference-server/oauth/token'.freeze

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -478,7 +478,7 @@ module Inferno
       #   end
       def replace(id_to_replace, replacement_id, &)
         index = children.find_index { |child| child.id.to_s.end_with? id_to_replace.to_s }
-        return unless index
+        raise Exceptions::RunnableChildNotFoundException.new(id_to_replace, self) unless index
 
         if children[index] < Inferno::TestGroup
           group(from: replacement_id, &)

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -81,6 +81,12 @@ module Inferno
         repository.insert(self)
       end
 
+      # @private
+      def remove_self_from_repository
+        repository.remove(self)
+        children.each(&:remove_self_from_repository)
+      end
+
       # An instance of the repository for the class using this module
       # @private
       def repository
@@ -486,7 +492,8 @@ module Inferno
           test(from: replacement_id, &)
         end
 
-        children[index] = children.pop
+        remove(id_to_replace)
+        children.insert(index, children.pop)
       end
 
       # Remove a child test/group
@@ -499,7 +506,9 @@ module Inferno
       #
       #   remove :test2
       def remove(id_to_remove)
+        removed = children.select { |child| child.id.to_s.end_with? id_to_remove.to_s }
         children.reject! { |child| child.id.to_s.end_with? id_to_remove.to_s }
+        removed.each(&:remove_self_from_repository)
       end
 
       # @private

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -467,7 +467,7 @@ module Inferno
       # Replace a child test/group
       #
       # @param id_to_replace [Symbol, String] The ID of the child to be replaced.
-      # @param replacement_id [Symbol, String] The ID of the child that will take the
+      # @param replacement_id [Symbol, String] The global ID of the group/test that will take the
       #   place of the child being replaced.
       # @yield [Inferno::TestGroup, Inferno::Test] Optional block executed in the
       #    context of the replacement child for additional configuration.

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -466,8 +466,8 @@ module Inferno
 
       # Replace a child test/group
       #
-      # @param id_to_replace (Symbol, String) The ID of the child to be replaced
-      # @param new_child (Inferno::TestGroup, Inferno::Test) The new child to replace the existing one
+      # @param id_to_replace [Symbol, String] The ID of the child to be replaced
+      # @param new_child [Inferno::TestGroup, Inferno::Test] The new child to replace the existing one
       # @example
       #   test from: :test1
       #   test from: :test2

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -466,17 +466,28 @@ module Inferno
 
       # Replace a child test/group
       #
-      # @param id_to_replace [Symbol, String] The ID of the child to be replaced
-      # @param new_child [Inferno::TestGroup, Inferno::Test] The new child to replace the existing one
+      # @param id_to_replace [Symbol, String] The ID of the child to be replaced.
+      # @param replacement_id [Symbol, String] The ID of the child that will take the
+      #   place of the child being replaced.
+      # @yield [Inferno::TestGroup, Inferno::Test] Optional block executed in the
+      #    context of the replacement child for additional configuration.
       # @example
-      #   test from: :test1
-      #   test from: :test2
-      #   test from: :test3
+      #   replace :test2, :test4 do
+      #     id :new_test_id
+      #     config(...)
+      #   end
       #
-      #   replace :test2, new_test
-      def replace(id_to_replace, new_child)
+      def replace(id_to_replace, replacement_id, &)
         index = children.find_index { |child| child.id.to_s.end_with? id_to_replace.to_s }
-        children[index] = new_child if index
+        return unless index
+
+        replacement_child = children.find { |child| child.id.to_s.end_with? replacement_id.to_s }
+        return unless replacement_child
+
+        remove(replacement_id)
+        replacement_child.instance_eval(&) if block_given?
+
+        children[index] = replacement_child
       end
 
       # Remove a child test/group

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -476,18 +476,17 @@ module Inferno
       #     id :new_test_id
       #     config(...)
       #   end
-      #
       def replace(id_to_replace, replacement_id, &)
         index = children.find_index { |child| child.id.to_s.end_with? id_to_replace.to_s }
         return unless index
 
-        replacement_child = children.find { |child| child.id.to_s.end_with? replacement_id.to_s }
-        return unless replacement_child
+        if children[index] < Inferno::TestGroup
+          group(from: replacement_id, &)
+        else
+          test(from: replacement_id, &)
+        end
 
-        remove(replacement_id)
-        replacement_child.instance_eval(&) if block_given?
-
-        children[index] = replacement_child
+        children[index] = children.pop
       end
 
       # Remove a child test/group

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -464,6 +464,21 @@ module Inferno
           end
       end
 
+      # Replace a child test/group
+      #
+      # @param id_to_replace (Symbol, String) The ID of the child to be replaced
+      # @param new_child (Inferno::TestGroup, Inferno::Test) The new child to replace the existing one
+      # @example
+      #   test from: :test1
+      #   test from: :test2
+      #   test from: :test3
+      #
+      #   replace :test2, new_test
+      def replace(id_to_replace, new_child)
+        index = children.find_index { |child| child.id.to_s.end_with? id_to_replace.to_s }
+        children[index] = new_child if index
+      end
+
       # @private
       def children(selected_suite_options = [])
         return all_children if selected_suite_options.blank?

--- a/lib/inferno/exceptions.rb
+++ b/lib/inferno/exceptions.rb
@@ -125,5 +125,11 @@ module Inferno
         super("ID '#{id}' already exists. Ensure the uniqueness of the IDs.")
       end
     end
+
+    class RunnableChildNotFoundException < StandardError
+      def initialize(id, runnable)
+        super("Could not find a child with an ID ending in '#{id}' for '#{runnable}'.")
+      end
+    end
   end
 end

--- a/lib/inferno/repositories/in_memory_repository.rb
+++ b/lib/inferno/repositories/in_memory_repository.rb
@@ -16,6 +16,13 @@ module Inferno
         entity
       end
 
+      def remove(entity)
+        return unless exists?(entity.id)
+
+        all.delete(entity)
+        all_by_id.delete(entity.id.to_s)
+      end
+
       def find(id)
         all_by_id[id.to_s]
       end

--- a/spec/inferno/dsl/runnable_spec.rb
+++ b/spec/inferno/dsl/runnable_spec.rb
@@ -213,52 +213,37 @@ RSpec.describe Inferno::DSL::Runnable do
   end
 
   describe '.replace' do
-    let(:group) do
-      Class.new(Inferno::TestGroup) do
-        test { id :abc }
-        test { id :def }
-        test { id :ghw }
-      end
-    end
-    let(:id) { 'xyz' }
+    let(:test_group) { test_groups_repo.find('auth_info-auth_info_demo') } # 'replace-repetitive_group'
 
     before do
-      group.id(SecureRandom.uuid)
+      test_group.id(SecureRandom.uuid)
     end
 
     it 'replaces a child with a another using its ID' do
-      group.test({ id: })
-      group.replace(:def, id)
+      id_to_replace = test_group.children.first.id.split('-').last
+      test_group.replace id_to_replace, 'DemoIG_STU1::DemoGroup'
 
-      expect(group.children.length).to eq(3)
-      expect(group.children.none? { |child| child.id.to_s.end_with?('def') }).to be true
-      expect(group.children[1].id.to_s.end_with?('xyz')).to be true
+      expect(test_group.children.length).to eq(2)
+      expect(test_group.children.none? { |child| child.id.to_s.end_with?('DEF') }).to be true
+      expect(test_group.children[0].id.to_s.end_with?('DemoIG_STU1::DemoGroup')).to be true
     end
 
     it 'applies block configuration to the new child' do
-      group.test({ id: })
-      group.replace(:def, id) do
-        id :new_test_id
+      id_to_replace = test_group.children.first.id.split('-').last
+      test_group.replace id_to_replace, 'DemoIG_STU1::DemoGroup' do
+        id :new_id
       end
 
-      expect(group.children.length).to eq(3)
-      expect(group.children[1].id.to_s.end_with?('new_test_id')).to be true
+      expect(test_group.children.length).to eq(2)
+      expect(test_group.children[0].id.to_s.end_with?('new_id')).to be true
     end
 
     it 'does not change children if the id to replace is not found' do
-      original_children = group.children.dup
+      original_children = test_group.children.dup
 
-      group.replace(id, :ghw)
+      test_group.replace 'test_id', 'DemoIG_STU1::DemoGroup'
 
-      expect(group.children).to eq(original_children)
-    end
-
-    it 'does not replace if the new child ID is not found in the repository' do
-      original_children = group.children.dup
-
-      group.replace(:def, id)
-
-      expect(group.children).to eq(original_children)
+      expect(test_group.children).to eq(original_children)
     end
   end
 end

--- a/spec/inferno/dsl/runnable_spec.rb
+++ b/spec/inferno/dsl/runnable_spec.rb
@@ -238,12 +238,10 @@ RSpec.describe Inferno::DSL::Runnable do
       expect(test_group.children[0].id.to_s.end_with?('new_id')).to be true
     end
 
-    it 'does not change children if the id to replace is not found' do
-      original_children = test_group.children.dup
-
-      test_group.replace 'test_id', 'DemoIG_STU1::DemoGroup'
-
-      expect(test_group.children).to eq(original_children)
+    it 'raises an error if the id to replace is not found' do
+      expect do
+        test_group.replace 'test_id', 'DemoIG_STU1::DemoGroup'
+      end.to raise_error(Inferno::Exceptions::RunnableChildNotFoundException, /Could not find a child with an ID/)
     end
   end
 end

--- a/spec/inferno/dsl/runnable_spec.rb
+++ b/spec/inferno/dsl/runnable_spec.rb
@@ -195,4 +195,36 @@ RSpec.describe Inferno::DSL::Runnable do
       end.to raise_error(Inferno::Exceptions::InvalidRunnableIdException, /length of 255 characters/)
     end
   end
+
+  describe '.replace' do
+    let(:group) do
+      Class.new(Inferno::TestGroup) do
+        test { id :abc }
+        test { id :def }
+        test { id :ghw }
+      end
+    end
+
+    let(:new_test) { Class.new(Inferno::Test) { id :xyz } }
+
+    before do
+      group.id(SecureRandom.uuid)
+    end
+
+    it 'replaces a child with a new one' do
+      group.replace(:def, new_test)
+
+      expect(group.children.length).to eq(3)
+      expect(group.children.none? { |child| child.id.to_s.end_with?('def') }).to be true
+      expect(group.children[1]).to eq(new_test)
+    end
+
+    it 'does not change children if the id to replace is not found' do
+      original_children = group.children.dup
+
+      group.replace(:not_found, new_test)
+
+      expect(group.children).to eq(original_children)
+    end
+  end
 end

--- a/spec/inferno/dsl/runnable_spec.rb
+++ b/spec/inferno/dsl/runnable_spec.rb
@@ -220,25 +220,43 @@ RSpec.describe Inferno::DSL::Runnable do
         test { id :ghw }
       end
     end
-
-    let(:new_test) { Class.new(Inferno::Test) { id :xyz } }
+    let(:id) { 'xyz' }
 
     before do
       group.id(SecureRandom.uuid)
     end
 
-    it 'replaces a child with a new one' do
-      group.replace(:def, new_test)
+    it 'replaces a child with a another using its ID' do
+      group.test({ id: })
+      group.replace(:def, id)
 
       expect(group.children.length).to eq(3)
       expect(group.children.none? { |child| child.id.to_s.end_with?('def') }).to be true
-      expect(group.children[1]).to eq(new_test)
+      expect(group.children[1].id.to_s.end_with?('xyz')).to be true
+    end
+
+    it 'applies block configuration to the new child' do
+      group.test({ id: })
+      group.replace(:def, id) do
+        id :new_test_id
+      end
+
+      expect(group.children.length).to eq(3)
+      expect(group.children[1].id.to_s.end_with?('new_test_id')).to be true
     end
 
     it 'does not change children if the id to replace is not found' do
       original_children = group.children.dup
 
-      group.replace(:not_found, new_test)
+      group.replace(id, :ghw)
+
+      expect(group.children).to eq(original_children)
+    end
+
+    it 'does not replace if the new child ID is not found in the repository' do
+      original_children = group.children.dup
+
+      group.replace(:def, id)
 
       expect(group.children).to eq(original_children)
     end


### PR DESCRIPTION
# Summary
This branch adds a `replace` method to replace a child test/group.

# Testing Guidance
Passing unit tests

