### PR TITLE
Fix navigator issue for patterIdentifier slices

### DIFF
--- a/lib/inferno/dsl/fhir_resource_navigation.rb
+++ b/lib/inferno/dsl/fhir_resource_navigation.rb
@@ -147,7 +147,7 @@ module Inferno
       end
 
       def matching_pattern_identifier_slice?(slice, discriminator)
-        slice.identifier.system == discriminator[:system]
+        slice.system == discriminator[:system]
       end
 
       def matching_value_slice?(slice, discriminator)

--- a/spec/fixtures/metadata/us_core_organization_v800.yml
+++ b/spec/fixtures/metadata/us_core_organization_v800.yml
@@ -1,0 +1,167 @@
+---
+:name: us_core_organization
+:class_name: USCorev800OrganizationSequence
+:version: v8.0.0
+:reformatted_version: v800
+:resource: Organization
+:profile_url: http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization
+:profile_name: US Core Organization Profile
+:profile_version: 8.0.0
+:title: Organization
+:short_description: Verify support for the server capabilities required by the US
+  Core Organization Profile.
+:is_delayed: true
+:interactions:
+- :code: create
+  :expectation: MAY
+- :code: search-type
+  :expectation: SHALL
+- :code: read
+  :expectation: SHALL
+- :code: vread
+  :expectation: SHOULD
+- :code: update
+  :expectation: MAY
+- :code: patch
+  :expectation: MAY
+- :code: delete
+  :expectation: MAY
+- :code: history-instance
+  :expectation: SHOULD
+- :code: history-type
+  :expectation: MAY
+:operations: []
+:searches:
+- :names:
+  - address
+  :expectation: SHALL
+  :names_not_must_support_or_mandatory: []
+  :must_support_or_mandatory: true
+- :names:
+  - name
+  :expectation: SHALL
+  :names_not_must_support_or_mandatory: []
+  :must_support_or_mandatory: true
+:search_definitions:
+  :address:
+    :paths:
+    - address
+    :full_paths:
+    - Organization.address
+    :comparators: {}
+    :values: []
+    :type: Address
+    :contains_multiple: true
+    :multiple_or: MAY
+  :name:
+    :paths:
+    - name
+    - alias
+    :full_paths:
+    - Organization.name
+    - Organization.alias
+    :comparators: {}
+    :values: []
+    :type: string
+    :contains_multiple: false
+    :multiple_or: MAY
+:include_params: []
+:revincludes: []
+:required_concepts: []
+:must_supports:
+  :extensions: []
+  :slices:
+  - :slice_id: Organization.identifier:NPI
+    :slice_name: NPI
+    :path: identifier
+    :discriminator:
+      :type: patternIdentifier
+      :path: ''
+      :system: http://hl7.org/fhir/sid/us-npi
+  :elements:
+  - :path: identifier
+  - :path: identifier.system
+  - :path: identifier.value
+  - :path: identifier:NPI.system
+  - :path: identifier:NPI.value
+  - :path: active
+  - :path: name
+  - :path: telecom
+  - :path: telecom.system
+  - :path: telecom.value
+  - :path: address
+  - :path: address.line
+  - :path: address.city
+  - :path: address.state
+  - :path: address.postalCode
+  - :path: address.country
+:mandatory_elements:
+- Organization.active
+- Organization.name
+:bindings:
+- :type: code
+  :strength: required
+  :system: http://hl7.org/fhir/ValueSet/identifier-use
+  :path: identifier.use
+- :type: code
+  :strength: required
+  :system: http://hl7.org/fhir/ValueSet/identifier-use
+  :path: identifier.use
+- :type: code
+  :strength: required
+  :system: http://hl7.org/fhir/ValueSet/identifier-use
+  :path: identifier.use
+- :type: code
+  :strength: required
+  :system: http://hl7.org/fhir/ValueSet/identifier-use
+  :path: identifier.use
+- :type: code
+  :strength: required
+  :system: http://hl7.org/fhir/ValueSet/contact-point-system
+  :path: telecom.system
+- :type: code
+  :strength: required
+  :system: http://hl7.org/fhir/ValueSet/contact-point-use
+  :path: telecom.use
+- :type: code
+  :strength: required
+  :system: http://hl7.org/fhir/ValueSet/address-use
+  :path: address.use
+- :type: code
+  :strength: required
+  :system: http://hl7.org/fhir/ValueSet/address-type
+  :path: address.type
+:references:
+- :path: Organization.identifier.assigner
+  :profiles:
+  - http://hl7.org/fhir/StructureDefinition/Organization
+- :path: Organization.identifier.assigner
+  :profiles:
+  - http://hl7.org/fhir/StructureDefinition/Organization
+- :path: Organization.identifier.assigner
+  :profiles:
+  - http://hl7.org/fhir/StructureDefinition/Organization
+- :path: Organization.identifier.assigner
+  :profiles:
+  - http://hl7.org/fhir/StructureDefinition/Organization
+- :path: Organization.partOf
+  :profiles:
+  - http://hl7.org/fhir/StructureDefinition/Organization
+- :path: Organization.endpoint
+  :profiles:
+  - http://hl7.org/fhir/StructureDefinition/Endpoint
+:tests:
+- :id: us_core_v800_organization_read_test
+  :file_name: organization_read_test.rb
+- :id: us_core_v800_organization_address_search_test
+  :file_name: organization_address_search_test.rb
+- :id: us_core_v800_organization_name_search_test
+  :file_name: organization_name_search_test.rb
+- :id: us_core_v800_organization_validation_test
+  :file_name: organization_validation_test.rb
+- :id: us_core_v800_organization_must_support_test
+  :file_name: organization_must_support_test.rb
+:id: us_core_v800_organization
+:file_name: organization_group.rb
+:delayed_references: []
+:resource_conformance_expectation: SHALL

--- a/spec/inferno/dsl/must_support_assessment_spec.rb
+++ b/spec/inferno/dsl/must_support_assessment_spec.rb
@@ -972,6 +972,44 @@ RSpec.describe Inferno::DSL::MustSupportAssessment do
       end
     end
 
+    let(:organization_metadata) { metadata_fixture('us_core_organization_v800.yml') }
+    let(:organization) do
+      FHIR::Organization.new(
+        identifier: [
+          type: {
+            coding: [
+              {
+                system: 'http://terminology.hl7.org/CodeSystem/v2-0203',
+                code: 'NPI'
+              }
+            ]
+          },
+          system: 'http://hl7.org/fhir/sid/us-npi',
+          value: '9941339100'
+        ],
+        active: true,
+          name: 'Orange Medical Group',
+          telecom: [
+            {
+              system: 'phone',
+              value: '(555)555-5510',
+              rank: 1
+            }
+          ],
+        address: [
+          {
+            line: [
+              'Attn: Orange Medical Group'
+            ],
+            city: 'Pittsburgh',
+            state: 'PA',
+            postalCode: '15222',
+            country: 'USA'
+          }
+        ]
+      )
+    end
+
     it 'passes if resources cover all must support sub elements of slices' do
       result = run_with_metadata([coverage_with_two_classes], coverage_metadata)
       expect(result).to be_empty
@@ -992,6 +1030,11 @@ RSpec.describe Inferno::DSL::MustSupportAssessment do
       coverage_with_just_plan.local_class = [plan_class]
 
       result = run_with_metadata([coverage_with_two_classes], coverage_metadata)
+      expect(result).to be_empty
+    end
+
+    it 'passes if resources covers sliced identifier subelements for patternIdentifier' do
+      result = run_with_metadata([organization], organization_metadata)
       expect(result).to be_empty
     end
   end


### PR DESCRIPTION
# Summary
This PR fixed a bug found in US Core v8 Organization must support testing.

When there's must support sub element in an identifier, such as in US Core v8 Organzation profile:
* identifier:NPI.system
* identifier:NPI.value

US Core test incorrectly reports that system does not support these elements.

The problem is in the navigator method `matching_pattern_identifier_slice`, which incorrectly uses `slice.identifier.syste`. The slice paramter value passed in is already an identifier data.

# What's changed:
* Fix bug in fhir_resource_navigator
* Add a unit test

# Testing Guidance

All unit test shall pass

