### PR TITLE
(WIP) FI-3813: MustSupport logic fixes

### DIFF
--- a/lib/inferno/dsl/fhir_resource_navigation.rb
+++ b/lib/inferno/dsl/fhir_resource_navigation.rb
@@ -177,8 +177,17 @@ module Inferno
       end
 
       def matching_required_binding_slice?(slice, discriminator)
-        discriminator[:path].present? ? slice.send((discriminator[:path]).to_s).coding : slice.coding
-        slice_value { |coding| discriminator[:values].include?(coding.code) }
+        slice_coding = discriminator[:path].present? ? slice.send((discriminator[:path]).to_s).coding : slice.coding
+        slice_coding.any? do |coding|
+          discriminator[:values].any? do |value|
+            case value
+            when String
+              value == coding.code
+            when Hash
+              value[:system] == coding.system && value[:code] == coding.code
+            end
+          end
+        end
       end
 
       def verify_slice_by_values(element, value_definitions)

--- a/lib/inferno/dsl/must_support_assessment.rb
+++ b/lib/inferno/dsl/must_support_assessment.rb
@@ -352,7 +352,14 @@ module Inferno
           coding_path = discriminator[:path].present? ? "#{discriminator[:path]}.coding" : 'coding'
 
           find_a_value_at(element, coding_path) do |coding|
-            discriminator[:values].any? { |value| value[:system] == coding.system && value[:code] == coding.code }
+            discriminator[:values].any? do |value|
+              case value
+              when String
+                value == coding.code
+              when Hash
+                value[:system] == coding.system && value[:code] == coding.code
+              end
+            end
           end
         end
 

--- a/lib/inferno/dsl/must_support_assessment.rb
+++ b/lib/inferno/dsl/must_support_assessment.rb
@@ -344,6 +344,11 @@ module Inferno
           when 'String'
             element.is_a? String
           else
+            if element.is_a? FHIR::Bundle::Entry
+              # Special case for type slicing in a Bundle - look at the resource not the entry
+              element = element.resource
+            end
+
             element.is_a? FHIR.const_get(discriminator[:code])
           end
         end

--- a/lib/inferno/dsl/must_support_assessment.rb
+++ b/lib/inferno/dsl/must_support_assessment.rb
@@ -332,13 +332,13 @@ module Inferno
           when 'Date'
             begin
               Date.parse(element)
-            rescue ArgumentError
+            rescue ArgumentError, TypeError
               false
             end
           when 'DateTime'
             begin
               DateTime.parse(element)
-            rescue ArgumentError
+            rescue ArgumentError, TypeError
               false
             end
           when 'String'

--- a/spec/fixtures/metadata/pas_request_bundle_v201.yml
+++ b/spec/fixtures/metadata/pas_request_bundle_v201.yml
@@ -1,0 +1,76 @@
+---
+:name: profile_pas_request_bundle
+:class_name: ProfilePasRequestBundleSequence
+:version: v2.0.1
+:reformatted_version: v201
+:resource: Bundle
+:profile_url: http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-pas-request-bundle
+:profile_name: PAS Request Bundle
+:profile_version: 2.0.1
+:title: Request Bundle
+:short_description: Verify support for the server capabilities required by the PAS
+  Request Bundle.
+:interactions: []
+:operations: []
+:required_concepts: []
+:must_supports:
+  :extensions: []
+  :slices:
+  - :slice_id: Bundle.entry:Claim
+    :slice_name: Claim
+    :path: entry
+    :discriminator:
+      :type: type
+      :code: Claim
+  :elements:
+  - :path: identifier
+  - :path: timestamp
+  - :path: entry
+  - :path: entry.fullUrl
+  - :path: entry.resource
+:mandatory_elements:
+- Bundle.identifier
+- Bundle.type
+- Bundle.timestamp
+- Bundle.link.relation
+- Bundle.link.url
+- Bundle.entry
+- Bundle.entry.fullUrl
+- Bundle.entry.resource
+- Bundle.entry.request.method
+- Bundle.entry.request.url
+- Bundle.entry.response.status
+:bindings:
+- :type: code
+  :strength: preferred
+  :system: http://hl7.org/fhir/ValueSet/languages
+  :path: language
+- :type: code
+  :strength: required
+  :system: http://hl7.org/fhir/ValueSet/bundle-type
+  :path: type
+- :type: code
+  :strength: required
+  :system: http://hl7.org/fhir/ValueSet/search-entry-mode
+  :path: entry.search.mode
+- :type: code
+  :strength: required
+  :system: http://hl7.org/fhir/ValueSet/http-verb
+  :path: entry.request.method
+- :type: code
+  :strength: required
+  :system: http://hl7.org/fhir/ValueSet/search-entry-mode
+  :path: entry.search.mode
+- :type: code
+  :strength: required
+  :system: http://hl7.org/fhir/ValueSet/http-verb
+  :path: entry.request.method
+:references: []
+:tests:
+- :id: pas_server_v201_pas_request_bundle_validation_test
+  :file_name: server_pas_request_bundle_validation_test.rb
+- :id: pas_server_submit_request_v201_pas_request_bundle_must_support_test
+  :file_name: server_submit_request_pas_request_bundle_must_support_test.rb
+- :id: pas_client_submit_request_v201_pas_request_bundle_must_support_test
+  :file_name: client_submit_request_pas_request_bundle_must_support_test.rb
+:delayed_references: []

--- a/spec/inferno/dsl/must_support_assessment_spec.rb
+++ b/spec/inferno/dsl/must_support_assessment_spec.rb
@@ -320,6 +320,41 @@ RSpec.describe Inferno::DSL::MustSupportAssessment do
       end
     end
 
+    context 'with type slicing on a Bundle' do
+      let(:pas_request_bundle_metadata) do
+        metadata_fixture('pas_request_bundle_v201.yml')
+      end
+
+      let(:pas_request_bundle) do
+        FHIR::Bundle.new(
+          identifier: {
+            system: "http://example.org/SUBMITTER_TRANSACTION_IDENTIFIER",
+            value: "16139462398"
+          },
+          type: 'collection',
+          timestamp: '2025-06-24T07:34:00+05:00',
+          entry: [
+            {
+              fullUrl: 'http://example.com/Claim/123',
+              resource: FHIR::Claim.new
+            }
+          ]
+        )
+      end
+
+      it 'identifies when the slice is present' do
+        result = run_with_metadata([pas_request_bundle], pas_request_bundle_metadata)
+        expect(result).to be_empty
+      end
+
+      it 'identifies when the slice is not present' do
+        pas_request_bundle.entry.clear
+
+        result = run_with_metadata([pas_request_bundle], pas_request_bundle_metadata)
+        expect(result).to include('Bundle.entry:Claim')
+      end
+    end
+
     context 'with requiredBinding slicing' do
       context 'when Condition ProblemsHealthConcerns' do
         let(:condition_problems_health_concerns_metadata) do


### PR DESCRIPTION
# Summary
This PR addresses a few issues identified in the process of migrating test kits to use the new core MustSupport assertion and related logic.

1. Type Slicing on Bundles, as seen in PAS
   - This is an edge case not originally caught in the core logic because US Core doesn't do anything with Bundles. On Bundles the slice definition is on `Bundle.entry`, but the type to check for is actually in the `Bundle.entry.resource`, so this adds conditional logic in the case that we're looking at a Bundle Entry.
   - See also: https://github.com/inferno-framework/davinci-pas-test-kit/blob/844840bdf98ae718cd89c150a3bf845b982120cb/lib/davinci_pas_test_kit/must_support_test.rb#L232
2. Required Binding issues, as seen in Carin4BB
   - Two things going on here.
   - First the original logic in `FHIRResourceNavigation#matching_required_binding_slice?` didn't even work due to a syntax error, so that had to be fixed.
   - Second, both this and `MustSupportAssessment#find_required_binding_slice` have similar logic but were looking for different types. The discriminator list of required values at one point would have contained just codes, but now the MS metadata extractor logic will use codings {system,code}. To be defensive, both these methods can now handle the list being codes or codings.
   - See also: https://github.com/inferno-framework/carin-for-blue-button-test-kit/blob/5784c2b8a6aaa1884e9557c560365696b2b1d75b/lib/carin_for_blue_button_test_kit/generated/v1.1.0/eob_inpatient_institutional/metadata.yml#L326
3. Date/DateTime parsing throws TypeError
   - I already forget where I saw this but the Date and DateTime type checks throw TypeError if the passed in value isn't a string, for example if it's a FHIR::Period

# Testing Guidance
TBD
