### PR TITLE
FI-3713: Delete empty fields from JSON inputs

### DIFF
--- a/client/src/components/InputsModal/InputHelpers.ts
+++ b/client/src/components/InputsModal/InputHelpers.ts
@@ -155,3 +155,13 @@ export const serializeMap = (
     ? JSON.stringify(flatObj, null, 2)
     : YAML.dump(flatObj, { lineWidth: -1 });
 };
+
+// Check if string str is JSON parseable
+export const isJsonString = (str: string) => {
+  try {
+    JSON.parse(str);
+  } catch {
+    return false;
+  }
+  return true;
+};

--- a/client/src/components/InputsModal/InputsModal.tsx
+++ b/client/src/components/InputsModal/InputsModal.tsx
@@ -29,6 +29,7 @@ import {
 } from '~/components/InputsModal/InputHelpers';
 import InputFields from '~/components/InputsModal/InputFields';
 import useStyles from '~/components/InputsModal/styles';
+import { isJsonString } from '~/components/InputsModal/InputHelpers';
 
 export interface InputsModalProps {
   modalVisible: boolean;
@@ -151,7 +152,20 @@ const InputsModal: FC<InputsModalProps> = ({
   const submitClicked = () => {
     const inputsWithValues: TestInput[] = [];
     inputsMap.forEach((inputValue, inputName) => {
-      inputsWithValues.push({ name: inputName, value: inputValue, type: 'text' });
+      if (typeof inputValue === 'string' && isJsonString(inputValue)) {
+        // Check if JSON values have empty strings and parse out those fields
+        const newJsonValue: Record<string, unknown> = {};
+        Object.entries(JSON.parse(inputValue) as object).forEach(([key, value]) => {
+          if (key && value) newJsonValue[key] = value;
+        });
+        inputsWithValues.push({
+          name: inputName,
+          value: JSON.stringify(newJsonValue),
+          type: 'text',
+        });
+      } else {
+        inputsWithValues.push({ name: inputName, value: inputValue, type: 'text' });
+      }
     });
     createTestRun(runnableType, runnable?.id || '', inputsWithValues);
     closeModal();


### PR DESCRIPTION
# Summary

Empty fields in JSON values were being set to empty strings automatically, causing type errors. Now, before input submission, JSON values get parsed and cleaned of empty strings such that only fields with filled in values are sent over.

# Testing Guidance

This can be a bit tricky to test -- if there's no test suite where empty string validation is important, then:

1. Add `console.log(JSON.parse(inputsWithValues[0].value));` to line 170 in `InputsModal.tsx`
2. Go to AuthInfo suite -> Auth mode -> Run Backend Services
3. Delete optional values (Key ID and JWKS) and submit
4. The console should print the submission values -- note that optional fields are not shown