### PR TITLE
FI-4181: Make unmatched requirement ids a warning rather than an error

### DIFF
--- a/lib/inferno/apps/cli/requirements_coverage_checker.rb
+++ b/lib/inferno/apps/cli/requirements_coverage_checker.rb
@@ -176,7 +176,7 @@ module Inferno
         if File.exist?(output_file_path)
           if old_csv == new_csv
             puts "'#{output_file_name}' file is up to date."
-            return unless unmatched_requirement_ids.present?
+            return
           else
             puts <<~MESSAGE
               #{output_file_name} file is out of date.


### PR DESCRIPTION
This branch prevents the requirements coverage check command from failing when a suite declares requirements which aren't included in its requirement sets.