### PR TITLE
FI-4047: Improve Requirement ID Expansion

### DIFF
--- a/lib/inferno/entities/requirement.rb
+++ b/lib/inferno/entities/requirement.rb
@@ -39,7 +39,7 @@ module Inferno
       # # => []
       # expand_requirement_ids('1,3,5-7', 'example-ig')
       # # => ['example-ig@1','example-ig@3','example-ig@5','example-ig@6','example-ig@7']
-      def self.expand_requirement_ids(requirement_id_string, default_set = nil)
+      def self.expand_requirement_ids(requirement_id_string, default_set = nil) # rubocop:disable Metrics/CyclomaticComplexity
         return [] if requirement_id_string.blank?
 
         current_set = default_set

--- a/lib/inferno/entities/requirement.rb
+++ b/lib/inferno/entities/requirement.rb
@@ -35,6 +35,8 @@ module Inferno
       # @example
       # expand_requirement_ids('example-ig@1,3,5-7')
       # # => ['example-ig@1','example-ig@3','example-ig@5','example-ig@6','example-ig@7']
+      # expand_requirement_ids('example-ig')
+      # # => []
       # expand_requirement_ids('1,3,5-7', 'example-ig')
       # # => ['example-ig@1','example-ig@3','example-ig@5','example-ig@6','example-ig@7']
       def self.expand_requirement_ids(requirement_id_string, default_set = nil)
@@ -50,7 +52,11 @@ module Inferno
             requirement_ids =
               if requirement_string.include? '-'
                 start_id, end_id = requirement_string.split('-')
-                (start_id..end_id).to_a
+                if start_id.match?(/^\d+$/) && end_id.match?(/^\d+$/)
+                  (start_id..end_id).to_a
+                else
+                  []
+                end
               else
                 [requirement_string]
               end

--- a/lib/inferno/repositories/requirements.rb
+++ b/lib/inferno/repositories/requirements.rb
@@ -33,7 +33,6 @@ module Inferno
 
         result.each do |raw_req|
           requirement = Entities::Requirement.new(raw_req)
-          next if exists?(requirement.id)
 
           insert(requirement)
         end

--- a/lib/inferno/repositories/requirements.rb
+++ b/lib/inferno/repositories/requirements.rb
@@ -33,6 +33,7 @@ module Inferno
 
         result.each do |raw_req|
           requirement = Entities::Requirement.new(raw_req)
+          next if exists?(requirement.id)
 
           insert(requirement)
         end

--- a/spec/inferno/entities/requirement_spec.rb
+++ b/spec/inferno/entities/requirement_spec.rb
@@ -34,5 +34,11 @@ RSpec.describe Inferno::Entities::Requirement do
 
       expect(described_class.expand_requirement_ids(ids.join(','))).to eq(expected_ids)
     end
+
+    it 'ignores invalid non-numeric range boundaries' do
+      ids = ['criteria3@a-b', 'criteria4@2', 'example-ig']
+      expected_ids = ['criteria4@2']
+      expect(described_class.expand_requirement_ids(ids.join(','))).to eq(expected_ids)
+    end
   end
 end


### PR DESCRIPTION
# Summary
- Fixes a bug in `expand_requirement_ids` where non-numeric range inputs (e.g., cds-hooks_2.0) would raise an exception.

# Testing Guidance

#### g35
1. Checkout the `fi-4047-demo` branch.
2. Run `bundle install`, then start Inferno. It should should exit with duplicate requirement ID error
3. Now, point `inferno_core` to the `main` branch, run `bundle install`, and restart Inferno. It will hang and fail to start.


