### PR TITLE
FI-3626: Integrate validator service into evaluator CLI

### DIFF
--- a/lib/inferno/apps/cli/evaluate.rb
+++ b/lib/inferno/apps/cli/evaluate.rb
@@ -1,6 +1,7 @@
 require_relative '../../dsl/fhir_evaluation/evaluator'
 require_relative '../../dsl/fhir_evaluation/config'
 require_relative '../../entities'
+require_relative '../../repositories/validator_sessions'
 require_relative '../../utils/ig_downloader'
 
 require 'tempfile'

--- a/lib/inferno/apps/cli/evaluate.rb
+++ b/lib/inferno/apps/cli/evaluate.rb
@@ -1,7 +1,7 @@
 require_relative '../../dsl/fhir_evaluation/evaluator'
 require_relative '../../dsl/fhir_evaluation/config'
 require_relative '../../entities'
-require_relative '../../repositories/validator_sessions'
+require_relative '../../repositories'
 require_relative '../../utils/ig_downloader'
 
 require 'tempfile'

--- a/lib/inferno/dsl/fhir_evaluation/profile_conformance_helper.rb
+++ b/lib/inferno/dsl/fhir_evaluation/profile_conformance_helper.rb
@@ -55,10 +55,16 @@ module Inferno
           declared_profiles.include?(profile_url) || declared_profiles.include?(versioned_url)
         end
 
-        # @private until implemented
-        def validates_profile?(_resource, _profile, _validator)
-          raise 'Profile validation is not yet implemented. ' \
-                'Set considerValidationResults=false.'
+        # Check if the given resource validates against the given profile.
+        # "Validates" means the provided Validator instance returns no fatal or error messages.
+        # @param resource [FHIR::Resource]
+        # @param profile [FHIR::StructureDefinition]
+        # @param validator [Inferno::DSL::FHIRResourceValidation::Validator]
+        def validates_profile?(resource, profile, validator)
+          return false if validator.nil?
+
+          runnable = Inferno::Entities::Test.new
+          validator.resource_is_valid?(resource, profile.url, runnable, add_messages_to_runnable: false)
         end
       end
     end

--- a/spec/inferno/dsl/fhir_evaluation/profile_conformance_helper_spec.rb
+++ b/spec/inferno/dsl/fhir_evaluation/profile_conformance_helper_spec.rb
@@ -108,16 +108,31 @@ RSpec.describe Inferno::DSL::FHIREvaluation::ProfileConformanceHelper do
       expect(result).to be(true)
     end
 
-    it 'raises for Not Yet Implemented if considerValidationResults' do
+    it 'returns true for a valid resource if considerValidationResults' do
       options = {
         considerMetaProfile: false,
         considerOnlyResourceType: false,
         considerValidationResults: true
       }
-      validator = nil
-      expect do
-        checker.conforms_to_profile?(patient, patient_profile, options, validator)
-      end.to raise_error(StandardError, /Profile validation is not yet implemented/)
+
+      validator = double
+      allow(validator).to receive(:resource_is_valid?).and_return(true)
+
+      result = checker.conforms_to_profile?(patient, patient_profile, options, validator)
+      expect(result).to be(true)
+    end
+
+    it 'returns false for an invalid resource if considerValidationResults' do
+      options = {
+        considerMetaProfile: false,
+        considerOnlyResourceType: false,
+        considerValidationResults: true
+      }
+      validator = double
+      allow(validator).to receive(:resource_is_valid?).and_return(false)
+
+      result = checker.conforms_to_profile?(patient, patient_profile, options, validator)
+      expect(result).to be(false)
     end
 
     it 'returns true for a resource when the block returns true' do


### PR DESCRIPTION
# Summary
Integrates the validator service into the evaluator CLI tool. As of right now the only way this is used is as a heuristic for resource selection for profile conformance, for instance in a rule "all profiles must have examples", we can say that if a resource conforms to a profile then it is an example of that profile.

The framework for this is already in place, so the key change here is just to fill in a few blanks. The only quirk is that if we want to evaluate against an IG by file, and that file isn't already in the new data/igs directory, we need to copy it there so that it's accessible to the validator container. Referencing an IG by identifier, eg `hl7.fhir.us.core#3.1.1`, works as-is in the validator so no need to do anything special in that case.

# Testing Guidance
By default, the new feature is disabled for performance reasons - starting up a validator session is pretty slow. To enable it, update `lib/inferno/dsl/fhir_evaluation/default.yml` and under `ConformanceOptions` set `considerValidationResults` = true, you may also want to set `considerMetaProfile` = false as well:

```yaml
    ConformanceOptions:
      # ConformanceOptions allows selecting from a few approaches to determine which subset of resources
      # should be used to search for the MustSupport elements from each profile.
      # Resources that are not the same type as the target of the profile are never searched, regardless of option.

      # - If considerMetaProfile, the search will include resources that declare the current profile in meta.profile
      considerMetaProfile: false

      # - If considerValidationResults, resources will be validated against each profile to determine which they should be checked against.
      #   The search will include resources that validate against the current profile
      #   (in other words, resources for which a validation request produces no errors).
      considerValidationResults: true

      # - If considerOnlyResourceType, the search will include resources of the same type as the profile target type (StructureDefintion.type)
      considerOnlyResourceType: false
```

Then to actually run it, make sure services are running: `bundle exec inferno services start`
then invoke the evaluator cli, examples:

```
bundle exec inferno evaluate "hl7.fhir.us.core#3.1.1"
bundle exec inferno evaluate ~/Downloads/davinci-dtr-2.1.0.tgz
bundle exec inferno evaluate ./spec/fixtures/uscore311.tgz
```
You should see activity in the validator service docker logs while these are running