### PR TITLE
FI-4107: Serialize runnable requirement ids

### DIFF
--- a/dev_suites/dev_infrastructure_test/infrastructure_test_suite.rb
+++ b/dev_suites/dev_infrastructure_test/infrastructure_test_suite.rb
@@ -44,6 +44,8 @@ module InfrastructureTest
       ]
     end
 
+    verifies_requirements 'sample-criteria@4', 'sample-criteria@5', 'sample-criteria@6'
+
     def suite_helper
       'SUITE_HELPER'
     end

--- a/dev_suites/dev_infrastructure_test/serializer_group.rb
+++ b/dev_suites/dev_infrastructure_test/serializer_group.rb
@@ -21,6 +21,8 @@ module InfrastructureTest
 
     output :output3
 
+    verifies_requirements 'sample-criteria@3'
+
     test from: :infrastructure_serializer_test
   end
 end

--- a/dev_suites/dev_infrastructure_test/serializer_test.rb
+++ b/dev_suites/dev_infrastructure_test/serializer_test.rb
@@ -17,6 +17,8 @@ module InfrastructureTest
 
     output :output1, :output2
 
+    verifies_requirements 'sample-criteria@1', 'sample-criteria@2'
+
     run { pass }
   end
 end

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -646,6 +646,11 @@ definitions:
           $ref: "#/definitions/SuiteOption"
       suite_summary:
         type: "string"
+      verifies_requirements:
+        type: "array"
+        readOnly: true,
+        items:
+          type: "string"
   SuiteOption:
     type: "object"
     required:
@@ -719,6 +724,11 @@ definitions:
       optional:
         type: "boolean"
         readOnly: true
+      verifies_requirements:
+        type: "array"
+        readOnly: true,
+        items:
+          type: "string"
   Test:
     type: "object"
     required:
@@ -749,6 +759,11 @@ definitions:
       optional:
         type: "boolean"
         readOnly: true
+      verifies_requirements:
+        type: "array"
+        readOnly: true,
+        items:
+          type: "string"
   Input:
     type: "object"
     required:

--- a/lib/inferno/apps/web/serializers/test.rb
+++ b/lib/inferno/apps/web/serializers/test.rb
@@ -20,6 +20,7 @@ module Inferno
         field :input_instructions
         field :user_runnable?, name: :user_runnable
         field :optional?, name: :optional
+        field :verifies_requirements, if: :field_present?
       end
     end
   end

--- a/lib/inferno/apps/web/serializers/test_group.rb
+++ b/lib/inferno/apps/web/serializers/test_group.rb
@@ -32,6 +32,7 @@ module Inferno
           Input.render_as_hash(group.available_inputs(suite_options).values)
         end
         field :output_definitions, name: :outputs, extractor: HashValueExtractor
+        field :verifies_requirements, if: :field_present?
       end
     end
   end

--- a/lib/inferno/apps/web/serializers/test_suite.rb
+++ b/lib/inferno/apps/web/serializers/test_suite.rb
@@ -46,6 +46,7 @@ module Inferno
 
             RequirementSet.render_as_hash(requirement_sets)
           end
+          field :verifies_requirements, if: :field_present?
         end
       end
     end

--- a/spec/inferno/web/serializers/test_group_spec.rb
+++ b/spec/inferno/web/serializers/test_group_spec.rb
@@ -21,9 +21,11 @@ RSpec.describe Inferno::Web::Serializers::TestGroup do
   it 'serializes a group' do
     serialized_group = JSON.parse(described_class.render(group))
 
-    expected_keys = ['id', 'short_id', 'description', 'inputs', 'outputs', 'title',
-                     'test_count', 'test_groups', 'tests', 'run_as_group', 'user_runnable',
-                     'optional', 'short_title', 'short_description', 'input_instructions']
+    expected_keys = ['id', 'short_id', 'description', 'inputs', 'outputs',
+                     'title', 'test_count', 'test_groups', 'tests',
+                     'run_as_group', 'user_runnable', 'optional', 'short_title',
+                     'short_description', 'input_instructions',
+                     'verifies_requirements']
 
     expect(serialized_group.keys).to match_array(expected_keys)
     expect(serialized_group['id']).to eq(group.id.to_s)
@@ -38,6 +40,7 @@ RSpec.describe Inferno::Web::Serializers::TestGroup do
     expect(serialized_group['test_count']).to eq(group.tests.length)
     expect(serialized_group['test_groups']).to be_empty
     expect(serialized_group['tests'].length).to eq(group.tests.length)
+    expect(serialized_group['verifies_requirements'].length).to eq(group.verifies_requirements.length)
 
     group.available_inputs.each_value do |definition|
       raw_input = serialized_group['inputs']

--- a/spec/inferno/web/serializers/test_spec.rb
+++ b/spec/inferno/web/serializers/test_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Inferno::Web::Serializers::Test do
 
     expected_keys = ['id', 'short_id', 'description', 'inputs', 'outputs', 'title',
                      'user_runnable', 'optional', 'short_description', 'short_title',
-                     'input_instructions']
+                     'input_instructions', 'verifies_requirements']
 
     expect(serialized_test.keys).to match_array(expected_keys)
     expect(serialized_test['id']).to eq(test.id.to_s)
@@ -20,6 +20,7 @@ RSpec.describe Inferno::Web::Serializers::Test do
     expect(serialized_test['input_instructions']).to eq(test.input_instructions)
     expect(serialized_test['inputs'].length).to eq(test.inputs.length)
     expect(serialized_test['outputs'].length).to eq(test.outputs.length)
+    expect(serialized_test['verifies_requirements'].length).to eq(test.verifies_requirements.length)
 
     test.available_inputs.each_value do |definition|
       raw_input = serialized_test['inputs']

--- a/spec/inferno/web/serializers/test_suite_spec.rb
+++ b/spec/inferno/web/serializers/test_suite_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Inferno::Web::Serializers::TestSuite do
     ]
   end
   let(:full_keys) do
-    summary_keys + ['configuration_messages', 'test_groups', 'inputs']
+    summary_keys + ['configuration_messages', 'test_groups', 'inputs', 'verifies_requirements']
   end
 
   it 'serializes a suite summary view' do
@@ -60,6 +60,7 @@ RSpec.describe Inferno::Web::Serializers::TestSuite do
     expect(serialized_suite['configuration_messages']).to eq(expected_messages)
     expect(serialized_suite['presets']).to eq([])
     expect(serialized_suite['suite_summary']).to eq(suite.suite_summary)
+    expect(serialized_suite['verifies_requirements']).to eq(suite.verifies_requirements)
 
     expected_links = suite.links.map(&:with_indifferent_access)
     expect(serialized_suite['links']).to eq(expected_links)


### PR DESCRIPTION
This branch adds the ids from `verifies_requirements` to serialized runnables.