### PR TITLE
FI-4172: Add not-tested requirement fields to JSON API

### DIFF
--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -846,4 +846,7 @@ definitions:
         type: "array"
         items:
           type: "string"
-
+      not_tested_reason:
+        type: "string"
+      not_tested_details:
+        type: "string"

--- a/lib/inferno/apps/web/serializers/requirement.rb
+++ b/lib/inferno/apps/web/serializers/requirement.rb
@@ -12,6 +12,8 @@ module Inferno
         field :sub_requirements
         field :conditionality
         field :url, if: :field_present?
+        field :not_tested_reason, if: :field_present?
+        field :not_tested_details, if: :field_present?
       end
     end
   end


### PR DESCRIPTION
This branch adds the `not_tested_reason` and `not_tested_details` fields to the requirements in the JSON API.