### PR TITLE
FI-3757: Allow setting suite defaults in UI

### DIFF
--- a/client/src/components/_common/SelectionPanel/RadioSelection.tsx
+++ b/client/src/components/_common/SelectionPanel/RadioSelection.tsx
@@ -15,9 +15,8 @@ const RadioSelection: FC<RadioSelectionProps> = ({
   setSelections: setParentSelections,
 }) => {
   const { classes } = useStyles();
+  // NOTE: Perhaps choices should be persisted in the URL to make it easy to share specific options
   const initialSelectedRadioOptions: RadioOptionSelection[] = options.map((option) => ({
-    // just grab the first to start
-    // perhaps choices should be persisted in the URL to make it easy to share specific options
     id: option.id,
     value: getStartingValue(option),
   }));
@@ -33,6 +32,7 @@ const RadioSelection: FC<RadioSelectionProps> = ({
     if (option.default) {
       return option.default;
     } else if (option.list_options) {
+      // Grab the first option to start if no default
       return option.list_options[0].value;
     }
     return '';

--- a/client/src/components/_common/SelectionPanel/RadioSelection.tsx
+++ b/client/src/components/_common/SelectionPanel/RadioSelection.tsx
@@ -19,7 +19,7 @@ const RadioSelection: FC<RadioSelectionProps> = ({
     // just grab the first to start
     // perhaps choices should be persisted in the URL to make it easy to share specific options
     id: option.id,
-    value: option && option.list_options ? option.list_options[0].value : '',
+    value: getStartingValue(option),
   }));
   const [selectedRadioOptions, setSelectedRadioOptions] = React.useState<RadioOptionSelection[]>(
     initialSelectedRadioOptions || [],
@@ -28,6 +28,15 @@ const RadioSelection: FC<RadioSelectionProps> = ({
   useEffect(() => {
     setParentSelections(initialSelectedRadioOptions);
   }, []);
+
+  function getStartingValue(option: RadioOption): string {
+    if (option.default) {
+      return option.default;
+    } else if (option.list_options) {
+      return option.list_options[0].value;
+    }
+    return '';
+  }
 
   const changeRadioOption = (option_id: string, value: string): void => {
     const newOptions = selectedRadioOptions.map((option: RadioOptionSelection) =>
@@ -58,9 +67,7 @@ const RadioSelection: FC<RadioSelectionProps> = ({
 
           <RadioGroup
             aria-label={`radio-group-${option.id}`}
-            defaultValue={
-              option.list_options && option.list_options.length && option.list_options[0].value
-            }
+            defaultValue={getStartingValue(option)}
             name={`radio-group-${option.id}`}
             data-testid="radio-option-group"
           >

--- a/client/src/models/selectionModels.ts
+++ b/client/src/models/selectionModels.ts
@@ -11,6 +11,7 @@ export type ListOptionSelection = string;
 
 export type RadioOption = Option & {
   description: string;
+  default?: string;
   list_options: SuiteOptionChoice[]; // Make this generic if other options are introduced
 };
 


### PR DESCRIPTION
# Summary

Suite options used to automatically default to the first available option; defaults are now accepted to override that setting.

![Screenshot 2025-03-06 at 3 56 06 PM](https://github.com/user-attachments/assets/d5852edf-268d-4eab-9b43-b46a42af47bf)


# Testing Guidance

Options Suite should select IG version v2 on load.
