### PR TITLE
FI-3722: Add branch for built UI

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -1,0 +1,52 @@
+name: UI Build
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ['20.x']
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Cache Node.js modules
+      uses: actions/cache@v4
+      with:
+        # npm cache files are stored in `~/.npm` on Linux/macOS
+        path: ~/.npm
+        key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.OS }}-node-
+          ${{ runner.OS }}-
+    - run: npm ci
+    - run: npm run build
+    - name: Remove js build files from .gitignore
+      run: |
+        sed -i '/\/lib\/inferno\/public\/assets\*/d' .gitignore
+        sed -i '/\/lib\/inferno\/public\/\*\.js/d' .gitignore
+        sed -i '/\/lib\/inferno\/public\/\*\.png/d' .gitignore
+    - name: Set github author
+      run: |
+          git config --global user.email "inferno-developers@groups.mitre.org"
+          git config --global user.name "Inferno CI"
+    - name: Commit docs
+      run: |
+        git add lib/inferno/public/*.js
+        git add lib/inferno/public/*.png
+        git add lib/inferno/public/assets*
+        git commit -m 'build ui'
+    - name: Push to ci-main-ui branch
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: ci-main-ui
+        force: true


### PR DESCRIPTION
# Summary
This branch adds an action to automatically push an update which includes the built UI to the `ci-main-ui` branch whenever `main` is updated. This will allow test kits/platforms to easily preview inferno core updates which have been merged but not yet released.

# Testing Guidance
In a test kit, add the following to the `Gemfile`:
```ruby
gem 'inferno_core',
    git: 'https://github.com/inferno-framework/inferno-core.git',
    branch: 'main'
```
Run `bundle`, then start inferno. When you navigate to inferno in the browser, the UI won't load because the UI isn't included in the `main` branch.

Change the code in the Gemfile to point at `ci-main-ui` rather than `main`, run `bundle` and restart inferno. Now when you navigate to inferno the UI should load as normal.