### PR TITLE
FI-3867: Add new env var to validator dockerfile to disable presets

### DIFF
--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -38,6 +38,7 @@ RUN wget -O validator-wrapper.jar "https://github.com/hapifhir/org.hl7.fhir.vali
 ENV ENVIRONMENT=prod
 ENV SESSION_CACHE_IMPLEMENTATION=PassiveExpiringSessionCache
 ENV SESSION_CACHE_DURATION=-1
+ENV VALIDATION_SERVICE_PRESETS_FILE_PATH=ignore-this-do-not-load-presets
 
 EXPOSE 3500
 

--- a/validator/README.md
+++ b/validator/README.md
@@ -8,6 +8,8 @@ This Dockerfile is based on the Dockerfile for org.hl7.fhir.validator-wrapper (s
    - SESSION_CACHE_IMPLEMENTATION=PassiveExpiringSessionCache
    - SESSION_CACHE_DURATION=-1
      - These enable the old session cache implementation, and configure the session cache to never expire sessions.
+   - VALIDATION_SERVICE_PRESETS_FILE_PATH=ignore-this-do-not-load-presets
+     - This disables loading presets at service startup by pointing it to a non-existent file. (There is no other explicit value or setting for "do not load presets")
 
 It is intended to be a drop-in replacement for the official image; i.e., if you don't need features 2 & 3 above you can use the same version of `markiantorno/validator-wrapper`. Version numbers of this image should match the version number of the official image. The only difference is you will need to set the environment variables as mentioned in (4) above, depending on which behavior you want.
 


### PR DESCRIPTION
# Summary
Adds a new environment variable to our `infernocommunity/inferno-resource-validator` dockerfile to disable loading presets at service startup. Unfortunately there's no explicit value or setting to disable presets, we have to just point it to a non-existent path. Hence I gave it a name that hopefully makes it obvious the error message it prints is intentional.

The logs at startup now look like this:
```
2025-04-03 08:31:33 Starting instance in 0.0.0.0:3500
2025-04-03 08:31:34 Attempting to load presets from ignore-this-do-not-load-presets
2025-04-03 08:31:34 Error occurred loading presets. No presets will be loaded
2025-04-03 08:31:34 java.io.FileNotFoundException: ignore-this-do-not-load-presets (No such file or directory)
2025-04-03 08:31:34     at java.base/java.io.FileInputStream.open0(Native Method)
2025-04-03 08:31:34     at java.base/java.io.FileInputStream.open(Unknown Source)
2025-04-03 08:31:34     at java.base/java.io.FileInputStream.<init>(Unknown Source)
```

# Testing Guidance
To build and run this image locally:

```
cd validator
docker buildx build --platform linux/arm64 --build-arg "PROJECT_VERSION=1.0.65" --tag "infernocommunity/inferno-resource-validator:1.0.65" --load .
docker run -p 3500:3500 infernocommunity/inferno-resource-validator:1.0.65
```
Notice in the logs it doesn't load presets, compare to version 1.0.60 which is the current latest.

You can also test validation in the UI at http://localhost:3500. Or after building the image, this branch of G10 can be run locally https://github.com/onc-healthit/onc-certification-g10-test-kit/pull/639
