### PR TITLE
FI-3778: Allow skip and omit to take blocks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -82,11 +82,17 @@ Metrics/ParameterLists:
 RSpec/AnyInstance:
   Enabled: false
 
+RSpec/BeforeAfterAll:
+  Enabled: false
+
 RSpec/DescribeClass:
   Exclude:
     - 'spec/requests/**/*'
 
 RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/SkipBlockInsideExample:
   Enabled: false
 
 RSpec/SpecFilePathFormat:

--- a/lib/inferno/dsl/results.rb
+++ b/lib/inferno/dsl/results.rb
@@ -22,7 +22,8 @@ module Inferno
 
       # Halt execution of the current test and mark it as skipped. This method
       # can also take a block with an assertion, and if the assertion fails, the
-      # test will skip rather than fail.
+      # test will skip rather than fail. The message parameter is ignored if a
+      # block is provided.
       #
       # @param message [String]
       # @return [void]
@@ -55,7 +56,8 @@ module Inferno
 
       # Halt execution of the current test and mark it as omitted. This method
       # can also take a block with an assertion, and if the assertion fails, the
-      # test will omit rather than fail.
+      # test will omit rather than fail. The message parameter is ignored if a
+      # block is provided.
       #
       # @param message [String]
       # @return [void]

--- a/lib/inferno/dsl/results.rb
+++ b/lib/inferno/dsl/results.rb
@@ -20,12 +20,27 @@ module Inferno
         raise Exceptions::PassException, message if test
       end
 
-      # Halt execution of the current test and mark it as skipped.
+      # Halt execution of the current test and mark it as skipped. This method
+      # can also take a block with an assertion, and if the assertion fails, the
+      # test will skip rather than fail.
       #
       # @param message [String]
       # @return [void]
+      #
+      # @example
+      #   if some_precondition_not_met?
+      #     skip('Some precondition was not met.')
+      #   end
+      #
+      #   skip do
+      #     assert false, 'This test will skip rather than fail'
+      #   end
       def skip(message = '')
-        raise Exceptions::SkipException, message
+        raise Exceptions::SkipException, message unless block_given?
+
+        yield
+      rescue Exceptions::AssertionException => e
+        raise Exceptions::SkipException, e.message
       end
 
       # Halt execution of the current test and mark it as skipped if a condition
@@ -38,12 +53,27 @@ module Inferno
         raise Exceptions::SkipException, message if test
       end
 
-      # Halt execution of the current test and mark it as omitted.
+      # Halt execution of the current test and mark it as omitted. This method
+      # can also take a block with an assertion, and if the assertion fails, the
+      # test will omit rather than fail.
       #
       # @param message [String]
       # @return [void]
+      #
+      # @example
+      #   if behavior_does_not_need_to_be_tested?
+      #     omit('Behavior does not need to be tested.')
+      #   end
+      #
+      #   omit do
+      #     assert false, 'This test will omit rather than fail'
+      #   end
       def omit(message = '')
-        raise Exceptions::OmitException, message
+        raise Exceptions::OmitException, message unless block_given?
+
+        yield
+      rescue Exceptions::AssertionException => e
+        raise Exceptions::OmitException, e.message
       end
 
       # Halt execution of the current test and mark it as omitted if a condition

--- a/spec/inferno/dsl/results_spec.rb
+++ b/spec/inferno/dsl/results_spec.rb
@@ -1,0 +1,77 @@
+RSpec.describe Inferno::DSL::Results, :runnable do
+  let(:suite_id) { 'demo' }
+
+  describe '#skip' do
+    let(:message) { 'SKIP_MESSAGE' }
+    let(:skip_test) { Inferno::Repositories::Tests.new.find('skip') }
+
+    before(:context) { Inferno::Repositories::Tests.new.insert(Class.new(Inferno::Test) { id 'skip' }) }
+
+    context 'when given a message' do
+      it 'skips' do
+        skip_test.run { skip 'SKIP_MESSAGE' }
+
+        result = run(skip_test)
+
+        expect(result.result).to eq('skip')
+        expect(result.result_message).to eq(message)
+      end
+    end
+
+    context 'when given a block' do
+      it 'skips if an assertion fails in the block' do
+        skip_test.run { skip { assert false, 'SKIP_MESSAGE' } }
+
+        result = run(skip_test)
+
+        expect(result.result).to eq('skip')
+        expect(result.result_message).to eq(message)
+      end
+
+      it 'does not skip if an assertion does not fail in the block' do
+        skip_test.run { skip { assert true, 'SKIP_MESSAGE' } }
+
+        result = run(skip_test)
+
+        expect(result.result).to eq('pass')
+      end
+    end
+  end
+
+  describe '#omit' do
+    let(:message) { 'OMIT_MESSAGE' }
+    let(:omit_test) { Inferno::Repositories::Tests.new.find('omit') }
+
+    before(:context) { Inferno::Repositories::Tests.new.insert(Class.new(Inferno::Test) { id 'omit' }) }
+
+    context 'when given a message' do
+      it 'omits' do
+        omit_test.run { omit 'OMIT_MESSAGE' }
+
+        result = run(omit_test)
+
+        expect(result.result).to eq('omit')
+        expect(result.result_message).to eq(message)
+      end
+    end
+
+    context 'when given a block' do
+      it 'omits if an assertion fails in the block' do
+        omit_test.run { omit { assert false, 'OMIT_MESSAGE' } }
+
+        result = run(omit_test)
+
+        expect(result.result).to eq('omit')
+        expect(result.result_message).to eq(message)
+      end
+
+      it 'does not omit if an assertion does not fail in the block' do
+        omit_test.run { omit { assert true, 'OMIT_MESSAGE' } }
+
+        result = run(omit_test)
+
+        expect(result.result).to eq('pass')
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Summary
This branch updates `skip` and `omit` to optionally take a block, and skip/omit if an assertion within that block fails.

# Testing Guidance
Unit tests cover these cases.