### PR TITLE
FI-3939: Add support for requirement sets

### DIFF
--- a/dev_suites/dev_options_suite/options_suite.rb
+++ b/dev_suites/dev_options_suite/options_suite.rb
@@ -157,6 +157,27 @@ module OptionsSuite
                    }
                  ]
 
+    requirement_sets(
+      {
+        identifier: 'sample-criteria-proposal',
+        actor: 'Client',
+        suite_options: {
+          ig_version: '1'
+        }
+      },
+      {
+        identifier: 'sample-criteria-proposal-2',
+        actor: 'Client',
+        suite_options: {
+          ig_version: '2'
+        }
+      },
+      {
+        identifier: 'sample-criteria-proposal-3',
+        actor: 'Client'
+      }
+    )
+
     group from: :all_versions_group
 
     group from: :v1_group,

--- a/dev_suites/dev_requirements/requirements/sample_requirements.csv
+++ b/dev_suites/dev_requirements/requirements/sample_requirements.csv
@@ -6,3 +6,11 @@ sample-criteria-proposal,4,,Consequat mauris nunc congue nisi vitae suscipit tel
 sample-criteria-proposal,5,,condimentum vitae sapien pellentesque habitant morbi tristique senectus,SHALL,Client,sample-criteria-proposal@6,TRUE
 sample-criteria-proposal,6,,Faucibus scelerisque eleifend donec pretium vulputate sapien nec sagittis,SHALL,Client,,TRUE
 sample-criteria-proposal,7,,Nulla facilisi nullam vehicula ipsum a,SHALL,Client,,FALSE
+sample-criteria-proposal-2,1,,text7,SHALL,Client,sample-criteria-proposal-3@2,FALSE
+sample-criteria-proposal-3,1,"https://hl7.org/fhir/R4/",text1,SHALL,Client,"sample-criteria-proposal-3@2-3,4,6",FALSE
+sample-criteria-proposal-3,2,"https://hl7.org/fhir/R4/",text2,SHALL,Client,sample-criteria-proposal-3@3,FALSE
+sample-criteria-proposal-3,3,"https://hl7.org/fhir/R4/",text3,SHALL,Client,sample-criteria-proposal-3@5,FALSE
+sample-criteria-proposal-3,4,,text4,SHALL,Client,sample-criteria-proposal-3@6,FALSE
+sample-criteria-proposal-3,5,,text5,SHALL,Client,sample-criteria-proposal-3@6,TRUE
+sample-criteria-proposal-3,6,,text6,SHALL,Client,,TRUE
+sample-criteria-proposal-3,7,,text7,SHALL,Client,,FALSE

--- a/dev_suites/dev_requirements/requirements_suite.rb
+++ b/dev_suites/dev_requirements/requirements_suite.rb
@@ -7,6 +7,7 @@ module RequirementsSuite
     requirement_sets(
       {
         identifier: 'sample-criteria-proposal',
+        title: 'Sample Criteria Proposal',
         actor: 'Client'
       }
     )

--- a/dev_suites/dev_requirements/requirements_suite.rb
+++ b/dev_suites/dev_requirements/requirements_suite.rb
@@ -4,6 +4,13 @@ module RequirementsSuite
     id :ig_requirements
     description 'Suite Description'
 
+    requirement_sets(
+      {
+        identifier: 'sample-criteria-proposal',
+        actor: 'Client'
+      }
+    )
+
     group do
       title 'Goup 1'
       group do

--- a/lib/inferno/apps/web/controllers/test_suites/requirements/index.rb
+++ b/lib/inferno/apps/web/controllers/test_suites/requirements/index.rb
@@ -16,8 +16,7 @@ module Inferno
                 halt 404, "Test session `#{req.params[:session_id]}` not found" if test_session.nil?
               end
 
-              requirement_ids = test_suite.all_requirements(test_session&.suite_options || [])
-              requirements = repo.filter_requirements_by_ids(requirement_ids)
+              requirements = repo.requirements_for_suite(test_suite.id, test_session&.id)
 
               res.body = serialize(requirements)
             end

--- a/lib/inferno/apps/web/controllers/test_suites/requirements/index.rb
+++ b/lib/inferno/apps/web/controllers/test_suites/requirements/index.rb
@@ -6,6 +6,7 @@ module Inferno
           class Index < Controller
             include Import[test_suites_repo: 'inferno.repositories.test_suites']
             include Import[test_sessions_repo: 'inferno.repositories.test_sessions']
+
             def handle(req, res)
               test_suite = test_suites_repo.find(req.params[:id])
               halt 404, "Test Suite `#{req.params[:id]}` not found" if test_suite.nil?

--- a/lib/inferno/apps/web/serializers/requirement_set.rb
+++ b/lib/inferno/apps/web/serializers/requirement_set.rb
@@ -1,0 +1,13 @@
+require_relative 'serializer'
+
+module Inferno
+  module Web
+    module Serializers
+      class RequirementSet < Serializer
+        identifier :identifier
+
+        field :title
+      end
+    end
+  end
+end

--- a/lib/inferno/apps/web/serializers/test_suite.rb
+++ b/lib/inferno/apps/web/serializers/test_suite.rb
@@ -1,4 +1,5 @@
 require_relative 'preset'
+require_relative 'requirement_set'
 require_relative 'suite_option'
 require_relative 'test_group'
 
@@ -27,6 +28,7 @@ module Inferno
 
         view :full do
           include_view :summary
+
           field :test_groups do |suite, options|
             suite_options = options[:suite_options]
             TestGroup.render_as_hash(suite.groups(suite_options), suite_options:)
@@ -35,6 +37,14 @@ module Inferno
           field :inputs do |suite, options|
             suite_options = options[:suite_options]
             Input.render_as_hash(suite.available_inputs(suite_options).values)
+          end
+          field :requirement_sets, if: :field_present? do |suite, options|
+            selected_options = options[:suite_options] || []
+            requirement_sets = suite.requirement_sets.select do |requirement_set|
+              requirement_set.suite_options.all? { |suite_option| selected_options.include? suite_option }
+            end
+
+            RequirementSet.render_as_hash(requirement_sets)
           end
         end
       end

--- a/lib/inferno/dsl/requirement_set.rb
+++ b/lib/inferno/dsl/requirement_set.rb
@@ -20,11 +20,13 @@ module Inferno
 
         attributes_hash.each do |name, value|
           if name == :suite_options
-            value = value&.map { |option_id, option_value| SuiteOption.new(id: option_id, value: option_value) } || []
+            value = value&.map { |option_id, option_value| SuiteOption.new(id: option_id, value: option_value) }
           end
 
           instance_variable_set(:"@#{name}", value)
         end
+
+        self.suite_options ||= []
       end
 
       def complete?
@@ -32,7 +34,7 @@ module Inferno
       end
 
       def referenced?
-        requirements.casecmp? 'referenced'
+        requirements&.casecmp? 'referenced'
       end
 
       def filtered?
@@ -40,25 +42,7 @@ module Inferno
       end
 
       def expand_requirement_ids
-        return [] if requirements.blank?
-
-        current_set = nil
-        requirements
-          .split(',')
-          .map(&:strip)
-          .flat_map do |requirement_string|
-            current_set, requirement_string = requirement_string.split('@') if requirement_string.include?('@')
-
-            requirement_ids =
-              if requirement_string.include? '-'
-                start_id, end_id = requirement_string.split('-')
-                (start_id..end_id).to_a
-              else
-                [requirement_string]
-              end
-
-            requirement_ids.map { |id| "#{current_set}@#{id}" }
-          end
+        Entities::Requirement.expand_requirement_ids(requirements, identifier)
       end
     end
   end

--- a/lib/inferno/dsl/requirement_set.rb
+++ b/lib/inferno/dsl/requirement_set.rb
@@ -1,0 +1,25 @@
+module Inferno
+  module DSL
+    class RequirementSet
+      ATTRIBUTES = [
+        :requirement_set,
+        :title,
+        :actor,
+        :requirements,
+        :suite_options
+      ]
+
+      include Entities::Attributes
+
+      def initialize(raw_attributes_hash)
+        attributes_hash = raw_attributes_hash.symbolize_keys
+
+        invalid_keys = attributes_hash.keys - ATTRIBUTES
+
+        raise Exceptions::UnknownAttributeException.new(invalid_keys, self.class) if invalid_keys.present?
+
+        attributes_hash.each { |name, value| instance_variable_set(:"@#{name}", value) }
+      end
+    end
+  end
+end

--- a/lib/inferno/dsl/requirement_set.rb
+++ b/lib/inferno/dsl/requirement_set.rb
@@ -1,5 +1,24 @@
 module Inferno
   module DSL
+    # A `RequirementSet` represents the set of requirements which are tested by
+    # a TestSuite.
+    #
+    # @!attribute identifier [rw] The unique identifier for the source of
+    #   requirements included in this `RequirementSet`
+    # @!attribute title [rw] A human-readable title for this `RequirementSet`
+    # @!attribute actor [rw] The actor whose requirements are included in this
+    #   `RequirementSet`
+    # @!attribute requirements [rw] There are three options:
+    #   * `"all"` (default) - Include all of the requirements for the specified
+    #     actor from the requirement source
+    #   * `"referenced"` - Only include requirements from this source if they
+    #     are referenced by other included requirements
+    #   * `"1,3,5-8"` - Only include the requirements from a comma-delimited
+    #     list
+    # @!attribute suite_options [rw] A set of suite options which must be
+    #   selected in order for this `RequirementSet` to be included
+    #
+    # @see Inferno::DSL::SuiteRequirements#requirement_sets
     class RequirementSet
       ATTRIBUTES = [
         :identifier,
@@ -29,18 +48,32 @@ module Inferno
         self.suite_options ||= []
       end
 
+      # Returns true when the `RequirementSet` includes all of the requirements
+      # from the source for the specified actor
+      #
+      # @return [Boolean]
       def complete?
         requirements.blank? || requirements.casecmp?('all')
       end
 
+      # Returns true when the `RequirementSet` only includes requirements
+      # referenced by other `RequirementSet`s
+      #
+      # @return [Boolean]
       def referenced?
         requirements&.casecmp? 'referenced'
       end
 
+      # Returns true when the `RequirementSet` only includes requirements
+      # specified in a list
+      #
+      # @return [Boolean]
       def filtered?
         !complete? && !referenced?
       end
 
+      # Expands the compressed comma-separated requirements list into an Array
+      # of full ids
       def expand_requirement_ids
         Entities::Requirement.expand_requirement_ids(requirements, identifier)
       end

--- a/lib/inferno/dsl/requirement_set.rb
+++ b/lib/inferno/dsl/requirement_set.rb
@@ -2,12 +2,12 @@ module Inferno
   module DSL
     class RequirementSet
       ATTRIBUTES = [
-        :requirement_set,
+        :identifier,
         :title,
         :actor,
         :requirements,
         :suite_options
-      ]
+      ].freeze
 
       include Entities::Attributes
 
@@ -18,7 +18,47 @@ module Inferno
 
         raise Exceptions::UnknownAttributeException.new(invalid_keys, self.class) if invalid_keys.present?
 
-        attributes_hash.each { |name, value| instance_variable_set(:"@#{name}", value) }
+        attributes_hash.each do |name, value|
+          if name == :suite_options
+            value = value&.map { |option_id, option_value| SuiteOption.new(id: option_id, value: option_value) } || []
+          end
+
+          instance_variable_set(:"@#{name}", value)
+        end
+      end
+
+      def complete?
+        requirements.blank? || requirements.casecmp?('all')
+      end
+
+      def referenced?
+        requirements.casecmp? 'referenced'
+      end
+
+      def filtered?
+        !complete? && !referenced?
+      end
+
+      def expand_requirement_ids
+        return [] if requirements.blank?
+
+        current_set = nil
+        requirements
+          .split(',')
+          .map(&:strip)
+          .flat_map do |requirement_string|
+            current_set, requirement_string = requirement_string.split('@') if requirement_string.include?('@')
+
+            requirement_ids =
+              if requirement_string.include? '-'
+                start_id, end_id = requirement_string.split('-')
+                (start_id..end_id).to_a
+              else
+                [requirement_string]
+              end
+
+            requirement_ids.map { |id| "#{current_set}@#{id}" }
+          end
       end
     end
   end

--- a/lib/inferno/dsl/suite_requirements.rb
+++ b/lib/inferno/dsl/suite_requirements.rb
@@ -1,4 +1,4 @@
-require_relative './requirement_set'
+require_relative 'requirement_set'
 
 module Inferno
   module DSL

--- a/lib/inferno/dsl/suite_requirements.rb
+++ b/lib/inferno/dsl/suite_requirements.rb
@@ -12,19 +12,19 @@ module Inferno
       # class Suite < Inferno::TestSuite
       #   requirement_sets(
       #     {
-      #       requirement_set: 'example-regulation-1',
+      #       identifier: 'example-regulation-1',
       #       title: 'Example Regulation 1',
       #       actor: 'Provider' # Only include requirements for the 'Provider'
       #                         # actor
       #     },
       #     {
-      #       requirement_set: 'example-ig-1',
+      #       identifier: 'example-ig-1',
       #       title: 'Example Implementation Guide 1',
       #       actor: 'Provider',
       #       requirements: '2, 4-5' # Only include these specific requirements
       #     },
       #     {
-      #       requirement_set: 'example-ig-2',
+      #       identifier: 'example-ig-2',
       #       title: 'Example Implementation Guide 2',
       #       requirements: 'Referenced', # Only include requirements from this
       #                                   # set that are referenced by other

--- a/lib/inferno/dsl/suite_requirements.rb
+++ b/lib/inferno/dsl/suite_requirements.rb
@@ -1,0 +1,13 @@
+require_relative './requirement_set'
+
+module Inferno
+  module DSL
+    module SuiteRequirements
+      def requirement_sets(*sets)
+        @requirement_sets = sets.map { |set| RequirementSet.new(**set) } if sets.present?
+
+        @requirement_sets || []
+      end
+    end
+  end
+end

--- a/lib/inferno/dsl/suite_requirements.rb
+++ b/lib/inferno/dsl/suite_requirements.rb
@@ -3,6 +3,39 @@ require_relative 'requirement_set'
 module Inferno
   module DSL
     module SuiteRequirements
+      # Get/Set the sets of requirments tested by a suite.
+      #
+      # @param sets [Array<Inferno::DSL::RequirementSet>]
+      # @return [Array<Inferno::DSL::RequirementSet>]
+      #
+      # @example
+      # class Suite < Inferno::TestSuite
+      #   requirement_sets(
+      #     {
+      #       requirement_set: 'example-regulation-1',
+      #       title: 'Example Regulation 1',
+      #       actor: 'Provider' # Only include requirements for the 'Provider'
+      #                         # actor
+      #     },
+      #     {
+      #       requirement_set: 'example-ig-1',
+      #       title: 'Example Implementation Guide 1',
+      #       actor: 'Provider',
+      #       requirements: '2, 4-5' # Only include these specific requirements
+      #     },
+      #     {
+      #       requirement_set: 'example-ig-2',
+      #       title: 'Example Implementation Guide 2',
+      #       requirements: 'Referenced', # Only include requirements from this
+      #                                   # set that are referenced by other
+      #                                   # included requirements
+      #       actor: 'Server',
+      #       suite_options: {      # Only include these requirements if the ig
+      #         ig_version: '3.0.0' # version 3.0.0 suite option is selected
+      #       }
+      #     }
+      #   )
+      # end
       def requirement_sets(*sets)
         @requirement_sets = sets.map { |set| RequirementSet.new(**set) } if sets.present?
 

--- a/lib/inferno/entities/requirement.rb
+++ b/lib/inferno/entities/requirement.rb
@@ -24,11 +24,11 @@ module Inferno
         self.requirement_set = id.split('@').first if requirement_set.blank? && id&.include?('@')
       end
 
-      def expand_sub_requirements
-        return [] if sub_requirements.blank?
+      def self.expand_requirement_ids(requirement_id_string, default_set = nil)
+        return [] if requirement_id_string.blank?
 
-        current_set = nil
-        sub_requirements
+        current_set = default_set
+        requirement_id_string
           .split(',')
           .map(&:strip)
           .flat_map do |requirement_string|

--- a/lib/inferno/entities/requirement.rb
+++ b/lib/inferno/entities/requirement.rb
@@ -34,9 +34,9 @@ module Inferno
       #
       # @example
       # expand_requirement_ids('example-ig@1,3,5-7')
-      # # -> ['example-ig@1','example-ig@3','example-ig@5','example-ig@6','example-ig@7']
+      # # => ['example-ig@1','example-ig@3','example-ig@5','example-ig@6','example-ig@7']
       # expand_requirement_ids('1,3,5-7', 'example-ig')
-      # # -> ['example-ig@1','example-ig@3','example-ig@5','example-ig@6','example-ig@7']
+      # # => ['example-ig@1','example-ig@3','example-ig@5','example-ig@6','example-ig@7']
       def self.expand_requirement_ids(requirement_id_string, default_set = nil)
         return [] if requirement_id_string.blank?
 

--- a/lib/inferno/entities/requirement.rb
+++ b/lib/inferno/entities/requirement.rb
@@ -24,6 +24,19 @@ module Inferno
         self.requirement_set = id.split('@').first if requirement_set.blank? && id&.include?('@')
       end
 
+      # Expand a comma-delimited list of requirement id references into an Array
+      # of full requirement ids
+      #
+      # @param requirement_id_string [String] A comma-delimited list of
+      #   requirement id references
+      # @param default_set [String] The requirement set identifier which will be
+      #   used if none is included in the `requirement_id_string`
+      #
+      # @example
+      # expand_requirement_ids('example-ig@1,3,5-7')
+      # # -> ['example-ig@1','example-ig@3','example-ig@5','example-ig@6','example-ig@7']
+      # expand_requirement_ids('1,3,5-7', 'example-ig')
+      # # -> ['example-ig@1','example-ig@3','example-ig@5','example-ig@6','example-ig@7']
       def self.expand_requirement_ids(requirement_id_string, default_set = nil)
         return [] if requirement_id_string.blank?
 

--- a/lib/inferno/entities/requirement.rb
+++ b/lib/inferno/entities/requirement.rb
@@ -7,6 +7,7 @@ module Inferno
     class Requirement < Entity
       ATTRIBUTES = [
         :id,
+        :requirement_set,
         :url,
         :requirement,
         :conformance,
@@ -19,6 +20,30 @@ module Inferno
 
       def initialize(params)
         super(params, ATTRIBUTES)
+
+        self.requirement_set = id.split('@').first if requirement_set.blank? && id&.include?('@')
+      end
+
+      def expand_sub_requirements
+        return [] if sub_requirements.blank?
+
+        current_set = nil
+        sub_requirements
+          .split(',')
+          .map(&:strip)
+          .flat_map do |requirement_string|
+            current_set, requirement_string = requirement_string.split('@') if requirement_string.include?('@')
+
+            requirement_ids =
+              if requirement_string.include? '-'
+                start_id, end_id = requirement_string.split('-')
+                (start_id..end_id).to_a
+              else
+                [requirement_string]
+              end
+
+            requirement_ids.map { |id| "#{current_set}@#{id}" }
+          end
       end
     end
   end

--- a/lib/inferno/entities/test_suite.rb
+++ b/lib/inferno/entities/test_suite.rb
@@ -1,6 +1,7 @@
 require_relative 'test_group'
 require_relative '../dsl/runnable'
 require_relative '../dsl/suite_option'
+require_relative '../dsl/suite_requirements'
 require_relative '../dsl/messages'
 require_relative '../dsl/links'
 require_relative '../repositories/test_groups'
@@ -16,6 +17,7 @@ module Inferno
       extend DSL::Links
       extend DSL::FHIRClient::ClassMethods
       extend DSL::HTTPClient::ClassMethods
+      extend DSL::SuiteRequirements
       include DSL::FHIRValidation
       include DSL::FHIRResourceValidation
       include DSL::FhirpathEvaluation

--- a/lib/inferno/repositories/requirements.rb
+++ b/lib/inferno/repositories/requirements.rb
@@ -6,7 +6,7 @@ module Inferno
   module Repositories
     # Repository that deals with persistence for the `Requirement` entity.
     class Requirements < InMemoryRepository
-      def insert_from_file(path) # rubocop:disable Metrics/CyclomaticComplexity
+      def insert_from_file(path)
         result = []
 
         CSV.foreach(path, headers: true, header_converters: :symbol) do |row|
@@ -17,21 +17,10 @@ module Inferno
           combined_id = "#{req_set}@#{id}"
 
           # Processing sub requirements: e.g. "170.315(g)(31)_hti-2-proposal@5,17,23,26,27,32,35,38-41"
-          sub_requirements = if sub_requirements_field.nil? || sub_requirements_field.blank?
-                               []
-                             else
-                               base, ids = sub_requirements_field.split('@')
-                               ids.split(',').flat_map do |item|
-                                 if item.include?('-')
-                                   start_range, end_range = item.split('-').map(&:to_i)
-                                   (start_range..end_range).map { |num| "#{base}@#{num}" }
-                                 else
-                                   "#{base}@#{item}"
-                                 end
-                               end
-                             end
+          sub_requirements = Inferno::Entities::Requirement.expand_requirement_ids(sub_requirements_field)
 
           result << {
+            requirement_set: req_set,
             id: combined_id,
             url: row[:url],
             requirement: row[:requirement],
@@ -51,6 +40,76 @@ module Inferno
 
       def filter_requirements_by_ids(ids)
         all.select { |requirement| ids.include?(requirement.id) }
+      end
+
+      def requirements_for_suite(test_suite_id, test_session_id = nil)
+        test_suite = Inferno::Repositories::TestSuites.new.find(test_suite_id)
+        selected_suite_options =
+          if test_session_id.present?
+            Inferno::Repositories::TestSessions.new.find(test_session_id).suite_options
+          else
+            []
+          end
+
+        requirement_sets =
+          test_suite
+            .requirement_sets
+            .select do |set|
+              set.suite_options.all? { |set_option| selected_suite_options.include? set_option }
+            end
+
+        requirements =
+          complete_requirement_set_requirements(requirement_sets) +
+          filtered_requirement_set_requirements(requirement_sets)
+
+        add_referenced_requirement_set_requirements(requirements, requirement_sets).uniq
+      end
+
+      def complete_requirement_set_requirements(requirement_sets)
+        requirement_sets.select(&:complete?)
+          .flat_map do |requirement_set|
+            all.select do |requirement|
+              requirement.requirement_set == requirement_set.identifier && requirement.actor == requirement_set.actor
+            end
+          end
+      end
+
+      def filtered_requirement_set_requirements(requirement_sets)
+        requirement_sets.select(&:filtered?)
+          .flat_map do |requirement_set|
+            requirement_set
+              .expand_requirement_ids
+              .map { |requirement_id| find(requirement_id) }
+              .select { |requirement| requirement.actor == requirement_set.actor }
+          end
+      end
+
+      def add_referenced_requirement_set_requirements( # rubocop:disable Metrics/CyclomaticComplexity
+        requirements_to_process,
+        requirement_sets,
+        processed_requirements = []
+      )
+        return processed_requirements if requirements_to_process.blank?
+
+        referenced_requirement_sets = requirement_sets.select(&:referenced?)
+
+        referenced_requirement_ids =
+          requirements_to_process
+            .flat_map(&:sub_requirements)
+            .select do |requirement_id|
+              referenced_requirement_sets.any? do |set|
+                requirement_id.start_with?("#{set.identifier}@") && (find(requirement_id).actor == set.actor)
+              end
+            end
+
+        new_requirements =
+          referenced_requirement_ids.map { |id| find(id) } - requirements_to_process - processed_requirements
+
+        add_referenced_requirement_set_requirements(
+          new_requirements,
+          referenced_requirement_sets,
+          (processed_requirements + requirements_to_process).uniq
+        )
       end
     end
   end

--- a/spec/inferno/dsl/requirement_set_spec.rb
+++ b/spec/inferno/dsl/requirement_set_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe Inferno::DSL::RequirementSet do
+  describe '#expand_requirement_ids' do
+    it 'returns an empty array if the requirements are blank' do
+      expect(described_class.new({}).expand_requirement_ids).to eq([])
+    end
+
+    it 'returns full ids unchanged' do
+      ids = ['criteria3@1', 'criteria4@2']
+
+      expect(described_class.new(requirements: ids.join(',')).expand_requirement_ids).to eq(ids)
+    end
+
+    it 'expands id ranges' do
+      ids = ['criteria3@1-3', 'criteria4@2']
+      expected_ids = [
+        'criteria3@1',
+        'criteria3@2',
+        'criteria3@3',
+        'criteria4@2'
+      ]
+
+      expect(described_class.new(requirements: ids.join(',')).expand_requirement_ids).to eq(expected_ids)
+    end
+
+    it 'adds the requirement set when missing' do
+      ids = ['criteria3@1', '2', '3', 'criteria4@2', '3']
+      expected_ids = [
+        'criteria3@1',
+        'criteria3@2',
+        'criteria3@3',
+        'criteria4@2',
+        'criteria4@3'
+      ]
+
+      expect(described_class.new(requirements: ids.join(',')).expand_requirement_ids).to eq(expected_ids)
+    end
+  end
+end

--- a/spec/inferno/entities/requirement_spec.rb
+++ b/spec/inferno/entities/requirement_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe Inferno::Entities::Requirement do
+  describe '#expand_sub_requirements' do
+    it 'returns an empty array of there are no sub_requirements' do
+      expect(described_class.new({}).expand_sub_requirements).to eq([])
+    end
+
+    it 'returns full ids unchanged' do
+      ids = ['criteria3@1', 'criteria4@2']
+
+      expect(described_class.new(sub_requirements: ids.join(',')).expand_sub_requirements).to eq(ids)
+    end
+
+    it 'expands id ranges' do
+      ids = ['criteria3@1-3', 'criteria4@2']
+      expected_ids = [
+        'criteria3@1',
+        'criteria3@2',
+        'criteria3@3',
+        'criteria4@2'
+      ]
+
+      expect(described_class.new(sub_requirements: ids.join(',')).expand_sub_requirements).to eq(expected_ids)
+    end
+
+    it 'adds the requirement set when missing' do
+      ids = ['criteria3@1', '2', '3', 'criteria4@2', '3']
+      expected_ids = [
+        'criteria3@1',
+        'criteria3@2',
+        'criteria3@3',
+        'criteria4@2',
+        'criteria4@3'
+      ]
+
+      expect(described_class.new(sub_requirements: ids.join(',')).expand_sub_requirements).to eq(expected_ids)
+    end
+  end
+end

--- a/spec/inferno/entities/requirement_spec.rb
+++ b/spec/inferno/entities/requirement_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Inferno::Entities::Requirement do
-  describe 'cexpand_requirement_ids' do
+  describe '.expand_requirement_ids' do
     it 'returns an empty array of there are no sub_requirements' do
       expect(described_class.expand_requirement_ids(nil)).to eq([])
     end

--- a/spec/inferno/entities/requirement_spec.rb
+++ b/spec/inferno/entities/requirement_spec.rb
@@ -1,13 +1,13 @@
 RSpec.describe Inferno::Entities::Requirement do
-  describe '#expand_sub_requirements' do
+  describe 'cexpand_requirement_ids' do
     it 'returns an empty array of there are no sub_requirements' do
-      expect(described_class.new({}).expand_sub_requirements).to eq([])
+      expect(described_class.expand_requirement_ids(nil)).to eq([])
     end
 
     it 'returns full ids unchanged' do
       ids = ['criteria3@1', 'criteria4@2']
 
-      expect(described_class.new(sub_requirements: ids.join(',')).expand_sub_requirements).to eq(ids)
+      expect(described_class.expand_requirement_ids(ids.join(','))).to eq(ids)
     end
 
     it 'expands id ranges' do
@@ -19,7 +19,7 @@ RSpec.describe Inferno::Entities::Requirement do
         'criteria4@2'
       ]
 
-      expect(described_class.new(sub_requirements: ids.join(',')).expand_sub_requirements).to eq(expected_ids)
+      expect(described_class.expand_requirement_ids(ids.join(','))).to eq(expected_ids)
     end
 
     it 'adds the requirement set when missing' do
@@ -32,7 +32,7 @@ RSpec.describe Inferno::Entities::Requirement do
         'criteria4@3'
       ]
 
-      expect(described_class.new(sub_requirements: ids.join(',')).expand_sub_requirements).to eq(expected_ids)
+      expect(described_class.expand_requirement_ids(ids.join(','))).to eq(expected_ids)
     end
   end
 end

--- a/spec/inferno/repositories/requirements_spec.rb
+++ b/spec/inferno/repositories/requirements_spec.rb
@@ -1,5 +1,34 @@
 RSpec.describe Inferno::Repositories::Requirements do
-  subject(:requirements) { described_class.new }
+  subject(:repo) { described_class.new }
+
+  let(:suite) { RequirementsSuite::Suite }
+  let(:complete_requirement_set) { suite.requirement_sets.first }
+  let(:empty_requirement_set) do
+    Inferno::DSL::RequirementSet.new(
+      identifier: 'sample-criteria-proposal',
+      actor: 'Server'
+    )
+  end
+  let(:filtered_requriment_set) do
+    Inferno::DSL::RequirementSet.new(
+      identifier: 'sample-criteria-proposal',
+      actor: 'Client',
+      requirements: '1, 3, 4-6'
+    )
+  end
+  let(:referenced_requirement_sets) do
+    [
+      Inferno::DSL::RequirementSet.new(
+        identifier: 'sample-criteria-proposal-2',
+        actor: 'Client'
+      ),
+      Inferno::DSL::RequirementSet.new(
+        identifier: 'sample-criteria-proposal-3',
+        actor: 'Client',
+        requirements: 'Referenced'
+      )
+    ]
+  end
 
   describe '#insert_from_file' do
     let(:csv) do
@@ -33,9 +62,66 @@ RSpec.describe Inferno::Repositories::Requirements do
     end
 
     it 'creates and inserts all requirements from the csv file' do
-      expect { requirements.insert_from_file(csv) }.to change { requirements.all.size }.by(2)
-      expect(requirements.find(req_one.id).to_hash).to eq(req_one.to_hash)
-      expect(requirements.find(req2.id).to_hash).to eq(req2.to_hash)
+      expect { repo.insert_from_file(csv) }.to change { repo.all.size }.by(2)
+      expect(repo.find(req_one.id).to_hash).to eq(req_one.to_hash)
+      expect(repo.find(req2.id).to_hash).to eq(req2.to_hash)
+    end
+  end
+
+  describe '#complete_requirement_set_requirements' do
+    it 'returns all requirements matching the specified actor' do
+      expect(repo.complete_requirement_set_requirements([complete_requirement_set]).length).to eq(7)
+      expect(repo.complete_requirement_set_requirements([empty_requirement_set]).length).to eq(0)
+    end
+  end
+
+  describe '#filtered_requirement_set_requirements' do
+    it 'returns the specified requirements matching the specified actor' do
+      expected_ids = [
+        'sample-criteria-proposal@1',
+        'sample-criteria-proposal@3',
+        'sample-criteria-proposal@4',
+        'sample-criteria-proposal@5',
+        'sample-criteria-proposal@6'
+      ]
+      found_ids = repo.filtered_requirement_set_requirements([filtered_requriment_set]).map(&:id)
+
+      expect(found_ids).to match_array(expected_ids)
+    end
+  end
+
+  describe '#add_referenced_requirement_set_requirements' do
+    it 'recursively returns referenced requirements matching the specified actor' do
+      expected_ids = [
+        'sample-criteria-proposal-2@1',
+        'sample-criteria-proposal-3@2',
+        'sample-criteria-proposal-3@3',
+        'sample-criteria-proposal-3@5',
+        'sample-criteria-proposal-3@6'
+      ]
+
+      requirements = repo.complete_requirement_set_requirements([referenced_requirement_sets.first])
+      found_ids = repo.add_referenced_requirement_set_requirements(requirements, referenced_requirement_sets).map(&:id)
+      expect(found_ids).to match_array(expected_ids)
+    end
+  end
+
+  describe '#requirements_for_suite' do
+    let(:session) do
+      repo_create(
+        :test_session,
+        suite: 'options',
+        suite_options: [Inferno::DSL::SuiteOption.new(id: :ig_version, value: '1')]
+      )
+    end
+
+    it 'only includes requirements for selected suite options' do
+      requirements = repo.requirements_for_suite('options', session.id)
+
+      included_requirement_sets = requirements.map(&:requirement_set)
+
+      expect(included_requirement_sets).to include('sample-criteria-proposal', 'sample-criteria-proposal-3')
+      expect(included_requirement_sets).to_not include('sample-criteria-proposal-2')
     end
   end
 end

--- a/spec/inferno/repositories/requirements_spec.rb
+++ b/spec/inferno/repositories/requirements_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Inferno::Repositories::Requirements do
         {
           id: 'sample-criteria@1',
           requirement: 'requirement',
+          requirement_set: 'sample-criteria',
           conformance: 'SHALL',
           actor: 'Client',
           sub_requirements: ['sample-criteria@2'],
@@ -22,6 +23,7 @@ RSpec.describe Inferno::Repositories::Requirements do
         {
           id: 'sample-criteria@2',
           requirement: 'requirement',
+          requirement_set: 'sample-criteria',
           conformance: 'SHALL',
           actor: 'Client',
           sub_requirements: [],

--- a/spec/inferno/web/serializers/test_suite_spec.rb
+++ b/spec/inferno/web/serializers/test_suite_spec.rb
@@ -87,5 +87,16 @@ RSpec.describe Inferno::Web::Serializers::TestSuite do
 
     expect(received_groups).to eq(expected_groups)
     expect(serialized_suite['test_count']).to eq(3)
+    expect(serialized_suite['requirement_sets'].length).to eq(2)
+  end
+
+  it 'serializes using selected options to filter requirement_sets' do
+    options_suite = OptionsSuite::Suite
+    options = [Inferno::DSL::SuiteOption.new(id: :ig_version, value: '1')]
+    serialized_suite = JSON.parse(described_class.render(options_suite,
+                                                         view: :full,
+                                                         suite_options: options))
+
+    expect(serialized_suite['requirement_sets'].length).to eq(2)
   end
 end

--- a/spec/requests/test_suites_spec.rb
+++ b/spec/requests/test_suites_spec.rb
@@ -54,6 +54,22 @@ RSpec.describe '/test_suites' do
         expect(last_response.status).to eq(404)
       end
     end
+
+    context 'when the test_suite has requirement sets' do
+      let(:test_suite_id) { 'ig_requirements' }
+
+      it 'includes the requirement sets' do
+        get router.path(:api_test_suites_show, id: test_suite_id)
+        expect(last_response.status).to eq(200)
+
+        received_sets = parsed_body['requirement_sets']
+
+        expect(received_sets).to be_present
+        expect(received_sets.length).to eq(1)
+        expect(received_sets.first['identifier']).to be_present
+        expect(received_sets.first['title']).to be_present
+      end
+    end
   end
 
   describe 'check_configuration' do


### PR DESCRIPTION
# Summary
This branch adds support for declaring which sets of requirements a suite tests. This will form the foundation for upcoming requirements UI work.

# Testing Guidance
Requirement sets should be visible in the console or in API responses for the dev suites which have been updated to use them.