### PR TITLE
FI-4168: Support actor subrequirements

### DIFF
--- a/dev_suites/dev_requirements/requirements/sample_requirements.csv
+++ b/dev_suites/dev_requirements/requirements/sample_requirements.csv
@@ -17,3 +17,6 @@ sample-criteria-proposal-3,7,,text7,SHALL,Client,,FALSE,,
 sample-criteria-proposal-4,1,,text1,SHALL,Client,,FALSE,Not Tested,NOT TESTED DETAILS
 sample-criteria-proposal-4,2,,text2,SHALL,Client,,FALSE,Not Verifiable,NOT VERIFIABLE DETAILS
 sample-criteria-proposal-4,3,,text3,SHALL,Client,,FALSE,,
+sample-criteria-proposal-5,1,,text3,SHALL,Client,,FALSE,,
+sample-criteria-proposal-5,2,,text2,SHALL,Server,,FALSE,,
+sample-criteria-proposal-5,3,,text3,SHALL,Client,,FALSE,,

--- a/lib/inferno/entities/requirement.rb
+++ b/lib/inferno/entities/requirement.rb
@@ -37,12 +37,14 @@ module Inferno
       #   used if none is included in the `requirement_id_string`
       #
       # @example
-      # expand_requirement_ids('example-ig@1,3,5-7')
-      # # => ['example-ig@1','example-ig@3','example-ig@5','example-ig@6','example-ig@7']
-      # expand_requirement_ids('example-ig')
-      # # => []
-      # expand_requirement_ids('1,3,5-7', 'example-ig')
-      # # => ['example-ig@1','example-ig@3','example-ig@5','example-ig@6','example-ig@7']
+      #   expand_requirement_ids('example-ig@1,3,5-7')
+      #   # => ['example-ig@1','example-ig@3','example-ig@5','example-ig@6','example-ig@7']
+      #   expand_requirement_ids('example-ig')
+      #   # => []
+      #   expand_requirement_ids('1,3,5-7', 'example-ig')
+      #   # => ['example-ig@1','example-ig@3','example-ig@5','example-ig@6','example-ig@7']
+      #   expand_requirement_ids('example-ig#actor1')
+      #   # => [all requirements for actor1 from example-ig]
       def self.expand_requirement_ids(requirement_id_string, default_set = nil) # rubocop:disable Metrics/CyclomaticComplexity
         return [] if requirement_id_string.blank?
 

--- a/lib/inferno/repositories/requirements.rb
+++ b/lib/inferno/repositories/requirements.rb
@@ -40,6 +40,10 @@ module Inferno
         end
       end
 
+      def requirements_for_actor(requirement_set, actor)
+        all.select { |requirement| requirement.requirement_set == requirement_set && requirement.actor == actor }
+      end
+
       def filter_requirements_by_ids(ids)
         all.select { |requirement| ids.include?(requirement.id) }
       end

--- a/spec/inferno/entities/requirement_spec.rb
+++ b/spec/inferno/entities/requirement_spec.rb
@@ -38,6 +38,14 @@ RSpec.describe Inferno::Entities::Requirement do
     it 'ignores invalid non-numeric range boundaries' do
       ids = ['criteria3@a-b', 'criteria4@2', 'example-ig']
       expected_ids = ['criteria4@2']
+
+      expect(described_class.expand_requirement_ids(ids.join(','))).to eq(expected_ids)
+    end
+
+    it 'adds requirements when specified by actor' do
+      ids = ['sample-criteria-proposal-5#Client']
+      expected_ids = ['sample-criteria-proposal-5@1', 'sample-criteria-proposal-5@3']
+
       expect(described_class.expand_requirement_ids(ids.join(','))).to eq(expected_ids)
     end
   end


### PR DESCRIPTION
# Summary
This branch allows subrequirements to be defined with `requirement-set#actor`.

# Testing Guidance
Add the pdex and bulk data requirement conversion branches to the Gemfile, require the pdex test kit in the demo suite. In the pdex branch, if you change the requirement set in the server suite from:
```ruby
        identifier: 'hl7.fhir.uv.bulkdata_2.0.0',
        title: 'Bulk Data Access IG',
        actor: 'Server'
```
to:
```ruby
        identifier: 'hl7.fhir.uv.bulkdata_2.0.0',
        title: 'Bulk Data Access IG',
        actor: 'Server',
        requirements: 'referenced'
```
you will see the bulk data requirements in the requirements ui for the suite.