### PR TITLE
Fix for requirements loading twice

### DIFF
--- a/lib/inferno/config/boot/requirements.rb
+++ b/lib/inferno/config/boot/requirements.rb
@@ -29,9 +29,9 @@ Inferno::Application.register_provider(:requirements) do
       end
 
     files_to_load.compact!
-    files_to_load.uniq!
     files_to_load.reject! { |file| file.include?('out_of_scope') }
     files_to_load.map! { |path| File.realpath(path) }
+    files_to_load.uniq!
 
     files_to_load.each do |path|
       requirements_repo.insert_from_file(path)


### PR DESCRIPTION
# Summary
Quick followup bugfix to FI-3600: when running a test kit standalone, the new requirements boot process is pulling in the local requirement files twice (once as `lib/*test_kit/requirements/*.csv`, once as `File.join(gem.full_gem_path, 'lib', '*test_kit', 'requirements', '*.csv')`). 
This causes errors like the following and prevents the UI from starting.

```
08:52:01 web.1    | ! Unable to load application: Inferno::Exceptions::DuplicateEntityIdException: ID 'hl7.fhir.us.carin-bb_2.0.0@1' already exists. Ensure the uniqueness of the IDs.
08:52:01 web.1    | /Users/dehall/.rvm/gems/ruby-3.3.6/bundler/gems/inferno-core-f6b3046637fc/lib/inferno/repositories/in_memory_repository.rb:12:in `insert': ID 'hl7.fhir.us.carin-bb_2.0.0@1' already exists. Ensure the uniqueness of the IDs. (Inferno::Exceptions::DuplicateEntityIdException)
08:52:01 web.1    | 	from /Users/dehall/.rvm/gems/ruby-3.3.6/bundler/gems/inferno-core-f6b3046637fc/lib/inferno/repositories/requirements.rb:50:in `block in insert_from_file'
08:52:01 web.1    | 	from /Users/dehall/.rvm/gems/ruby-3.3.6/bundler/gems/inferno-core-f6b3046637fc/lib/inferno/repositories/requirements.rb:47:in `each'
08:52:01 web.1    | 	from /Users/dehall/.rvm/gems/ruby-3.3.6/bundler/gems/inferno-core-f6b3046637fc/lib/inferno/repositories/requirements.rb:47:in `insert_from_file'
08:52:01 web.1    | 	from /Users/dehall/.rvm/gems/ruby-3.3.6/bundler/gems/inferno-core-f6b3046637fc/lib/inferno/config/boot/requirements.rb:37:in `block (3 levels) in <top (required)>'
08:52:01 web.1    | 	from /Users/dehall/.rvm/gems/ruby-3.3.6/bundler/gems/inferno-core-f6b3046637fc/lib/inferno/config/boot/requirements.rb:36:in `each'
08:52:01 web.1    | 	from /Users/dehall/.rvm/gems/ruby-3.3.6/bundler/gems/inferno-core-f6b3046637fc/lib/inferno/config/boot/requirements.rb:36:in `block (2 levels) in <top (required)>'

```

The fix is just to get the unique paths after mapping them to absolute paths (realpath), not before.

# Testing Guidance

Unfortunately this only happens when running in the context of a test kit, and this feature hasn't been released yet, so to experience this you need to point a test kit to this version of core.

Pick your test kit of choice that uses requirements, let's say davinci-dtr. 

First to confirm the issue. Add this to Gemfile:
```
﻿﻿﻿gem 'inferno_core',
    git: 'https://github.com/inferno-framework/inferno-core.git',
    branch: 'main'
```

And change the .gempec so there's no version pin on inferno_core:
```
  spec.add_dependency 'inferno_core'
```

Run `bundle update` and `bundle exec inferno start`. You should get the error noted above

To confirm the fix, switch the gemfile to point to this branch:
```
gem 'inferno_core',
    git: 'https://github.com/inferno-framework/inferno-core.git',
    branch: 'fi-3600-bugfix'
```


Run `bundle update` and `bundle exec inferno start`. The requirements process should complete without error.