### PR TITLE
FI-4175: Add not tested detail to requirements

### DIFF
--- a/client/src/components/TestSuite/Requirements/RequirementContent.tsx
+++ b/client/src/components/TestSuite/Requirements/RequirementContent.tsx
@@ -74,6 +74,7 @@ const RequirementContent: FC<RequirementContentProps> = ({
               sx={{ color: lightTheme.palette.common.orangeDark }}
             >
               {requirement.not_tested_reason}
+              {requirement.not_tested_details && `: ${requirement.not_tested_details}`}{' '}
             </Typography>
           ) : (
             <Typography ml={0} variant="body2" fontWeight="bold">


### PR DESCRIPTION
# Summary

Adds not tested details to individual requirements:

<img width="488" alt="Screenshot 2025-07-02 at 3 18 08 PM" src="https://github.com/user-attachments/assets/e71fd119-ee9e-44a2-85f7-2b44a4aa8a4b" />

# Testing Guidance

Check that this is showing up correctly in the requirements page. Styling feedback?
