### PR TITLE
FI-3882: Handle AuthInfo date parsing errors

### DIFF
--- a/lib/inferno/dsl/auth_info.rb
+++ b/lib/inferno/dsl/auth_info.rb
@@ -143,6 +143,8 @@ module Inferno
           value = DateTime.parse(value) if name == :issue_time && value.is_a?(String)
 
           instance_variable_set(:"@#{name}", value)
+        rescue Date::Error
+          Inferno::Application['logger'].error("Received invalid date: #{value.inspect}")
         end
 
         self.issue_time = DateTime.now if access_token.present? && issue_time.blank?

--- a/lib/inferno/dsl/auth_info.rb
+++ b/lib/inferno/dsl/auth_info.rb
@@ -132,7 +132,7 @@ module Inferno
       # @!attribute [rw] name
 
       # @private
-      def initialize(raw_attributes_hash)
+      def initialize(raw_attributes_hash) # rubocop:disable Metrics/CyclomaticComplexity
         attributes_hash = raw_attributes_hash.symbolize_keys
 
         invalid_keys = attributes_hash.keys - ATTRIBUTES

--- a/spec/inferno/dsl/auth_info_spec.rb
+++ b/spec/inferno/dsl/auth_info_spec.rb
@@ -37,6 +37,10 @@ RSpec.describe Inferno::DSL::AuthInfo do
         )
       )
     end
+
+    it 'does not raise an error when issue_time as an empty string' do
+      expect { described_class.new(issue_time: '') }.to_not raise_error
+    end
   end
 
   describe '#add_to_client' do


### PR DESCRIPTION
# Summary
This branch rescues and logs errors when an AuthInfo object has an invalid issue time.

# Testing Guidance
Add the following to the `Gemfile` and run `bundle`:
```ruby
gem 'davinci_us_drug_formulary_test_kit',
    git: 'https://github.com/inferno-framework/davinci-us-drug-formulary-test-kit.git',
    branch: 'fi-3746-use-authinfo'
```
Add `require 'davinci_us_drug_formulary_test_kit'` to the demo suite, start inferno, and the formulary tests should work with the preset. If you do the same on `main`, you will be unable to run the tests.