### PR TITLE
FI-4191: Fix requirements loading

### DIFF
--- a/client/src/components/App/__mocked_data__/mockData.ts
+++ b/client/src/components/App/__mocked_data__/mockData.ts
@@ -40,7 +40,7 @@ export const requirements = [
     conditionality: 'false',
     conformance: 'SHALL',
     requirement: 'Feugiat in ante metus dictum. Dignissim cras tincidunt lobortis feugiat.',
-    sub_requirements: [
+    subrequirements: [
       'sample-criteria-proposal@2',
       'sample-criteria-proposal@3',
       'sample-criteria-proposal@4',
@@ -54,7 +54,7 @@ export const requirements = [
     conditionality: 'false',
     conformance: 'SHALL',
     requirement: 'tempor incididunt ut labore et dolore magna aliqua',
-    sub_requirements: ['sample-criteria-proposal@3'],
+    subrequirements: ['sample-criteria-proposal@3'],
     url: 'https://hl7.org/fhir/R4/',
   },
 ];

--- a/client/src/models/testSuiteModels.ts
+++ b/client/src/models/testSuiteModels.ts
@@ -88,7 +88,7 @@ export type Requirement = {
   actor: string;
   conditionality: string;
   url?: string;
-  sub_requirements: string[];
+  subrequirements: string[];
   not_tested_reason?: string;
   not_tested_details?: string;
 };

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -844,7 +844,7 @@ definitions:
         type: "string"
       url:
         type: "string"
-      sub_requirements:
+      subrequirements:
         type: "array"
         items:
           type: "string"

--- a/lib/inferno/apps/cli/requirements.rb
+++ b/lib/inferno/apps/cli/requirements.rb
@@ -15,8 +15,6 @@ module Inferno
 
         require_relative '../../../inferno'
 
-        Inferno::Application.start(:requirements)
-
         RequirementsExporter.new.run
       end
 

--- a/lib/inferno/apps/cli/requirements_exporter.rb
+++ b/lib/inferno/apps/cli/requirements_exporter.rb
@@ -128,36 +128,36 @@ module Inferno
         @old_requirements_csv ||= File.read(requirements_output_file_path)
       end
 
-      def missing_sub_requirements
-        @missing_sub_requirements =
+      def missing_subrequirements
+        @missing_subrequirements =
           {}.tap do |missing_requirements|
             repo = Inferno::Repositories::Requirements.new
 
             input_requirement_sets
               .each do |requirement_set, requirements|
                 requirements.each do |requirement_hash|
-                  missing_sub_requirements =
+                  missing_subrequirements =
                     Inferno::Entities::Requirement.expand_requirement_ids(requirement_hash['Sub-Requirement(s)'])
                       .reject { |requirement_id| repo.exists? requirement_id }
 
-                  missing_sub_requirements += missing_actor_sub_requirements(requirement_hash['Sub-Requirement(s)'])
+                  missing_subrequirements += missing_actor_subrequirements(requirement_hash['Sub-Requirement(s)'])
 
-                  next if missing_sub_requirements.blank?
+                  next if missing_subrequirements.blank?
 
                   id = "#{requirement_set}@#{requirement_hash['ID*']}"
 
-                  missing_requirements[id] = missing_sub_requirements
+                  missing_requirements[id] = missing_subrequirements
                 end
               end
           end
       end
 
-      def missing_actor_sub_requirements(sub_requirement_string)
-        return [] if sub_requirement_string.blank?
+      def missing_actor_subrequirements(subrequirement_string)
+        return [] if subrequirement_string.blank?
 
-        return [] unless sub_requirement_string.include? '#'
+        return [] unless subrequirement_string.include? '#'
 
-        sub_requirement_string
+        subrequirement_string
           .split(',')
           .map(&:strip)
           .select { |requirement_string| requirement_string.include? '#' }
@@ -166,11 +166,11 @@ module Inferno
           end
       end
 
-      def check_sub_requirements
-        return if missing_sub_requirements.blank?
+      def check_subrequirements
+        return if missing_subrequirements.blank?
 
-        missing_sub_requirements.each do |id, sub_requirement_ids|
-          puts "#{id} is missing the following sub-requirements:\n  #{sub_requirement_ids.join(', ')}"
+        missing_subrequirements.each do |id, subrequirement_ids|
+          puts "#{id} is missing the following sub-requirements:\n  #{subrequirement_ids.join(', ')}"
         end
       end
 
@@ -198,7 +198,7 @@ module Inferno
 
         Inferno::Repositories::Requirements.new.insert_from_file(requirements_output_file_path)
 
-        check_sub_requirements
+        check_subrequirements
 
         puts 'Done.'
       end
@@ -230,9 +230,9 @@ module Inferno
           exit(1)
         end
 
-        check_sub_requirements
+        check_subrequirements
 
-        return if missing_sub_requirements.blank?
+        return if missing_subrequirements.blank?
 
         exit(1)
       end

--- a/lib/inferno/apps/cli/requirements_exporter.rb
+++ b/lib/inferno/apps/cli/requirements_exporter.rb
@@ -196,6 +196,8 @@ module Inferno
           File.write(requirements_output_file_path, new_requirements_csv, encoding: Encoding::UTF_8)
         end
 
+        Inferno::Repositories::Requirements.new.insert_from_file(requirements_output_file_path)
+
         check_sub_requirements
 
         puts 'Done.'

--- a/lib/inferno/apps/cli/requirements_exporter.rb
+++ b/lib/inferno/apps/cli/requirements_exporter.rb
@@ -196,7 +196,7 @@ module Inferno
           File.write(requirements_output_file_path, new_requirements_csv, encoding: Encoding::UTF_8)
         end
 
-        Inferno::Repositories::Requirements.new.insert_from_file(requirements_output_file_path)
+        Inferno::Application.start(:requirements)
 
         check_subrequirements
 

--- a/lib/inferno/apps/web/serializers/requirement.rb
+++ b/lib/inferno/apps/web/serializers/requirement.rb
@@ -9,7 +9,7 @@ module Inferno
         field :requirement
         field :conformance
         field :actors
-        field :sub_requirements
+        field :subrequirements
         field :conditionality
         field :url, if: :field_present?
         field :not_tested_reason, if: :field_present?

--- a/lib/inferno/entities/requirement.rb
+++ b/lib/inferno/entities/requirement.rb
@@ -13,6 +13,7 @@ module Inferno
         :conformance,
         :actors,
         :sub_requirements,
+        :sub_requirements_string,
         :conditionality,
         :not_tested_reason,
         :not_tested_details
@@ -26,6 +27,10 @@ module Inferno
         return unless requirement_set.blank? && (id&.include?('@') || id&.include?('#'))
 
         self.requirement_set = id.split(/[@#]/).first
+      end
+
+      def sub_requirements
+        @sub_requirements ||= self.class.expand_requirement_ids(sub_requirements_string, requirement_set)
       end
 
       # Expand a comma-delimited list of requirement id references into an Array

--- a/lib/inferno/entities/requirement.rb
+++ b/lib/inferno/entities/requirement.rb
@@ -12,8 +12,8 @@ module Inferno
         :requirement,
         :conformance,
         :actors,
-        :sub_requirements,
-        :sub_requirements_string,
+        :subrequirements,
+        :subrequirements_string,
         :conditionality,
         :not_tested_reason,
         :not_tested_details
@@ -29,8 +29,8 @@ module Inferno
         self.requirement_set = id.split(/[@#]/).first
       end
 
-      def sub_requirements
-        @sub_requirements ||= self.class.expand_requirement_ids(sub_requirements_string, requirement_set)
+      def subrequirements
+        @subrequirements ||= self.class.expand_requirement_ids(subrequirements_string, requirement_set)
       end
 
       # Expand a comma-delimited list of requirement id references into an Array

--- a/lib/inferno/repositories/requirements.rb
+++ b/lib/inferno/repositories/requirements.rb
@@ -14,12 +14,8 @@ module Inferno
 
           req_set = row[:req_set]
           id = row[:id]
-          sub_requirements_field = row[:subrequirements]
 
           combined_id = "#{req_set}@#{id}"
-
-          # Processing sub requirements: e.g. "170.315(g)(31)_hti-2-proposal@5,17,23,26,27,32,35,38-41"
-          sub_requirements = Inferno::Entities::Requirement.expand_requirement_ids(sub_requirements_field)
 
           result << {
             requirement_set: req_set,
@@ -28,7 +24,7 @@ module Inferno
             requirement: row[:requirement],
             conformance: row[:conformance],
             actors: row[:actors]&.split(',')&.map(&:strip) || [],
-            sub_requirements: sub_requirements,
+            sub_requirements_string: row[:subrequirements],
             conditionality: row[:conditionality]&.downcase,
             not_tested_reason: row[:not_tested_reason],
             not_tested_details: row[:not_tested_details]

--- a/lib/inferno/repositories/requirements.rb
+++ b/lib/inferno/repositories/requirements.rb
@@ -24,7 +24,7 @@ module Inferno
             requirement: row[:requirement],
             conformance: row[:conformance],
             actors: row[:actors]&.split(',')&.map(&:strip) || [],
-            sub_requirements_string: row[:subrequirements],
+            subrequirements_string: row[:subrequirements],
             conditionality: row[:conditionality]&.downcase,
             not_tested_reason: row[:not_tested_reason],
             not_tested_details: row[:not_tested_details]
@@ -104,7 +104,7 @@ module Inferno
 
         referenced_requirement_ids =
           requirements_to_process
-            .flat_map(&:sub_requirements)
+            .flat_map(&:subrequirements)
             .select do |requirement_id|
               referenced_requirement_sets.any? do |set|
                 requirement_id.start_with?("#{set.identifier}@") && find(requirement_id)&.actor?(set.actor)

--- a/spec/inferno/entities/requirement_spec.rb
+++ b/spec/inferno/entities/requirement_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Inferno::Entities::Requirement do
   describe '.expand_requirement_ids' do
-    it 'returns an empty array of there are no sub_requirements' do
+    it 'returns an empty array of there are no subrequirements' do
       expect(described_class.expand_requirement_ids(nil)).to eq([])
     end
 

--- a/spec/inferno/repositories/requirements_spec.rb
+++ b/spec/inferno/repositories/requirements_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Inferno::Repositories::Requirements do
           requirement_set: 'sample-criteria',
           conformance: 'SHALL',
           actors: ['Client'],
-          sub_requirements: ['sample-criteria@2'],
+          sub_requirements_string: 'sample-criteria@2',
           conditionality: 'false'
         }
       )
@@ -61,7 +61,6 @@ RSpec.describe Inferno::Repositories::Requirements do
           requirement_set: 'sample-criteria',
           conformance: 'SHALL',
           actors: ['Client', 'Server'],
-          sub_requirements: [],
           conditionality: 'false'
         }
       )
@@ -74,7 +73,6 @@ RSpec.describe Inferno::Repositories::Requirements do
           requirement_set: 'sample-criteria',
           conformance: 'SHALL',
           actors: ['Client'],
-          sub_requirements: [],
           conditionality: 'false',
           not_tested_reason: 'Not Tested',
           not_tested_details: 'NOT TESTED DETAILS'

--- a/spec/inferno/repositories/requirements_spec.rb
+++ b/spec/inferno/repositories/requirements_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Inferno::Repositories::Requirements do
           requirement_set: 'sample-criteria',
           conformance: 'SHALL',
           actors: ['Client'],
-          sub_requirements_string: 'sample-criteria@2',
+          subrequirements_string: 'sample-criteria@2',
           conditionality: 'false'
         }
       )

--- a/spec/requests/requirements_spec.rb
+++ b/spec/requests/requirements_spec.rb
@@ -3,7 +3,7 @@ require 'request_helper'
 RSpec.describe '/requirements' do
   let(:router) { Inferno::Web::Router }
   let(:repo) { Inferno::Repositories::Requirements.new }
-  let(:fields) { ['id', 'requirement', 'conformance', 'actors', 'conditionality', 'sub_requirements'] }
+  let(:fields) { ['id', 'requirement', 'conformance', 'actors', 'conditionality', 'subrequirements'] }
   let(:requirement_id) { 'sample-criteria-proposal@4' }
 
   describe 'show' do


### PR DESCRIPTION
This branch:
- loads requirements into the repository after export so that subrequirements can be properly evaluated when performing an export
- lazily loads subrequirements to avoid issues with the order in which requirement sets are loaded
- renames `sub_requirement` to `subrequirement` throughout the code