### PR TITLE
FI-4106: Handle not tested requirements

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -92,6 +92,9 @@ RSpec/DescribeClass:
 RSpec/ExampleLength:
   Enabled: false
 
+RSpec/IndexedLet:
+  Enabled: false
+
 RSpec/SkipBlockInsideExample:
   Enabled: false
 

--- a/dev_suites/dev_requirements/requirements/sample_requirements.csv
+++ b/dev_suites/dev_requirements/requirements/sample_requirements.csv
@@ -1,16 +1,19 @@
-﻿Req Set,ID,URL,Requirement,Conformance,Actor,Sub-Requirement(s),Conditionality
-sample-criteria-proposal,1,"https://hl7.org/fhir/R4/",Feugiat in ante metus dictum. Dignissim cras tincidunt lobortis feugiat.,SHALL,Client,"sample-criteria-proposal@2-3,4,6",FALSE
-sample-criteria-proposal,2,"https://hl7.org/fhir/R4/",tempor incididunt ut labore et dolore magna aliqua,SHALL,Client,sample-criteria-proposal@3,FALSE
-sample-criteria-proposal,3,"https://hl7.org/fhir/R4/","Lorem ipsum dolor sit amet, consectetur adipiscing elit",SHALL,Client,sample-criteria-proposal@5,FALSE
-sample-criteria-proposal,4,,Consequat mauris nunc congue nisi vitae suscipit tellus mauris.,SHALL,Client,sample-criteria-proposal@6,FALSE
-sample-criteria-proposal,5,,condimentum vitae sapien pellentesque habitant morbi tristique senectus,SHALL,Client,sample-criteria-proposal@6,TRUE
-sample-criteria-proposal,6,,Faucibus scelerisque eleifend donec pretium vulputate sapien nec sagittis,SHALL,Client,,TRUE
-sample-criteria-proposal,7,,Nulla facilisi nullam vehicula ipsum a,SHALL,Client,,FALSE
-sample-criteria-proposal-2,1,,text7,SHALL,Client,sample-criteria-proposal-3@2,FALSE
-sample-criteria-proposal-3,1,"https://hl7.org/fhir/R4/",text1,SHALL,Client,"sample-criteria-proposal-3@2-3,4,6",FALSE
-sample-criteria-proposal-3,2,"https://hl7.org/fhir/R4/",text2,SHALL,Client,sample-criteria-proposal-3@3,FALSE
-sample-criteria-proposal-3,3,"https://hl7.org/fhir/R4/",text3,SHALL,Client,sample-criteria-proposal-3@5,FALSE
-sample-criteria-proposal-3,4,,text4,SHALL,Client,sample-criteria-proposal-3@6,FALSE
-sample-criteria-proposal-3,5,,text5,SHALL,Client,sample-criteria-proposal-3@6,TRUE
-sample-criteria-proposal-3,6,,text6,SHALL,Client,,TRUE
-sample-criteria-proposal-3,7,,text7,SHALL,Client,,FALSE
+﻿Req Set,ID,URL,Requirement,Conformance,Actor,Sub-Requirement(s),Conditionality,Not Tested Reason,Not Tested Details
+sample-criteria-proposal,1,"https://hl7.org/fhir/R4/",Feugiat in ante metus dictum. Dignissim cras tincidunt lobortis feugiat.,SHALL,Client,"sample-criteria-proposal@2-3,4,6",FALSE,,
+sample-criteria-proposal,2,"https://hl7.org/fhir/R4/",tempor incididunt ut labore et dolore magna aliqua,SHALL,Client,sample-criteria-proposal@3,FALSE,,
+sample-criteria-proposal,3,"https://hl7.org/fhir/R4/","Lorem ipsum dolor sit amet, consectetur adipiscing elit",SHALL,Client,sample-criteria-proposal@5,FALSE,,
+sample-criteria-proposal,4,,Consequat mauris nunc congue nisi vitae suscipit tellus mauris.,SHALL,Client,sample-criteria-proposal@6,FALSE,,
+sample-criteria-proposal,5,,condimentum vitae sapien pellentesque habitant morbi tristique senectus,SHALL,Client,sample-criteria-proposal@6,TRUE,,
+sample-criteria-proposal,6,,Faucibus scelerisque eleifend donec pretium vulputate sapien nec sagittis,SHALL,Client,,TRUE,,
+sample-criteria-proposal,7,,Nulla facilisi nullam vehicula ipsum a,SHALL,Client,,FALSE,,
+sample-criteria-proposal-2,1,,text7,SHALL,Client,sample-criteria-proposal-3@2,FALSE,,
+sample-criteria-proposal-3,1,"https://hl7.org/fhir/R4/",text1,SHALL,Client,"sample-criteria-proposal-3@2-3,4,6",FALSE,,
+sample-criteria-proposal-3,2,"https://hl7.org/fhir/R4/",text2,SHALL,Client,sample-criteria-proposal-3@3,FALSE,,
+sample-criteria-proposal-3,3,"https://hl7.org/fhir/R4/",text3,SHALL,Client,sample-criteria-proposal-3@5,FALSE,,
+sample-criteria-proposal-3,4,,text4,SHALL,Client,sample-criteria-proposal-3@6,FALSE,,
+sample-criteria-proposal-3,5,,text5,SHALL,Client,sample-criteria-proposal-3@6,TRUE,,
+sample-criteria-proposal-3,6,,text6,SHALL,Client,,TRUE,,
+sample-criteria-proposal-3,7,,text7,SHALL,Client,,FALSE,,
+sample-criteria-proposal-4,1,,text1,SHALL,Client,,FALSE,Not Tested,NOT TESTED DETAILS
+sample-criteria-proposal-4,2,,text2,SHALL,Client,,FALSE,Not Verifiable,NOT VERIFIABLE DETAILS
+sample-criteria-proposal-4,3,,text3,SHALL,Client,,FALSE,,

--- a/lib/inferno/entities/requirement.rb
+++ b/lib/inferno/entities/requirement.rb
@@ -13,7 +13,9 @@ module Inferno
         :conformance,
         :actor,
         :sub_requirements,
-        :conditionality
+        :conditionality,
+        :not_tested_reason,
+        :not_tested_details
       ].freeze
 
       include Inferno::Entities::Attributes
@@ -63,6 +65,10 @@ module Inferno
 
             requirement_ids.map { |id| "#{current_set}@#{id}" }
           end
+      end
+
+      def tested?
+        not_tested_reason.blank?
       end
     end
   end

--- a/lib/inferno/repositories/requirements.rb
+++ b/lib/inferno/repositories/requirements.rb
@@ -27,7 +27,9 @@ module Inferno
             conformance: row[:conformance],
             actor: row[:actor],
             sub_requirements: sub_requirements,
-            conditionality: row[:conditionality]&.downcase
+            conditionality: row[:conditionality]&.downcase,
+            not_tested_reason: row[:not_tested_reason],
+            not_tested_details: row[:not_tested_details]
           }
         end
 
@@ -69,7 +71,9 @@ module Inferno
         requirement_sets.select(&:complete?)
           .flat_map do |requirement_set|
             all.select do |requirement|
-              requirement.requirement_set == requirement_set.identifier && requirement.actor == requirement_set.actor
+              requirement.requirement_set == requirement_set.identifier &&
+                requirement.actor == requirement_set.actor &&
+                requirement.tested?
             end
           end
       end

--- a/spec/fixtures/simple_requirements.csv
+++ b/spec/fixtures/simple_requirements.csv
@@ -1,3 +1,4 @@
-﻿Req Set,ID,URL,Requirement,Conformance,Actor,Sub-Requirement(s),Conditionality
-sample-criteria,1,,requirement,SHALL,Client,sample-criteria@2,FALSE
-sample-criteria,2,,requirement,SHALL,Client,,FALSE
+﻿Req Set,ID,URL,Requirement,Conformance,Actor,Sub-Requirement(s),Conditionality,Not Tested Reason,Not Tested Details
+sample-criteria,1,,requirement,SHALL,Client,sample-criteria@2,FALSE,,
+sample-criteria,2,,requirement,SHALL,Client,,FALSE,,
+sample-criteria,3,,requirement,SHALL,Client,,FALSE,Not Tested,NOT TESTED DETAILS

--- a/spec/inferno/cli/requirements_exporter_spec.rb
+++ b/spec/inferno/cli/requirements_exporter_spec.rb
@@ -46,18 +46,4 @@ RSpec.describe Inferno::CLI::RequirementsExporter do
       expect(parsed_csv.length).to eq(exporter.input_requirement_sets.values.first.length + 1)
     end
   end
-
-  describe '#new_planned_not_tested_csv' do
-    it 'generates a CSV with the correct columns' do
-      csv = exporter.new_planned_not_tested_csv
-
-      parsed_csv = CSV.parse(csv)
-
-      # The added BOM makes the first column header not match
-      expect(parsed_csv.first.first).to_not eq(described_class::PLANNED_NOT_TESTED_OUTPUT_HEADERS.first)
-      expect(parsed_csv.first.slice(1..-1)).to eq(described_class::PLANNED_NOT_TESTED_OUTPUT_HEADERS.slice(1..-1))
-
-      expect(parsed_csv.length).to eq(3)
-    end
-  end
 end

--- a/spec/inferno/repositories/requirements_spec.rb
+++ b/spec/inferno/repositories/requirements_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe Inferno::Repositories::Requirements do
       actor: 'Server'
     )
   end
+  let(:not_tested_requirement_set) do
+    Inferno::DSL::RequirementSet.new(
+      identifier: 'sample-criteria-proposal-4',
+      actor: 'Client'
+    )
+  end
   let(:filtered_requriment_set) do
     Inferno::DSL::RequirementSet.new(
       identifier: 'sample-criteria-proposal',
@@ -34,7 +40,7 @@ RSpec.describe Inferno::Repositories::Requirements do
     let(:csv) do
       File.realpath(File.join(Dir.pwd, 'spec/fixtures/simple_requirements.csv'))
     end
-    let(:req_one) do
+    let(:req1) do
       Inferno::Entities::Requirement.new(
         {
           id: 'sample-criteria@1',
@@ -60,18 +66,38 @@ RSpec.describe Inferno::Repositories::Requirements do
         }
       )
     end
+    let(:req3) do
+      Inferno::Entities::Requirement.new(
+        {
+          id: 'sample-criteria@3',
+          requirement: 'requirement',
+          requirement_set: 'sample-criteria',
+          conformance: 'SHALL',
+          actor: 'Client',
+          sub_requirements: [],
+          conditionality: 'false',
+          not_tested_reason: 'Not Tested',
+          not_tested_details: 'NOT TESTED DETAILS'
+        }
+      )
+    end
 
     it 'creates and inserts all requirements from the csv file' do
-      expect { repo.insert_from_file(csv) }.to change { repo.all.size }.by(2)
-      expect(repo.find(req_one.id).to_hash).to eq(req_one.to_hash)
+      expect { repo.insert_from_file(csv) }.to change { repo.all.size }.by(3)
+      expect(repo.find(req1.id).to_hash).to eq(req1.to_hash)
       expect(repo.find(req2.id).to_hash).to eq(req2.to_hash)
+      expect(repo.find(req3.id).to_hash).to eq(req3.to_hash)
     end
   end
 
   describe '#complete_requirement_set_requirements' do
-    it 'returns all requirements matching the specified actor' do
+    it 'returns all tested requirements matching the specified actor' do
       expect(repo.complete_requirement_set_requirements([complete_requirement_set]).length).to eq(7)
       expect(repo.complete_requirement_set_requirements([empty_requirement_set]).length).to eq(0)
+    end
+
+    it 'excludes not-tested requirements' do
+      expect(repo.complete_requirement_set_requirements([not_tested_requirement_set]).length).to eq(1)
     end
   end
 


### PR DESCRIPTION
This branch merges the requirements and not-tested CSVs into a single CSV file. For now, untested requirements are not included in requirement sets which include all requirements for a particular actor. They are include if they are explicitly included by id, or are referenced as a sub-requirement. A future ticket will include them all the time once the UI considerations have been taken into account.