### PR TITLE
FI-4177: Add error handling to requirements loading

### DIFF
--- a/lib/inferno/repositories/requirements.rb
+++ b/lib/inferno/repositories/requirements.rb
@@ -33,6 +33,8 @@ module Inferno
             not_tested_reason: row[:not_tested_reason],
             not_tested_details: row[:not_tested_details]
           }
+        rescue StandardError => e
+          Application[:logger].error("Unable to load requirement: #{combined_id}:\n#{e.full_message.lines.first}")
         end
 
         result.each do |raw_req|
@@ -109,7 +111,7 @@ module Inferno
             .flat_map(&:sub_requirements)
             .select do |requirement_id|
               referenced_requirement_sets.any? do |set|
-                requirement_id.start_with?("#{set.identifier}@") && find(requirement_id).actor?(set.actor)
+                requirement_id.start_with?("#{set.identifier}@") && find(requirement_id)&.actor?(set.actor)
               end
             end
 


### PR DESCRIPTION
# Summary
This branch handles errors when loading requirements.

# Testing Guidance
I used the requirements update branches on pdex and bulk data to test this. On `main`, the errors from the requirements will prevent inferno from starting. On this branch, the UI will still load, but the suite requirements UI won't be displayed for PDEX. Changing the `Actor` heading to `Actors` in the CSVs on those test kit branches will allow the suite requirements UI to be displayed even though some errors are still displayed while loading.