### PR TITLE
FI-4179: Refactor requirements button

### DIFF
--- a/client/src/components/TestSuite/Requirements/RequirementContent.tsx
+++ b/client/src/components/TestSuite/Requirements/RequirementContent.tsx
@@ -26,7 +26,7 @@ const RequirementContent: FC<RequirementContentProps> = ({
   // Reduce list of requirements into map of specification -> url -> list of requirements
   const requirementsByUrl = requirements.reduce(
     (acc, current) => {
-      const specification = current.id.split('@')[0];
+      const specification = current.specification || current.id.split('@')[0];
       const url = current.url ?? '';
       if (acc[specification]) {
         if (acc[specification][url]) acc[specification][url].push(current);

--- a/client/src/components/TestSuite/Requirements/RequirementsModalButton.tsx
+++ b/client/src/components/TestSuite/Requirements/RequirementsModalButton.tsx
@@ -1,0 +1,53 @@
+import React, { FC } from 'react';
+import { enqueueSnackbar } from 'notistack';
+import { Box, Link } from '@mui/material';
+import { getSingleRequirement } from '~/api/RequirementsApi';
+import { Requirement, Runnable } from '~/models/testSuiteModels';
+import { shouldShowRequirementsButton } from '~/components/TestSuite/TestSuiteUtilities';
+import RequirementsModal from '~/components/TestSuite/Requirements/RequirementsModal';
+import useStyles from './styles';
+
+interface RequirementsModalButtonProps {
+  runnable: Runnable;
+}
+
+const RequirementsModalButton: FC<RequirementsModalButtonProps> = ({ runnable }) => {
+  const { classes } = useStyles();
+  const [requirements, setRequirements] = React.useState<Requirement[]>([]);
+  const [showRequirements, setShowRequirements] = React.useState(false);
+
+  const showRequirementsClick = () => {
+    const requirementIds = runnable.verifies_requirements;
+    if (requirementIds) {
+      Promise.all(requirementIds.map((requirementId) => getSingleRequirement(requirementId)))
+        .then((resolvedValues) => {
+          setRequirements(resolvedValues.filter((r) => !!r));
+          setShowRequirements(true);
+        })
+        .catch((e: Error) => {
+          enqueueSnackbar(`Error fetching specification requirements: ${e.message}`, {
+            variant: 'error',
+          });
+        });
+    }
+  };
+
+  return (
+    <>
+      <Box display="flex" justifyContent="end" minWidth="fit-content" p={2}>
+        <Link color="secondary" className={classes.textButton} onClick={showRequirementsClick}>
+          View Specification Requirements
+        </Link>
+      </Box>
+      {requirements && shouldShowRequirementsButton(runnable) && (
+        <RequirementsModal
+          requirements={requirements}
+          modalVisible={showRequirements}
+          hideModal={() => setShowRequirements(false)}
+        />
+      )}
+    </>
+  );
+};
+
+export default RequirementsModalButton;

--- a/client/src/components/TestSuite/Requirements/styles.tsx
+++ b/client/src/components/TestSuite/Requirements/styles.tsx
@@ -28,4 +28,8 @@ export default makeStyles()((theme: Theme) => ({
       margin: 0,
     },
   },
+  textButton: {
+    fontWeight: 'bolder',
+    cursor: 'pointer',
+  },
 }));

--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
@@ -1,16 +1,14 @@
 import React, { FC, useMemo } from 'react';
-import { Box, Card, Divider, Link, Typography } from '@mui/material';
-import { enqueueSnackbar } from 'notistack';
+import { Box, Card, Divider, Typography } from '@mui/material';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { getSingleRequirement } from '~/api/RequirementsApi';
-import { TestGroup, RunnableType, TestSuite, Requirement } from '~/models/testSuiteModels';
+import { TestGroup, RunnableType, TestSuite } from '~/models/testSuiteModels';
 import {
   shouldShowDescription,
   shouldShowRequirementsButton,
 } from '~/components/TestSuite/TestSuiteUtilities';
 import InputOutputList from '~/components/TestSuite/TestSuiteDetails/TestListItem/InputOutputList';
-import RequirementsModal from '~/components/TestSuite/Requirements/RequirementsModal';
+import RequirementsModalButton from '~/components/TestSuite/Requirements/RequirementsModalButton';
 import ResultIcon from '~/components/TestSuite/TestSuiteDetails/ResultIcon';
 import TestRunButton from '~/components/TestSuite/TestRunButton/TestRunButton';
 import { useTestSessionStore } from '~/store/testSession';
@@ -26,8 +24,6 @@ interface TestGroupCardProps {
 const TestGroupCard: FC<TestGroupCardProps> = ({ children, runnable, runTests, view }) => {
   const { classes } = useStyles();
   const viewOnly = useTestSessionStore((state) => state.viewOnly);
-  const [requirements, setRequirements] = React.useState<Requirement[]>([]);
-  const [showRequirements, setShowRequirements] = React.useState(false);
 
   const buttonText = `${viewOnly ? 'View' : 'Run'}${runnable.run_as_group ? '' : ' All'}${viewOnly ? ' Inputs' : ' Tests'}`;
 
@@ -39,22 +35,6 @@ const TestGroupCard: FC<TestGroupCardProps> = ({ children, runnable, runTests, v
   }, [runnable.description]);
 
   const runnableType = 'tests' in runnable ? RunnableType.TestGroup : RunnableType.TestSuite;
-
-  const showRequirementsClick = () => {
-    const requirementIds = runnable.verifies_requirements;
-    if (requirementIds) {
-      Promise.all(requirementIds.map((requirementId) => getSingleRequirement(requirementId)))
-        .then((resolvedValues) => {
-          setRequirements(resolvedValues.filter((r) => !!r));
-          setShowRequirements(true);
-        })
-        .catch((e: Error) => {
-          enqueueSnackbar(`Error fetching specification requirements: ${e.message}`, {
-            variant: 'error',
-          });
-        });
-    }
-  };
 
   const renderHeader = () => {
     return (
@@ -93,25 +73,8 @@ const TestGroupCard: FC<TestGroupCardProps> = ({ children, runnable, runTests, v
               {description}
             </Box>
           )}
-          {showRequirementsButton && (
-            <Box display="flex" justifyContent="end" minWidth="fit-content" p={2}>
-              <Link
-                color="secondary"
-                className={classes.textButton}
-                onClick={showRequirementsClick}
-              >
-                View Specification Requirements
-              </Link>
-            </Box>
-          )}
+          {showRequirementsButton && <RequirementsModalButton runnable={runnable} />}
           <Divider />
-          {requirements && showRequirementsButton && (
-            <RequirementsModal
-              requirements={requirements}
-              modalVisible={showRequirements}
-              hideModal={() => setShowRequirements(false)}
-            />
-          )}
         </>
       );
     }

--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
@@ -82,7 +82,7 @@ const TestGroupCard: FC<TestGroupCardProps> = ({ children, runnable, runTests, v
 
   const renderInputOutputs = () => {
     if ((runnable as TestGroup).user_runnable && runnable.result && runnable.run_as_group) {
-      return <InputOutputList headerName="Input" inputOutputs={runnable.result?.inputs || []} />;
+      return <InputOutputList headerName="Input" values={runnable.result?.inputs || []} />;
     }
   };
 

--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupListItem/NestedDescriptionPanel.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupListItem/NestedDescriptionPanel.tsx
@@ -14,9 +14,9 @@ import {
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { TestGroup } from '~/models/testSuiteModels';
-import useStyles from './styles';
 import { shouldShowRequirementsButton } from '~/components/TestSuite/TestSuiteUtilities';
 import RequirementsModalButton from '~/components/TestSuite/Requirements/RequirementsModalButton';
+import useStyles from './styles';
 
 interface NestedDescriptionPanelProps {
   testGroup: TestGroup;
@@ -25,7 +25,6 @@ interface NestedDescriptionPanelProps {
 const NestedDescriptionPanel: FC<NestedDescriptionPanelProps> = ({ testGroup }) => {
   const { classes } = useStyles();
   const [descriptionMouseHover, setDescriptionMouseHover] = React.useState(false);
-  const showRequirementsButton = shouldShowRequirementsButton(testGroup);
 
   return (
     <Box py={1} className={classes.descriptionContainer}>
@@ -63,7 +62,9 @@ const NestedDescriptionPanel: FC<NestedDescriptionPanelProps> = ({ testGroup }) 
         >
           <Box className={`${classes.accordionDetail} ${classes.description}`}>
             <Markdown remarkPlugins={[remarkGfm]}>{testGroup.description as string}</Markdown>
-            {showRequirementsButton && <RequirementsModalButton runnable={testGroup} />}
+            {shouldShowRequirementsButton(testGroup) && (
+              <RequirementsModalButton runnable={testGroup} />
+            )}
           </Box>
         </AccordionDetails>
       </Accordion>

--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupListItem/NestedDescriptionPanel.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupListItem/NestedDescriptionPanel.tsx
@@ -1,26 +1,22 @@
 import React, { FC } from 'react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { enqueueSnackbar } from 'notistack';
-
 import {
   Accordion,
   AccordionDetails,
   AccordionSummary,
   Box,
   Divider,
-  Link,
   List,
   ListItem,
   ListItemText,
   Typography,
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import { getSingleRequirement } from '~/api/RequirementsApi';
-import { Requirement, TestGroup } from '~/models/testSuiteModels';
+import { TestGroup } from '~/models/testSuiteModels';
 import useStyles from './styles';
 import { shouldShowRequirementsButton } from '~/components/TestSuite/TestSuiteUtilities';
-import RequirementsModal from '~/components/TestSuite/Requirements/RequirementsModal';
+import RequirementsModalButton from '~/components/TestSuite/Requirements/RequirementsModalButton';
 
 interface NestedDescriptionPanelProps {
   testGroup: TestGroup;
@@ -28,26 +24,8 @@ interface NestedDescriptionPanelProps {
 
 const NestedDescriptionPanel: FC<NestedDescriptionPanelProps> = ({ testGroup }) => {
   const { classes } = useStyles();
-  const [showRequirements, setShowRequirements] = React.useState(false);
-  const [requirements, setRequirements] = React.useState<Requirement[]>([]);
   const [descriptionMouseHover, setDescriptionMouseHover] = React.useState(false);
   const showRequirementsButton = shouldShowRequirementsButton(testGroup);
-
-  const showRequirementsClick = () => {
-    const requirementIds = testGroup.verifies_requirements;
-    if (requirementIds) {
-      Promise.all(requirementIds.map((requirementId) => getSingleRequirement(requirementId)))
-        .then((resolvedValues) => {
-          setRequirements(resolvedValues.filter((r) => !!r));
-          setShowRequirements(true);
-        })
-        .catch((e: Error) => {
-          enqueueSnackbar(`Error fetching specification requirements: ${e.message}`, {
-            variant: 'error',
-          });
-        });
-    }
-  };
 
   return (
     <Box py={1} className={classes.descriptionContainer}>
@@ -85,27 +63,10 @@ const NestedDescriptionPanel: FC<NestedDescriptionPanelProps> = ({ testGroup }) 
         >
           <Box className={`${classes.accordionDetail} ${classes.description}`}>
             <Markdown remarkPlugins={[remarkGfm]}>{testGroup.description as string}</Markdown>
-            {showRequirementsButton && (
-              <Box display="flex" justifyContent="end" minWidth="fit-content" pt={1}>
-                <Link
-                  color="secondary"
-                  className={classes.textButton}
-                  onClick={showRequirementsClick}
-                >
-                  View Specification Requirements
-                </Link>
-              </Box>
-            )}
+            {showRequirementsButton && <RequirementsModalButton runnable={testGroup} />}
           </Box>
         </AccordionDetails>
       </Accordion>
-      {requirements && showRequirementsButton && (
-        <RequirementsModal
-          requirements={requirements}
-          modalVisible={showRequirements}
-          hideModal={() => setShowRequirements(false)}
-        />
-      )}
     </Box>
   );
 };

--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupListItem/TestGroupListItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupListItem/TestGroupListItem.tsx
@@ -190,7 +190,7 @@ const TestGroupListItem: FC<TestGroupListItemProps> = ({
         testGroup.run_as_group &&
         testGroup.user_runnable &&
         testGroup.result && (
-          <InputOutputList headerName="Input" inputOutputs={testGroup.result?.inputs || []} />
+          <InputOutputList headerName="Input" values={testGroup.result?.inputs || []} />
         )}
       <AccordionDetails
         title={groupMouseHover ? '' : `${testGroup.id}-detail`}

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/InputOutputList.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/InputOutputList.tsx
@@ -4,16 +4,12 @@ import { Table, TableBody, TableRow, TableCell, Typography, TableHead, Box } fro
 import { TestInput, TestOutput } from '~/models/testSuiteModels';
 
 interface InputOutputListProps {
-  inputOutputs: TestInput[] | TestOutput[];
+  values: TestInput[] | TestOutput[];
   noValuesMessage?: string;
   headerName: string;
 }
 
-const InputOutputList: FC<InputOutputListProps> = ({
-  inputOutputs,
-  noValuesMessage,
-  headerName,
-}) => {
+const InputOutputList: FC<InputOutputListProps> = ({ values, noValuesMessage, headerName }) => {
   const { classes } = useStyles();
 
   const headerTitles = [headerName, 'Value'];
@@ -32,30 +28,28 @@ const InputOutputList: FC<InputOutputListProps> = ({
     </TableRow>
   );
 
-  const inputOutputsListItems = inputOutputs.map(
-    (inputOutputs: TestInput | TestOutput, index: number) => {
-      return (
-        <TableRow key={`inputOutputsRow-${index}`}>
-          <TableCell className={classes.noPrintSpacing}>
-            <Typography variant="subtitle2" component="p" className={classes.bolderText}>
-              {inputOutputs.name}
-            </Typography>
-          </TableCell>
-          <TableCell className={classes.inputOutputsValue}>
-            <Typography variant="subtitle2" component="p">
-              {(inputOutputs?.value as string) || ''}
-            </Typography>
-          </TableCell>
-        </TableRow>
-      );
-    },
-  );
+  const valuesListItems = values.map((value: TestInput | TestOutput, index: number) => {
+    return (
+      <TableRow key={`inputOutputsRow-${index}`}>
+        <TableCell className={classes.noPrintSpacing}>
+          <Typography variant="subtitle2" component="p" className={classes.bolderText}>
+            {value.name}
+          </Typography>
+        </TableCell>
+        <TableCell className={classes.inputOutputsValue}>
+          <Typography variant="subtitle2" component="p">
+            {(value?.value as string) || ''}
+          </Typography>
+        </TableCell>
+      </TableRow>
+    );
+  });
 
   const output =
-    inputOutputs.length > 0 ? (
+    values.length > 0 ? (
       <Table size="small">
         <TableHead>{inputOutputsListHeader}</TableHead>
-        <TableBody>{inputOutputsListItems}</TableBody>
+        <TableBody>{valuesListItems}</TableBody>
       </Table>
     ) : (
       noValuesMessage && (

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestRunDetail.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestRunDetail.tsx
@@ -108,14 +108,14 @@ const TestRunDetail: FC<TestRunDetailProps> = ({
       </TabPanel>
       <TabPanel id={test.id} currentTabIndex={currentTabIndex} index={2}>
         <InputOutputList
-          inputOutputs={test.result?.inputs || []}
+          values={test.result?.inputs || []}
           noValuesMessage="No Inputs"
           headerName="Input"
         />
       </TabPanel>
       <TabPanel id={test.id} currentTabIndex={currentTabIndex} index={3}>
         <InputOutputList
-          inputOutputs={test.result?.outputs || []}
+          values={test.result?.outputs || []}
           noValuesMessage="No Outputs"
           headerName="Output"
         />

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestRunDetail.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestRunDetail.tsx
@@ -1,17 +1,8 @@
 import React, { FC, useEffect, useMemo } from 'react';
-import { Box, Card, Divider, Link, Tabs, Typography } from '@mui/material';
+import { Box, Card, Divider, Tabs, Typography } from '@mui/material';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { enqueueSnackbar } from 'notistack';
-import { getSingleRequirement } from '~/api/RequirementsApi';
-import {
-  Message,
-  Request,
-  Requirement,
-  Test,
-  TestInput,
-  TestOutput,
-} from '~/models/testSuiteModels';
+import { Message, Request, Test, TestInput, TestOutput } from '~/models/testSuiteModels';
 import {
   shouldShowDescription,
   shouldShowRequirementsButton,
@@ -21,7 +12,7 @@ import CustomTooltip from '~/components/_common/CustomTooltip';
 import InputOutputList from '~/components/TestSuite/TestSuiteDetails/TestListItem/InputOutputList';
 import MessageList from '~/components/TestSuite/TestSuiteDetails/TestListItem/MessageList';
 import RequestList from '~/components/TestSuite/TestSuiteDetails/TestListItem/RequestList';
-import RequirementsModal from '~/components/TestSuite/Requirements/RequirementsModal';
+import RequirementsModalButton from '~/components/TestSuite/Requirements/RequirementsModalButton';
 import TabPanel from '~/components/TestSuite/TestSuiteDetails/TestListItem/TabPanel';
 import useStyles from './styles';
 
@@ -46,8 +37,6 @@ const TestRunDetail: FC<TestRunDetailProps> = ({
   tabs,
 }) => {
   const { classes } = useStyles();
-  const [requirements, setRequirements] = React.useState<Requirement[]>([]);
-  const [showRequirements, setShowRequirements] = React.useState(false);
 
   useEffect(() => {
     setTabIndex(currentTabIndex);
@@ -89,22 +78,6 @@ const TestRunDetail: FC<TestRunDetailProps> = ({
         disabled={disableTab}
       />
     );
-  };
-
-  const showRequirementsClick = () => {
-    const requirementIds = test.verifies_requirements;
-    if (requirementIds) {
-      Promise.all(requirementIds.map((requirementId) => getSingleRequirement(requirementId)))
-        .then((resolvedValues) => {
-          setRequirements(resolvedValues.filter((r) => !!r));
-          setShowRequirements(true);
-        })
-        .catch((e: Error) => {
-          enqueueSnackbar(`Error fetching specification requirements: ${e.message}`, {
-            variant: 'error',
-          });
-        });
-    }
   };
 
   return (
@@ -157,21 +130,8 @@ const TestRunDetail: FC<TestRunDetailProps> = ({
             </Typography>
           </Box>
         )}
-        {shouldShowRequirementsButton(test) && (
-          <Box display="flex" justifyContent="end" minWidth="fit-content" px={2} pb={2}>
-            <Link color="secondary" className={classes.textButton} onClick={showRequirementsClick}>
-              View Specification Requirements
-            </Link>
-          </Box>
-        )}
+        {shouldShowRequirementsButton(test) && <RequirementsModalButton runnable={test} />}
       </TabPanel>
-      {requirements && shouldShowRequirementsButton(test) && (
-        <RequirementsModal
-          requirements={requirements}
-          modalVisible={showRequirements}
-          hideModal={() => setShowRequirements(false)}
-        />
-      )}
     </Card>
   );
 };

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestRunDetail.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestRunDetail.tsx
@@ -125,7 +125,7 @@ const TestRunDetail: FC<TestRunDetailProps> = ({
           testDescription
         ) : (
           <Box p={2}>
-            <Typography variant="subtitle2" component="p">
+            <Typography variant="subtitle1" component="p">
               No Description
             </Typography>
           </Box>

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/__tests__/InputOutputList.test.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/__tests__/InputOutputList.test.tsx
@@ -17,7 +17,7 @@ describe('The InputOutputsList component', () => {
     render(
       <ThemeProvider>
         <SnackbarProvider>
-          <InputOutputList inputOutputs={inputs} noValuesMessage="No Inputs" headerName="Input" />
+          <InputOutputList values={inputs} noValuesMessage="No Inputs" headerName="Input" />
         </SnackbarProvider>
       </ThemeProvider>,
     );
@@ -36,7 +36,7 @@ describe('The InputOutputsList component', () => {
       <ThemeProvider>
         <SnackbarProvider>
           <InputOutputList
-            inputOutputs={outputs}
+            values={outputs}
             noValuesMessage="No Outputs"
             headerName="Output"
           />


### PR DESCRIPTION
# Summary

Moves the requirement dialog button into its own component for better organization and to reduce reuse.

# Testing Guidance

Dialog buttons should work as normal -- test the following:

- Test description
![Screenshot 2025-06-20 at 8 16 56 PM](https://github.com/user-attachments/assets/acf8017c-c11f-4be4-b987-d67ee1abdf26)

- Test group description
![Screenshot 2025-06-20 at 8 17 30 PM](https://github.com/user-attachments/assets/79127586-b734-48fc-84d4-0ebf24e34213)

- Nested test description (no examples in Requirements Suite)

