### PR TITLE
Fi 3950 Handle Error message in evaluator CLI when fhirpath service not running is unclear

### DIFF
--- a/lib/inferno/dsl/fhir_evaluation/default.yml
+++ b/lib/inferno/dsl/fhir_evaluation/default.yml
@@ -56,7 +56,7 @@ Rule:
   AllSearchParametersHaveExamples:
     Description: 'Examples cover all search parameters defined in an IG'
     Enabled: true
-  AllIGExtensionsHaveExamples:
+  AllDefinedExtensionsHaveExamples:
     Description: 'All defined extensions are represented in Examples'
     Enabled: true
   AllProfilesHaveExamples:

--- a/lib/inferno/dsl/fhir_evaluation/rules/all_search_parameters_have_examples.rb
+++ b/lib/inferno/dsl/fhir_evaluation/rules/all_search_parameters_have_examples.rb
@@ -78,7 +78,7 @@ module Inferno
             param_used
           end
 
-          def add_message
+          def add_message(message_type, message)
             # No implementation but to prevent error from evaluate_fhirpath().
             # Without this, will throw "undefined method" error since it expects to be called from a Runnable.
           end

--- a/lib/inferno/dsl/fhir_evaluation/rules/all_search_parameters_have_examples.rb
+++ b/lib/inferno/dsl/fhir_evaluation/rules/all_search_parameters_have_examples.rb
@@ -39,20 +39,16 @@ module Inferno
           end
 
           def fhirpath_is_available?(context)
-            begin
-              response = Faraday.new(
-                URI(ENV['FHIRPATH_URL']), request: { timeout: 600 }
-              ).post(
-                "evaluate?path=Bundle", { "resourceType" => "Bundle" }.to_json, content_type: 'application/json'
-              )
-              return true
-            rescue StandardError => e
-              message = "Failed to connect to the FHIRPath server. #{e.message}"
-              result = EvaluationResult.new(message, severity: 'error', rule: self)
-              context.add_result result
-              return false
-            end
-
+            Faraday.new(
+              URI(ENV.fetch('FHIRPATH_URL', nil)), request: { timeout: 600 }
+            ).post(
+              'evaluate?path=Bundle', { 'resourceType' => 'Bundle' }.to_json, content_type: 'application/json'
+            )
+          rescue StandardError => e
+            message = "FHIRPath server: #{e.message}. Skipping rule AllSearchParametersHaveExamples."
+            result = EvaluationResult.new(message, severity: 'error', rule: self)
+            context.add_result result
+            false
           end
 
           def param_is_used?(param, context)
@@ -92,8 +88,7 @@ module Inferno
             param_used
           end
 
-          def add_message()
-          end
+          def add_message; end
         end
       end
     end

--- a/spec/inferno/dsl/fhir_evaluation/rules/all_search_parameters_have_examples_spec.rb
+++ b/spec/inferno/dsl/fhir_evaluation/rules/all_search_parameters_have_examples_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe Inferno::DSL::FHIREvaluation::Rules::AllSearchParametersHaveExamp
     context = Inferno::DSL::FHIREvaluation::EvaluationContext.new(ig, ig.examples,
                                                                   Inferno::DSL::FHIREvaluation::Config.new, nil)
     fhirpath = "#{ENV.fetch('FHIRPATH_URL', nil)}/evaluate?path="
+    stub_request(:post, "#{fhirpath}Bundle").to_return(
+      status: 200, body: '[{"type": "code", "element": "notnull"}]'
+    )
     stub_request(:post, "#{fhirpath}AllergyIntolerance.clinicalStatus").to_return(
       status: 200, body: '[{"type": "code", "element": "notnull"}]'
     )


### PR DESCRIPTION
# Summary

Running the evaluator CLI when the fhirpath service isn't running produces some unexpected error messages in the results. This PR addresses this issue by 
 - The error message should be more clear that the evaluation couldn't be performed because the service isn't running.
 - The AllSearchParametersHaveExamples rule shouldn't run if the fhirpath service isn't available.

# Method

1. Added a method `fhirpath_is_available?` to check if the fhirpath service is available. If not the rule stops.
2. If the service is failed by other reasons, it returns details to be handled by the rule.

# Test

All US Core versions have some failed evaluation due to wrong number of arguments.

Examples:
```
WARNING: SearchParameter http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-onset-date failed to evaluate due to an error. Expression: Condition.onset.as(dateTime). wrong number of arguments (given 2, expected 0)
WARNING: SearchParameter http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-category failed to evaluate due to an error. Expression: DiagnosticReport.category. wrong number of arguments (given 2, expected 0)
WARNING: SearchParameter http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-code failed to evaluate due to an error. Expression: DiagnosticReport.code. wrong number of arguments (given 2, expected 0)
``` 

# Consideration

1. The `fhirpath_is_available?` method tests availability of the service by sending an empty Bundle through POST. If there's a better method than that to just ping the service, it should be considered. Also, the method is currently in the rule. If it is something generally useful, it is better to be located in the fhirpath_evaluator.
2. Currently, if a search parameter is failed to be evaluated for some reason, the rule handles the parameter is being used, which isn't correct.
https://github.com/inferno-framework/inferno-core/blob/0bfeb8dbaed0d532fd49545f3734ba0e19152994/lib/inferno/dsl/fhir_evaluation/rules/all_search_parameters_have_examples.rb#L64
It is tricky since it's neither of yes nor no. It is don't know. In other rules there's another option of "unevaluated". It may be something we can add in this rule too.