### PR TITLE
FI-4050: Dynamically look up FHIR/HTTP clients

### DIFF
--- a/lib/inferno/dsl/fhir_client.rb
+++ b/lib/inferno/dsl/fhir_client.rb
@@ -52,7 +52,11 @@ module Inferno
       # @see Inferno::DSL::FHIRClientBuilder
       def fhir_client(client = :default)
         fhir_clients[client] ||=
-          FHIRClientBuilder.new.build(self, self.class.fhir_client_definitions[client])
+          FHIRClientBuilder.new.build(self, find_fhir_client_definition(client))
+      end
+
+      def find_fhir_client_definition(client)
+        self.class.find_fhir_client_definition(client)
       end
 
       # @private
@@ -441,6 +445,10 @@ module Inferno
         # @private
         def fhir_client_definitions
           @fhir_client_definitions ||= {}
+        end
+
+        def find_fhir_client_definition(client)
+          fhir_client_definitions[client] || parent&.find_fhir_client_definition(client)
         end
 
         # Define a FHIR client to be used by a Runnable.

--- a/lib/inferno/dsl/http_client.rb
+++ b/lib/inferno/dsl/http_client.rb
@@ -46,12 +46,16 @@ module Inferno
       def http_client(client = :default)
         return http_clients[client] if http_clients[client]
 
-        definition = self.class.http_client_definitions[client]
+        definition = find_http_client_definition(client)
         return nil if definition.nil?
 
         tcp_exception_handler do
           http_clients[client] = HTTPClientBuilder.new.build(self, definition)
         end
+      end
+
+      def find_http_client_definition(client)
+        self.class.find_http_client_definition(client)
       end
 
       # @private
@@ -194,6 +198,10 @@ module Inferno
         # @private
         def http_client_definitions
           @http_client_definitions ||= {}
+        end
+
+        def find_http_client_definition(client)
+          http_client_definitions[client] || parent&.find_http_client_definition(client)
         end
 
         # Define a HTTP client to be used by a Runnable.

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -164,22 +164,6 @@ module Inferno
           klass.output output_name
         end
 
-        new_fhir_client_definitions = klass.instance_variable_get(:@fhir_client_definitions) || {}
-        fhir_client_definitions.each do |name, definition|
-          next if new_fhir_client_definitions.include? name
-
-          new_fhir_client_definitions[name] = definition.dup
-        end
-        klass.instance_variable_set(:@fhir_client_definitions, new_fhir_client_definitions)
-
-        new_http_client_definitions = klass.instance_variable_get(:@http_client_definitions) || {}
-        http_client_definitions.each do |name, definition|
-          next if new_http_client_definitions.include? name
-
-          new_http_client_definitions[name] = definition.dup
-        end
-        klass.instance_variable_set(:@http_client_definitions, new_http_client_definitions)
-
         klass.config(config)
 
         klass.all_children.select!(&:required?) if hash_args.delete(:exclude_optional)

--- a/spec/inferno/dsl/fhir_client_spec.rb
+++ b/spec/inferno/dsl/fhir_client_spec.rb
@@ -1,9 +1,4 @@
-class FHIRClientDSLTestClass
-  include Inferno::DSL::FHIRClient
-  include Inferno::DSL::HTTPClient
-  extend Inferno::DSL::Configurable
-  include Inferno::DSL::Results
-
+class FHIRClientDSLTestClass < Inferno::Test
   def test_session_id
     nil
   end

--- a/spec/inferno/dsl/http_client_spec.rb
+++ b/spec/inferno/dsl/http_client_spec.rb
@@ -1,10 +1,6 @@
 require_relative '../../../lib/inferno/dsl/http_client_builder'
 
-class HTTPClientDSLTestClass
-  include Inferno::DSL::HTTPClient
-  extend Inferno::DSL::Configurable
-  include Inferno::DSL::Results
-
+class HTTPClientDSLTestClass < Inferno::Test
   def test_session_id
     nil
   end

--- a/spec/inferno/dsl/test_creation_spec.rb
+++ b/spec/inferno/dsl/test_creation_spec.rb
@@ -158,8 +158,10 @@ RSpec.describe InfrastructureTest::Suite do
         expect(found_short_ids).to eq(expected_short_ids)
       end
 
-      it "contains its own fhir clients as well as its parents' fhir clients" do
-        expect(outer_inline_group.fhir_client_definitions.keys).to eq([:suite, :outer_inline_group])
+      it "has access to its own fhir clients as well as its parents' fhir clients" do
+        [:suite, :outer_inline_group].each do |client_name|
+          expect(outer_inline_group.find_fhir_client_definition(client_name)).to be_present
+        end
       end
 
       it 'passes' do
@@ -232,8 +234,9 @@ RSpec.describe InfrastructureTest::Suite do
       end
 
       it "contains its own fhir clients as well as its parents' fhir clients" do
-        expected_clients = [:suite, :outer_inline_group, :inner_inline_group]
-        expect(inner_inline_group.fhir_client_definitions.keys).to eq(expected_clients)
+        [:suite, :outer_inline_group, :inner_inline_group].each do |client_name|
+          expect(inner_inline_group.find_fhir_client_definition(client_name)).to be_present
+        end
       end
 
       it 'passes' do
@@ -293,8 +296,9 @@ RSpec.describe InfrastructureTest::Suite do
       end
 
       it "contains its own fhir clients as well as its parents' fhir clients" do
-        expected_clients = [:suite, :outer_inline_group, :inner_inline_group, :inline_test1]
-        expect(inline_test1.fhir_client_definitions.keys).to eq(expected_clients)
+        [:suite, :outer_inline_group, :inner_inline_group, :inline_test1].each do |client_name|
+          expect(inline_test1.find_fhir_client_definition(client_name)).to be_present
+        end
       end
 
       it 'passes' do
@@ -370,7 +374,9 @@ RSpec.describe InfrastructureTest::Suite do
       end
 
       it "contains its own fhir clients as well as its parents' fhir clients" do
-        expect(external_outer_group.fhir_client_definitions.keys).to contain_exactly(:suite, :external_outer_group)
+        [:suite, :external_outer_group].each do |client_name|
+          expect(external_outer_group.find_fhir_client_definition(client_name)).to be_present
+        end
       end
 
       it 'passes' do
@@ -431,8 +437,9 @@ RSpec.describe InfrastructureTest::Suite do
       end
 
       it "contains its own fhir clients as well as its parents' fhir clients" do
-        expected_clients = [:suite, :external_outer_group, :external_inner_group]
-        expect(external_inner_group.fhir_client_definitions.keys).to match_array(expected_clients)
+        [:suite, :external_outer_group, :external_inner_group].each do |client_name|
+          expect(external_inner_group.find_fhir_client_definition(client_name)).to be_present
+        end
       end
 
       it 'contains an externally defined test' do
@@ -516,8 +523,9 @@ RSpec.describe InfrastructureTest::Suite do
       end
 
       it "contains its own fhir clients as well as its parents' fhir clients" do
-        expected_clients = [:suite, :external_outer_group, :external_inner_group, :external_test1]
-        expect(external_test.fhir_client_definitions.keys).to match_array(expected_clients)
+        [:suite, :external_outer_group, :external_inner_group, :external_test1].each do |client_name|
+          expect(external_test.find_fhir_client_definition(client_name)).to be_present
+        end
       end
 
       it 'passes' do


### PR DESCRIPTION
This branch updates how FHIR/HTTP clients are looked up to be more similar to validators. Currently, client definitions are copied to a runnable upon creation, so in a case like the following
```ruby
group from: :some_group do
  fhir_client { url '...' }
end
```
none of the group's children will have access to that client, because the group and its children are created prior to executing the block in the group declaration.

This branch makes it so that children no longer copy clients from their parents. Instead, they look up through their ancestors until they find an appropriate client.