### PR TITLE
FI-4180: Prevent loading requirements from vendor directory

### DIFF
--- a/lib/inferno/apps/cli/requirements.rb
+++ b/lib/inferno/apps/cli/requirements.rb
@@ -66,7 +66,7 @@ module Inferno
           RequirementsCoverageChecker.new(test_suite_id).run_check
         else
           Inferno::Repositories::TestSuites.all.each do |test_suite|
-            if Object.const_source_location(test_suite.to_s).first.start_with?(Dir.pwd, 'lib')
+            if Object.const_source_location(test_suite.to_s).first.start_with?(File.join(Dir.pwd, 'lib'))
               RequirementsCoverageChecker.new(test_suite.id).run_check
             end
           end


### PR DESCRIPTION
This branch updates the coverage check to only load test kit requirements located in `WORKING_DIRECTORY/lib`.