### PR TITLE
FI-4169: Support non-numeric requirement ids

### DIFF
--- a/lib/inferno/entities/requirement.rb
+++ b/lib/inferno/entities/requirement.rb
@@ -62,7 +62,7 @@ module Inferno
             requirement_ids =
               if actor.present?
                 return Repositories::Requirements.new.requirements_for_actor(current_set, actor).map(&:id)
-              elsif requirement_string.include? '-'
+              elsif requirement_string.include?('-') && !requirement_string.match?(/[^\d\-]/)
                 start_id, end_id = requirement_string.split('-')
                 if start_id.match?(/^\d+$/) && end_id.match?(/^\d+$/)
                   (start_id..end_id).to_a

--- a/spec/inferno/entities/requirement_spec.rb
+++ b/spec/inferno/entities/requirement_spec.rb
@@ -35,9 +35,9 @@ RSpec.describe Inferno::Entities::Requirement do
       expect(described_class.expand_requirement_ids(ids.join(','))).to eq(expected_ids)
     end
 
-    it 'ignores invalid non-numeric range boundaries' do
+    it 'does not treat hyphens in non-numeric ids as ranges' do
       ids = ['criteria3@a-b', 'criteria4@2', 'example-ig']
-      expected_ids = ['criteria4@2']
+      expected_ids = ['criteria3@a-b', 'criteria4@2', 'criteria4@example-ig']
 
       expect(described_class.expand_requirement_ids(ids.join(','))).to eq(expected_ids)
     end


### PR DESCRIPTION
This branch updates the requirements handling to support non-numeric requirement ids.