### PR TITLE
FI-4199: Remove requirements feature flag

### DIFF
--- a/.env
+++ b/.env
@@ -36,6 +36,3 @@ MAX_IO_DISPLAY_CHAR=10000
 # Set to false to skip initializing validator sessions in the hl7 validator
 # service.
 # INITIALIZE_VALIDATOR_SESSIONS=false
-
-# When not true, requirements will not be sent via the JSON API
-ENABLE_REQUIREMENTS=true

--- a/lib/inferno/apps/web/router.rb
+++ b/lib/inferno/apps/web/router.rb
@@ -51,17 +51,13 @@ module Inferno
           put '/:id/check_configuration',
               to: Inferno::Web::Controllers::TestSuites::CheckConfiguration,
               as: :check_configuration
-          if Feature.requirements_enabled?
-            get ':id/requirements',
-                to: Inferno::Web::Controllers::TestSuites::Requirements::Index,
-                as: :requirements
-          end
+          get ':id/requirements',
+              to: Inferno::Web::Controllers::TestSuites::Requirements::Index,
+              as: :requirements
         end
 
-        if Feature.requirements_enabled?
-          scope 'requirements' do
-            get '/:id', to: Inferno::Web::Controllers::Requirements::Show, as: :show
-          end
+        scope 'requirements' do
+          get '/:id', to: Inferno::Web::Controllers::Requirements::Show, as: :show
         end
 
         get '/requests/:id', to: Inferno::Web::Controllers::Requests::Show, as: :requests_show

--- a/lib/inferno/apps/web/serializers/serializer.rb
+++ b/lib/inferno/apps/web/serializers/serializer.rb
@@ -14,12 +14,6 @@ module Inferno
             result.send(name).present?
           end
         end
-
-        # When removing the feature flag, replace all instances of this method
-        # with `.field_present?`
-        def self.field_present_and_requirements_enabled?(field_name, result, options)
-          field_present?(field_name, result, options) && Feature.requirements_enabled?
-        end
       end
     end
   end

--- a/lib/inferno/apps/web/serializers/test.rb
+++ b/lib/inferno/apps/web/serializers/test.rb
@@ -20,7 +20,7 @@ module Inferno
         field :input_instructions
         field :user_runnable?, name: :user_runnable
         field :optional?, name: :optional
-        field :verifies_requirements, if: :field_present_and_requirements_enabled?
+        field :verifies_requirements, if: :field_present?
       end
     end
   end

--- a/lib/inferno/apps/web/serializers/test_group.rb
+++ b/lib/inferno/apps/web/serializers/test_group.rb
@@ -32,7 +32,7 @@ module Inferno
           Input.render_as_hash(group.available_inputs(suite_options).values)
         end
         field :output_definitions, name: :outputs, extractor: HashValueExtractor
-        field :verifies_requirements, if: :field_present_and_requirements_enabled?
+        field :verifies_requirements, if: :field_present?
       end
     end
   end

--- a/lib/inferno/apps/web/serializers/test_suite.rb
+++ b/lib/inferno/apps/web/serializers/test_suite.rb
@@ -38,7 +38,7 @@ module Inferno
             suite_options = options[:suite_options]
             Input.render_as_hash(suite.available_inputs(suite_options).values)
           end
-          field :requirement_sets, if: :field_present_and_requirements_enabled? do |suite, options|
+          field :requirement_sets, if: :field_present? do |suite, options|
             selected_options = options[:suite_options] || []
             requirement_sets = suite.requirement_sets.select do |requirement_set|
               requirement_set.suite_options.all? { |suite_option| selected_options.include? suite_option }
@@ -46,7 +46,7 @@ module Inferno
 
             RequirementSet.render_as_hash(requirement_sets)
           end
-          field :verifies_requirements, if: :field_present_and_requirements_enabled?
+          field :verifies_requirements, if: :field_present?
         end
       end
     end

--- a/lib/inferno/feature.rb
+++ b/lib/inferno/feature.rb
@@ -1,10 +1,6 @@
 module Inferno
   module Feature
     class << self
-      def requirements_enabled?
-        ENV.fetch('ENABLE_REQUIREMENTS', 'false')&.casecmp?('true')
-      end
-
       def use_validation_context_key?
         ENV.fetch('USE_VALIDATION_CONTEXT', 'false')&.casecmp?('true')
       end

--- a/spec/inferno/web/serializers/test_suite_spec.rb
+++ b/spec/inferno/web/serializers/test_suite_spec.rb
@@ -100,15 +100,4 @@ RSpec.describe Inferno::Web::Serializers::TestSuite do
 
     expect(serialized_suite['requirement_sets'].length).to eq(2)
   end
-
-  context 'when requirments feature flag is not set' do
-    it 'does not include requirements fields' do
-      allow(Inferno::Feature).to receive(:requirements_enabled?).and_return(false)
-
-      serialized_suite = JSON.parse(described_class.render(suite, view: :full))
-
-      expect(serialized_suite).to include('id')
-      expect(serialized_suite).to_not include('verifies_requirements')
-    end
-  end
 end


### PR DESCRIPTION
The requirements feature is complete, so the feature flag can be removed and they can always be enabled.

If you run core and load the requirements suite, you will see the requirements in the UI even though the feature flag is no longer set.