### PR TITLE
Hide authorization header value for request if safe_mode

### DIFF
--- a/lib/inferno/apps/web/controllers/requests/show.rb
+++ b/lib/inferno/apps/web/controllers/requests/show.rb
@@ -7,7 +7,21 @@ module Inferno
             request = repo.find_full_request(req.params[:id])
             halt 404 if request.nil?
 
+            update_request_headers(request) if safe_mode?
+
             res.body = serialize(request, view: :full)
+          end
+
+          private
+
+          def safe_mode?
+            ENV['SAFE_MODE'] == 'true'
+          end
+
+          def update_request_headers(request)
+            request.request_headers.each do |header|
+              header.value = 'PROTECTED' if header.name.downcase == 'authorization'
+            end
           end
         end
       end

--- a/spec/factories/request.rb
+++ b/spec/factories/request.rb
@@ -23,6 +23,11 @@ FactoryBot.define do
           type: 'response',
           name: 'Response-Header',
           value: 'RESPONSE HEADER VALUE'
+        },
+        {
+          type: 'request',
+          name: 'Authorization',
+          value: 'Bearer token123'
         }
       ]
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 $VERBOSE = nil
 
 ENV['APP_ENV'] ||= 'test'
+ENV['SAFE_MODE'] ||= 'false'
 
 require 'pry'
 require 'database_cleaner/sequel'


### PR DESCRIPTION
Ref: https://github.com/inferno-framework/inferno-core/issues/657

# Summary
I updated the request controller "show" action to replace the header value with 'PROTECTED' if the header name is 'authorization' and ENV['SAFE_MODE'] is 'true'

# Testing Guidance

```bash
bundle exec rake spec
```

