### PR TITLE
FI-4046: Support Long Runnable IDs Without DB Schema Change

### DIFF
--- a/lib/inferno/result_collection.rb
+++ b/lib/inferno/result_collection.rb
@@ -66,7 +66,10 @@ module Inferno
     private
 
     def lookup_by_runnable_id(key)
-      results.find { |result| result.runnable&.id == key.to_s || result.runnable&.id&.end_with?("-#{key}") }
+      results.find do |result|
+        result.runnable&.id == key.to_s || result.runnable&.id&.end_with?("-#{key}") ||
+          result.runnable&.full_id&.end_with?("-#{key}")
+      end
     end
   end
 end

--- a/lib/inferno/result_collection.rb
+++ b/lib/inferno/result_collection.rb
@@ -66,10 +66,7 @@ module Inferno
     private
 
     def lookup_by_runnable_id(key)
-      results.find do |result|
-        result.runnable&.id == key.to_s || result.runnable&.id&.end_with?("-#{key}") ||
-          result.runnable&.full_id&.end_with?("-#{key}")
-      end
+      results.find { |result| result.runnable&.id == key.to_s || result.runnable&.full_id&.end_with?("-#{key}") }
     end
   end
 end

--- a/spec/inferno/dsl/runnable_spec.rb
+++ b/spec/inferno/dsl/runnable_spec.rb
@@ -190,10 +190,15 @@ RSpec.describe Inferno::DSL::Runnable do
   end
 
   describe '.id' do
-    it 'raises an error if the id is longer than 255 characters' do
-      expect do
-        Class.new(Inferno::Test).id('a' * 256)
-      end.to raise_error(Inferno::Exceptions::InvalidRunnableIdException, /length of 255 characters/)
+    it 'shortens the id and preserves the full_id if longer than 255 characters' do
+      long_id = 'a' * 256
+      test = Class.new(Inferno::Test) do
+        id long_id
+      end
+
+      expect(test.id.length).to be <= 255
+      expect(test.full_id).to eq(long_id)
+      expect(test.id).to_not eq(long_id)
     end
   end
 
@@ -267,25 +272,25 @@ RSpec.describe Inferno::DSL::Runnable do
 
     it 'replaces a child with a new one using its ID' do
       child = test_group.children.first
-      global_id = child.id.split('-').last
+      global_id = child.full_id.split('-').last
       test_group.replace global_id, 'DemoIG_STU1::DemoGroup'
 
       expect(test_group.children.length).to eq(2)
-      expect(test_group.children.none? { |c| c.id.to_s.end_with?('DEF') }).to be true
-      expect(test_group.children[0].id.to_s.end_with?('DemoIG_STU1::DemoGroup')).to be true
+      expect(test_group.children.none? { |c| c.full_id.to_s.end_with?('DEF') }).to be true
+      expect(test_group.children[0].full_id.to_s.end_with?('DemoIG_STU1::DemoGroup')).to be true
       expect(test_groups_repo.find(child.id)).to be_nil
       expect(child.children.filter_map { |c| tests_repo.find(c.id) }).to be_empty
     end
 
     it 'applies block configuration to the new child when block given' do
       child = test_group.children.first
-      global_id = child.id.split('-').last
+      global_id = child.full_id.split('-').last
       test_group.replace global_id, 'DemoIG_STU1::DemoGroup' do
         id :new_id
       end
 
       expect(test_group.children.length).to eq(2)
-      expect(test_group.children[0].id.to_s.end_with?('new_id')).to be true
+      expect(test_group.children[0].full_id.to_s.end_with?('new_id')).to be true
       expect(test_groups_repo.find(child.id)).to be_nil
       expect(child.children.filter_map { |c| tests_repo.find(c.id) }).to be_empty
     end

--- a/spec/inferno/result_collection_spec.rb
+++ b/spec/inferno/result_collection_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Inferno::ResultCollection do
 
       context 'when using partial ID' do
         it 'returns the result with the runnable ID ending with the partial ID' do
-          partial_id = suite_children.first.id.split('-').last
+          partial_id = suite_children.first.full_id.split('-').last
           expect(result_collection[partial_id]).to eq(child_results.first)
         end
       end

--- a/spec/runnable_context.rb
+++ b/spec/runnable_context.rb
@@ -34,7 +34,7 @@ RSpec.shared_context('when testing a runnable') do
   # can include some ancestor context if needed to identify the
   # correct test. The first matching test found will be returned.
   def find_test(runnable, id_suffix)
-    return runnable if runnable.id.ends_with?(id_suffix)
+    return runnable if runnable.full_id.ends_with?(id_suffix)
 
     runnable.children.each do |entity|
       found = find_test(entity, id_suffix)


### PR DESCRIPTION
# Summary
This PR introduces support for runnable IDs longer than 255 characters by truncating and appending a hash when needed. The original full ID is preserved separately via `full_id`.

**Note**: The ticket mentioned implementing this in a non-breaking manner. While existing test kits that do not manipulate the runnable ID directly should continue working as expected, this may be a breaking change for test kits that use logic like id.include?('...') or id.end_with?('...'). Those will need to be updated to use `full_id` instead. Not sure if there’s a cleaner workaround to fully preserve backward compatibility — open to suggestions.

