### PR TITLE
FI-3908: Change how evaluator CLI requires repositories, fixing migrate task

### DIFF
--- a/lib/inferno/apps/cli/evaluate.rb
+++ b/lib/inferno/apps/cli/evaluate.rb
@@ -1,7 +1,6 @@
 require_relative '../../dsl/fhir_evaluation/evaluator'
 require_relative '../../dsl/fhir_evaluation/config'
 require_relative '../../entities'
-require_relative '../../repositories'
 require_relative '../../utils/ig_downloader'
 
 require 'tempfile'
@@ -10,6 +9,12 @@ module Inferno
   module CLI
     class Evaluate < Thor::Group
       def evaluate(ig_path, data_path, _log_level)
+        # NOTE: repositories is required here rather than at the top of the file because
+        # the tree of requires means that this file and its requires get required by every CLI app.
+        # Sequel::Model, used in some repositories, fetches the table schema at instantiation.
+        # This breaks the `migrate` task by fetching a table before the task runs/creates it.
+        require_relative '../../repositories'
+
         validate_args(ig_path, data_path)
         ig = Inferno::Repositories::IGs.new.find_or_load(ig_path)
 


### PR DESCRIPTION
# Summary
This PR fixes an issue that causes the `inferno migrate` task to fail with an error. The `evaluate` task requires the repositories so that it can read/persist validator session IDs, but this broke the `migrate` task when the tables don't already exist. The fix (for now at least) is to just move the require into a method call so that it's not invoked for all the other unrelated rake tasks. 

# Testing Guidance
To make sure the evaluator still works:
- Set the evaluator to use the validator by changing settings in `lib/inferno/dsl/fhir_evaluation/default.yml`:
- Start up the background services `bundle exec inferno services start`
- Run an evaluation, eg `bundle exec inferno evaluate ./spec/fixtures/uscore311.tgz` . 
- This may take a while so if you don't want to wait for it to finish, just confirm no ruby  errors in the log here, then confirm from the validator service logs that it is handling validation requests. If the ValidatorSessions repository was not required properly, the process would crash before making any validator calls


To make sure the migrate task is fixed:
- Delete or move away any existing `./data/inferno_development.db`
- Run `bundle exec inferno migrate`