### PR TITLE
FI-3771: Deprecate legacy validator

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -2,3 +2,4 @@ LOAD_DEV_SUITES=dev_*
 VALIDATOR_URL=https://example.com/validatorapi
 ASYNC_JOBS=false
 FHIRPATH_URL=https://example.com/fhirpath
+INITIALIZE_VALIDATOR_SESSIONS=false

--- a/dev_suites/dev_demo_ig_stu1/demo_suite.rb
+++ b/dev_suites/dev_demo_ig_stu1/demo_suite.rb
@@ -43,7 +43,7 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
       ]
     end
 
-    validator do
+    fhir_resource_validator do
       exclude_message { |message| message.type == 'info' }
     end
 

--- a/dev_suites/dev_options_suite/options_suite.rb
+++ b/dev_suites/dev_options_suite/options_suite.rb
@@ -116,12 +116,12 @@ module OptionsSuite
       }
     ]
 
-    validator required_suite_options: { ig_version: '1' } do
-      url 'v1_validator'
+    fhir_resource_validator required_suite_options: { ig_version: '1' } do
+      url 'https://example.com/v1_validator'
     end
 
-    validator required_suite_options: { ig_version: '2' } do
-      url 'v2_validator'
+    fhir_resource_validator required_suite_options: { ig_version: '2' } do
+      url 'https://example.com/v2_validator'
     end
 
     suite_option :ig_version,

--- a/lib/inferno/dsl/fhir_resource_validation.rb
+++ b/lib/inferno/dsl/fhir_resource_validation.rb
@@ -9,7 +9,7 @@ module Inferno
     #
     # @example
     #
-    #   validator do
+    #   fhir_resource_validator do
     #     url 'http://example.com/validator'
     #     exclude_message { |message| message.type == 'info' }
     #     perform_additional_validation do |resource, profile_url|
@@ -18,6 +18,11 @@ module Inferno
     #       else
     #         { type: 'info', message: 'everything is ok' }
     #       end
+    #     end
+    #     cli_context do
+    #       noExtensibleBindingMessages true
+    #       allowExampleUrls true
+    #       txServer nil
     #     end
     #   end
     module FHIRResourceValidation

--- a/lib/inferno/dsl/fhir_validation.rb
+++ b/lib/inferno/dsl/fhir_validation.rb
@@ -7,6 +7,7 @@ module Inferno
     # `assert_valid_resource` for validation rather than directly calling
     # methods on a validator.
     #
+    # @deprecated Use {Inferno::DSL::FHIRResourceValidation} instead
     # @example
     #
     #   validator do
@@ -249,6 +250,8 @@ module Inferno
         end
 
         # Define a validator
+        # @deprecated Use
+        #   {Inferno::DSL::FHIRResourceValidation::ClassMethods#fhir_resource_validator} instead
         # @example
         #   validator do
         #     url 'http://example.com/validator'
@@ -267,6 +270,10 @@ module Inferno
         # @param required_suite_options [Hash] suite options that must be
         #   selected in order to use this validator
         def validator(name = :default, required_suite_options: nil, &)
+          Inferno::Application['logger'].warn(
+            "'validator' in '#{suite.id}' TestSuite is deprecated and will be removed in an upcoming release. " \
+            "Use 'fhir_resource_validator' instead."
+          )
           current_validators = fhir_validators[name] || []
 
           new_validator = Inferno::DSL::FHIRValidation::Validator.new(required_suite_options, &)

--- a/spec/inferno/dsl/assertions_spec.rb
+++ b/spec/inferno/dsl/assertions_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Inferno::DSL::Assertions do
   let(:klass) do
     Class.new(Inferno::Entities::Test) do
-      fhir_resource_validator {}
+      fhir_resource_validator {} # rubocop:disable Lint/EmptyBlock
     end.new
   end
   let(:error_response) do
@@ -165,7 +165,7 @@ RSpec.describe Inferno::DSL::Assertions do
       it 'does not raise an exception if the resource is valid' do
         validation_request =
           stub_request(:post, validation_url)
-            .with(body: validation_body(patient_resource, FHIR::Definitions.resource_definition('Patient').url).to_json)
+            .with(body: validation_body(patient_resource, FHIR::Definitions.resource_definition('Patient').url))
             .to_return(status: 200, body: success_response.to_json)
 
         klass.assert_valid_resource(resource: patient_resource)
@@ -179,7 +179,7 @@ RSpec.describe Inferno::DSL::Assertions do
         allow(klass).to receive(:resource).and_return(patient_resource)
         validation_request =
           stub_request(:post, validation_url)
-            .with(body: validation_body(patient_resource, FHIR::Definitions.resource_definition('Patient').url).to_json)
+            .with(body: validation_body(patient_resource, FHIR::Definitions.resource_definition('Patient').url))
             .to_return(status: 200, body: success_response.to_json)
 
         klass.assert_valid_resource
@@ -192,7 +192,7 @@ RSpec.describe Inferno::DSL::Assertions do
       it "uses the resource's base profile" do
         validation_request =
           stub_request(:post, validation_url)
-            .with(body: validation_body(patient_resource, FHIR::Definitions.resource_definition('Patient').url).to_json)
+            .with(body: validation_body(patient_resource, FHIR::Definitions.resource_definition('Patient').url))
             .to_return(status: 200, body: success_response.to_json)
 
         klass.assert_valid_resource(resource: patient_resource)
@@ -214,7 +214,7 @@ RSpec.describe Inferno::DSL::Assertions do
       it 'uses the provided profile_url' do
         validation_request =
           stub_request(:post, validation_url)
-            .with(body: validation_body(patient_resource, profile_url).to_json)
+            .with(body: validation_body(patient_resource, profile_url))
             .to_return(status: 200, body: success_response.to_json)
 
         klass.assert_valid_resource(resource: patient_resource, profile_url:)
@@ -312,13 +312,17 @@ RSpec.describe Inferno::DSL::Assertions do
 
     context 'when a resource is invalid' do
       it 'raises an exception' do
+        patient_validation_body =
+          validation_body(patient_resource, FHIR::Definitions.resource_definition('Patient').url)
+        care_plan_validation_body =
+          validation_body(care_plan_resource, FHIR::Definitions.resource_definition('CarePlan').url)
         validation_requests =
           [
             stub_request(:post, validation_url)
-              .with(body: validation_body(patient_resource, FHIR::Definitions.resource_definition('Patient').url).to_json)
+              .with(body: patient_validation_body)
               .to_return(status: 200, body: success_response.to_json),
             stub_request(:post, validation_url)
-              .with(body: validation_body(care_plan_resource, FHIR::Definitions.resource_definition('CarePlan').url).to_json)
+              .with(body: care_plan_validation_body)
               .to_return(status: 200, body: error_response.to_json)
           ]
 
@@ -333,14 +337,18 @@ RSpec.describe Inferno::DSL::Assertions do
     context 'when no bundle is provided' do
       it "uses the class's resource" do
         allow(klass).to receive(:resource).and_return(bundle)
+        patient_validation_body =
+          validation_body(patient_resource, FHIR::Definitions.resource_definition('Patient').url)
+        care_plan_validation_body =
+          validation_body(care_plan_resource, FHIR::Definitions.resource_definition('CarePlan').url)
 
         validation_requests =
           [
             stub_request(:post, validation_url)
-              .with(body: validation_body(patient_resource, FHIR::Definitions.resource_definition('Patient').url).to_json)
+              .with(body: patient_validation_body)
               .to_return(status: 200, body: success_response.to_json),
             stub_request(:post, validation_url)
-              .with(body: validation_body(care_plan_resource, FHIR::Definitions.resource_definition('CarePlan').url).to_json)
+              .with(body: care_plan_validation_body)
               .to_return(status: 200, body: success_response.to_json)
           ]
 
@@ -352,13 +360,17 @@ RSpec.describe Inferno::DSL::Assertions do
 
     context 'when no resource_types hash is provided' do
       it 'validates all entries against their base profiles' do
+        patient_validation_body =
+          validation_body(patient_resource, FHIR::Definitions.resource_definition('Patient').url)
+        care_plan_validation_body =
+          validation_body(care_plan_resource, FHIR::Definitions.resource_definition('CarePlan').url)
         validation_requests =
           [
             stub_request(:post, validation_url)
-              .with(body: validation_body(patient_resource, FHIR::Definitions.resource_definition('Patient').url).to_json)
+              .with(body: patient_validation_body)
               .to_return(status: 200, body: success_response.to_json),
             stub_request(:post, validation_url)
-              .with(body: validation_body(care_plan_resource, FHIR::Definitions.resource_definition('CarePlan').url).to_json)
+              .with(body: care_plan_validation_body)
               .to_return(status: 200, body: success_response.to_json)
           ]
 
@@ -370,9 +382,11 @@ RSpec.describe Inferno::DSL::Assertions do
 
     context 'when a resource_types string is provided' do
       it 'only validates that resource_type against its base profile' do
+        care_plan_validation_body =
+          validation_body(care_plan_resource, FHIR::Definitions.resource_definition('CarePlan').url)
         validation_request =
           stub_request(:post, validation_url)
-            .with(body: validation_body(care_plan_resource, FHIR::Definitions.resource_definition('CarePlan').url).to_json)
+            .with(body: care_plan_validation_body)
             .to_return(status: 200, body: success_response.to_json)
 
         klass.assert_valid_bundle_entries(bundle:, resource_types: 'CarePlan')
@@ -383,9 +397,11 @@ RSpec.describe Inferno::DSL::Assertions do
 
     context 'when a resource_types array is provided' do
       it 'only validates those resource_types against their base profiles' do
+        care_plan_validation_body =
+          validation_body(care_plan_resource, FHIR::Definitions.resource_definition('CarePlan').url)
         validation_request =
           stub_request(:post, validation_url)
-            .with(body: validation_body(care_plan_resource, FHIR::Definitions.resource_definition('CarePlan').url).to_json)
+            .with(body: care_plan_validation_body)
             .to_return(status: 200, body: success_response.to_json)
 
         klass.assert_valid_bundle_entries(bundle:, resource_types: ['CarePlan'])
@@ -397,13 +413,17 @@ RSpec.describe Inferno::DSL::Assertions do
     context 'when a resource_types hash is provided' do
       it 'only validates those types against the provided profile or the base profile if no profile provided' do
         patient_profile = 'PATIENT_PROFILE'
+        patient_validation_body =
+          validation_body(patient_resource, patient_profile)
+        care_plan_validation_body =
+          validation_body(care_plan_resource, FHIR::Definitions.resource_definition('CarePlan').url)
         validation_requests =
           [
             stub_request(:post, validation_url)
-              .with(body: validation_body(patient_resource, patient_profile))
-                      .to_return(status: 200, body: success_response.to_json),
+              .with(body: patient_validation_body)
+              .to_return(status: 200, body: success_response.to_json),
             stub_request(:post, validation_url)
-              .with(body: validation_body(care_plan_resource, FHIR::Definitions.resource_definition('CarePlan').url).to_json)
+              .with(body: care_plan_validation_body)
               .to_return(status: 200, body: success_response.to_json)
           ]
 

--- a/spec/inferno/dsl/fhir_resource_validation_spec.rb
+++ b/spec/inferno/dsl/fhir_resource_validation_spec.rb
@@ -312,8 +312,8 @@ RSpec.describe Inferno::DSL::FHIRResourceValidation do
       v1_validator = suite.find_validator(:default, ig_version: '1')
       v2_validator = suite.find_validator(:default, ig_version: '2')
 
-      expect(v1_validator.url).to eq('v1_validator')
-      expect(v2_validator.url).to eq('v2_validator')
+      expect(v1_validator.url).to eq('https://example.com/v1_validator')
+      expect(v2_validator.url).to eq('https://example.com/v2_validator')
     end
   end
 
@@ -326,8 +326,8 @@ RSpec.describe Inferno::DSL::FHIRResourceValidation do
       v1_validator = v1_test.find_validator(:default)
       v2_validator = v2_test.find_validator(:default)
 
-      expect(v1_validator.url).to eq('v1_validator')
-      expect(v2_validator.url).to eq('v2_validator')
+      expect(v1_validator.url).to eq('https://example.com/v1_validator')
+      expect(v2_validator.url).to eq('https://example.com/v2_validator')
     end
   end
 end

--- a/spec/inferno/dsl/fhir_validation_spec.rb
+++ b/spec/inferno/dsl/fhir_validation_spec.rb
@@ -234,8 +234,8 @@ RSpec.describe Inferno::DSL::FHIRValidation do
       v1_validator = suite.find_validator(:default, ig_version: '1')
       v2_validator = suite.find_validator(:default, ig_version: '2')
 
-      expect(v1_validator.url).to eq('v1_validator')
-      expect(v2_validator.url).to eq('v2_validator')
+      expect(v1_validator.url).to eq('https://example.com/v1_validator')
+      expect(v2_validator.url).to eq('https://example.com/v2_validator')
     end
   end
 
@@ -248,8 +248,8 @@ RSpec.describe Inferno::DSL::FHIRValidation do
       v1_validator = v1_test.find_validator(:default)
       v2_validator = v2_test.find_validator(:default)
 
-      expect(v1_validator.url).to eq('v1_validator')
-      expect(v2_validator.url).to eq('v2_validator')
+      expect(v1_validator.url).to eq('https://example.com/v1_validator')
+      expect(v2_validator.url).to eq('https://example.com/v2_validator')
     end
   end
 end

--- a/spec/inferno/test_runner_spec.rb
+++ b/spec/inferno/test_runner_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Inferno::TestRunner do
       stub_request(:get, "#{base_url}/Observation")
         .with(query: { 'patient' => patient_id })
         .to_return(status: 200, body: observation_bundle.to_json)
-      stub_request(:post, "#{ENV.fetch('VALIDATOR_URL')}/validate")
+      stub_request(:post, "#{ENV.fetch('FHIR_RESOURCE_VALIDATOR_URL')}/validate")
         .with(query: hash_including({}))
         .to_return(status: 200, body: FHIR::OperationOutcome.new.to_json)
       stub_request(:get, 'http://example.com')

--- a/spec/shared/test_kit_examples.rb
+++ b/spec/shared/test_kit_examples.rb
@@ -155,6 +155,19 @@ RSpec.shared_examples 'platform_deployable_test_kit' do
         expect(link_labels).to include(*expected_labels), error_message
       end
     end
+
+    it 'does not rely on the deprecated `Inferno::DSL::FHIRValidation`' do
+      suites.each do |suite|
+        suite.fhir_validators.each do |name, validators|
+          validators.each do |validator|
+            error_message =
+              "Validator '#{name}' in Suite '#{suite.id}' should be changed to a " \
+              'fhir_resource_validator'
+            expect(validator).to_not be_an_instance_of(Inferno::DSL::FHIRValidation::Validator), error_message
+          end
+        end
+      end
+    end
   end
 
   describe 'presets' do


### PR DESCRIPTION
# Summary
This branch adds a deprecation warning to the old validator and switches dev suites and unit tests to rely on the new validator.

# Testing Guidance
If you check out `7ac6aedc1a8dc8a930445acc91a9ab1d0ec51aaa` and start Inferno, you will see the deprecation warnings for the validators in the dev suites.