### PR TITLE
FI-4242: Filter runnable requirements in serializers

### DIFF
--- a/dev_suites/dev_requirements/requirements_suite.rb
+++ b/dev_suites/dev_requirements/requirements_suite.rb
@@ -17,6 +17,8 @@ module RequirementsSuite
       }
     )
 
+    verifies_requirements 'sample-criteria-proposal-5@3'
+
     group do
       title 'Group 1'
       group do
@@ -68,6 +70,20 @@ module RequirementsSuite
 
       test do
         title 'Requirement 7'
+        run { pass }
+      end
+    end
+
+    group do
+      title 'Requirements not in requirement sets'
+
+      verifies_requirements 'sample-criteria-proposal-5@2'
+
+      test do
+        title 'Requirement 6'
+
+        verifies_requirements 'sample-criteria-proposal@6', 'sample-criteria-proposal-5@1'
+
         run { pass }
       end
     end

--- a/lib/inferno/apps/web/serializers/requirements_filtering_extractor.rb
+++ b/lib/inferno/apps/web/serializers/requirements_filtering_extractor.rb
@@ -1,0 +1,17 @@
+module Inferno
+  module Web
+    module Serializers
+      class RequirementsFilteringExtractor < Blueprinter::Extractor
+        def extract(_field_name, runnable, local_options, _options)
+          if local_options[:suite_requirement_ids].blank?
+            runnable.verifies_requirements
+          else
+            runnable.verifies_requirements.select do |requirement_id|
+              local_options[:suite_requirement_ids].include? requirement_id
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/inferno/apps/web/serializers/test.rb
+++ b/lib/inferno/apps/web/serializers/test.rb
@@ -25,7 +25,7 @@ module Inferno
             test.verifies_requirements
           else
             test.verifies_requirements.select do |requirement_id|
-              test_requirement_ids.include? requirement_id
+              options[:suite_requirement_ids].include? requirement_id
             end
           end
         end

--- a/lib/inferno/apps/web/serializers/test.rb
+++ b/lib/inferno/apps/web/serializers/test.rb
@@ -20,7 +20,15 @@ module Inferno
         field :input_instructions
         field :user_runnable?, name: :user_runnable
         field :optional?, name: :optional
-        field :verifies_requirements, if: :field_present?
+        field :verifies_requirements, if: :field_present? do |test, options|
+          if options[:suite_requirement_ids].blank?
+            test.verifies_requirements
+          else
+            test.verifies_requirements.select do |requirement_id|
+              test_requirement_ids.include? requirement_id
+            end
+          end
+        end
       end
     end
   end

--- a/lib/inferno/apps/web/serializers/test.rb
+++ b/lib/inferno/apps/web/serializers/test.rb
@@ -1,5 +1,6 @@
 require_relative 'hash_value_extractor'
 require_relative 'input'
+require_relative 'requirements_filtering_extractor'
 
 module Inferno
   module Web
@@ -20,15 +21,7 @@ module Inferno
         field :input_instructions
         field :user_runnable?, name: :user_runnable
         field :optional?, name: :optional
-        field :verifies_requirements, if: :field_present? do |test, options|
-          if options[:suite_requirement_ids].blank?
-            test.verifies_requirements
-          else
-            test.verifies_requirements.select do |requirement_id|
-              options[:suite_requirement_ids].include? requirement_id
-            end
-          end
-        end
+        field :verifies_requirements, if: :field_present?, extractor: RequirementsFilteringExtractor
       end
     end
   end

--- a/lib/inferno/apps/web/serializers/test_group.rb
+++ b/lib/inferno/apps/web/serializers/test_group.rb
@@ -21,18 +21,28 @@ module Inferno
         end
         field :test_groups do |group, options|
           suite_options = options[:suite_options]
-          TestGroup.render_as_hash(group.groups(suite_options), suite_options:)
+          suite_requirement_ids = options[:suite_requirement_ids]
+          TestGroup.render_as_hash(group.groups(suite_options), suite_options:, suite_requirement_ids:)
         end
         field :tests do |group, options|
           suite_options = options[:suite_options]
-          Test.render_as_hash(group.tests(suite_options), suite_options:)
+          suite_requirement_ids = options[:suite_requirement_ids]
+          Test.render_as_hash(group.tests(suite_options), suite_options:, suite_requirement_ids:)
         end
         field :inputs do |group, options|
           suite_options = options[:suite_options]
           Input.render_as_hash(group.available_inputs(suite_options).values)
         end
         field :output_definitions, name: :outputs, extractor: HashValueExtractor
-        field :verifies_requirements, if: :field_present?
+        field :verifies_requirements, if: :field_present? do |group, options|
+          if options[:suite_requirement_ids].blank?
+            group.verifies_requirements
+          else
+            group.verifies_requirements.select do |requirement_id|
+              group_requirement_ids.include? requirement_id
+            end
+          end
+        end
       end
     end
   end

--- a/lib/inferno/apps/web/serializers/test_group.rb
+++ b/lib/inferno/apps/web/serializers/test_group.rb
@@ -39,7 +39,7 @@ module Inferno
             group.verifies_requirements
           else
             group.verifies_requirements.select do |requirement_id|
-              group_requirement_ids.include? requirement_id
+              options[:suite_requirement_ids].include? requirement_id
             end
           end
         end

--- a/lib/inferno/apps/web/serializers/test_group.rb
+++ b/lib/inferno/apps/web/serializers/test_group.rb
@@ -1,3 +1,5 @@
+require_relative 'hash_value_extractor'
+require_relative 'requirements_filtering_extractor'
 require_relative 'test'
 
 module Inferno
@@ -34,15 +36,7 @@ module Inferno
           Input.render_as_hash(group.available_inputs(suite_options).values)
         end
         field :output_definitions, name: :outputs, extractor: HashValueExtractor
-        field :verifies_requirements, if: :field_present? do |group, options|
-          if options[:suite_requirement_ids].blank?
-            group.verifies_requirements
-          else
-            group.verifies_requirements.select do |requirement_id|
-              options[:suite_requirement_ids].include? requirement_id
-            end
-          end
-        end
+        field :verifies_requirements, if: :field_present?, extractor: RequirementsFilteringExtractor
       end
     end
   end

--- a/lib/inferno/apps/web/serializers/test_session.rb
+++ b/lib/inferno/apps/web/serializers/test_session.rb
@@ -10,8 +10,18 @@ module Inferno
         field :test_suite_id
         association :suite_options, blueprint: SuiteOption
 
-        field :test_suite do |session, _options|
-          TestSuite.render_as_hash(session.test_suite, view: :full, suite_options: session.suite_options)
+        field :test_suite do |test_session, _options|
+          suite_requirement_ids =
+            Inferno::Repositories::Requirements.new
+              .requirements_for_suite(test_session.test_suite_id, test_session.id)
+              .map(&:id)
+
+          TestSuite.render_as_hash(
+            test_session.test_suite,
+            view: :full,
+            suite_options: test_session.suite_options,
+            suite_requirement_ids:
+          )
         end
       end
     end

--- a/lib/inferno/apps/web/serializers/test_suite.rb
+++ b/lib/inferno/apps/web/serializers/test_suite.rb
@@ -53,7 +53,7 @@ module Inferno
               suite.verifies_requirements
             else
               suite.verifies_requirements.select do |requirement_id|
-                suite_requirement_ids.include? requirement_id
+                options[:suite_requirement_ids].include? requirement_id
               end
             end
           end

--- a/lib/inferno/apps/web/serializers/test_suite.rb
+++ b/lib/inferno/apps/web/serializers/test_suite.rb
@@ -1,4 +1,5 @@
 require_relative 'preset'
+require_relative 'requirements_filtering_extractor'
 require_relative 'requirement_set'
 require_relative 'suite_option'
 require_relative 'test_group'
@@ -48,15 +49,7 @@ module Inferno
 
             RequirementSet.render_as_hash(requirement_sets)
           end
-          field :verifies_requirements, if: :field_present? do |suite, options|
-            if options[:suite_requirement_ids].blank?
-              suite.verifies_requirements
-            else
-              suite.verifies_requirements.select do |requirement_id|
-                options[:suite_requirement_ids].include? requirement_id
-              end
-            end
-          end
+          field :verifies_requirements, if: :field_present?, extractor: RequirementsFilteringExtractor
         end
       end
     end

--- a/lib/inferno/apps/web/serializers/test_suite.rb
+++ b/lib/inferno/apps/web/serializers/test_suite.rb
@@ -36,7 +36,8 @@ module Inferno
 
           field :test_groups do |suite, options|
             suite_options = options[:suite_options]
-            TestGroup.render_as_hash(suite.groups(suite_options), suite_options:)
+            suite_requirement_ids = options[:suite_requirement_ids]
+            TestGroup.render_as_hash(suite.groups(suite_options), suite_options:, suite_requirement_ids:)
           end
           field :configuration_messages
           field :requirement_sets, if: :field_present? do |suite, options|
@@ -47,7 +48,15 @@ module Inferno
 
             RequirementSet.render_as_hash(requirement_sets)
           end
-          field :verifies_requirements, if: :field_present?
+          field :verifies_requirements, if: :field_present? do |suite, options|
+            if options[:suite_requirement_ids].blank?
+              suite.verifies_requirements
+            else
+              suite.verifies_requirements.select do |requirement_id|
+                suite_requirement_ids.include? requirement_id
+              end
+            end
+          end
         end
       end
     end

--- a/spec/fixtures/requirements/ig_requirements_requirements_coverage.csv
+++ b/spec/fixtures/requirements/ig_requirements_requirements_coverage.csv
@@ -4,7 +4,7 @@ sample-criteria-proposal,2,https://hl7.org/fhir/R4/,tempor incididunt ut labore 
 sample-criteria-proposal,3,https://hl7.org/fhir/R4/,"Lorem ipsum dolor sit amet, consectetur adipiscing elit",SHALL,Client,false,,,1.2,ig_requirements-Group01-Group02
 sample-criteria-proposal,4,,Consequat mauris nunc congue nisi vitae suscipit tellus mauris.,SHALL,Client,false,,,1.2,ig_requirements-Group01-Group02
 sample-criteria-proposal,5,,condimentum vitae sapien pellentesque habitant morbi tristique senectus,SHALL,Client,true,,,1.1.03,ig_requirements-Group01-Group01-Test03
-sample-criteria-proposal,6,,Faucibus scelerisque eleifend donec pretium vulputate sapien nec sagittis,SHALL,Client,true,,,2,ig_requirements-Group02
+sample-criteria-proposal,6,,Faucibus scelerisque eleifend donec pretium vulputate sapien nec sagittis,SHALL,Client,true,,,"2, 3.01","ig_requirements-Group02, ig_requirements-Group03-Test01"
 sample-criteria-proposal,7,,Nulla facilisi nullam vehicula ipsum a,SHALL,Client,false,,,2,ig_requirements-Group02
 sample-criteria-proposal-4,1,,text1,SHALL,Client,false,Not Tested,NOT TESTED DETAILS,NA,NA
 sample-criteria-proposal-4,2,,text2,SHALL,Client,false,Not Verifiable,NOT VERIFIABLE DETAILS,NA,NA

--- a/spec/inferno/web/serializers/test_group_spec.rb
+++ b/spec/inferno/web/serializers/test_group_spec.rb
@@ -82,4 +82,20 @@ RSpec.describe Inferno::Web::Serializers::TestGroup do
     expect(recieved_groups).to eq(expected_groups)
     expect(serialized_group['test_count']).to eq(4)
   end
+
+  context 'when part of a session' do
+    let(:group) { RequirementsSuite::Suite.groups.last }
+    let(:session) { repo_create(:test_session, test_suite_id: RequirementsSuite::Suite.id) }
+    let(:suite_requirement_ids) do
+      Inferno::Repositories::Requirements.new
+        .requirements_for_suite(session.test_suite_id, session.id)
+        .map(&:id)
+    end
+
+    it 'excludes requirements which not in the suite requirement sets' do
+      serialized_group = JSON.parse(described_class.render(group, suite_requirement_ids:))
+
+      expect(serialized_group['verifies_requirements']).to eq([])
+    end
+  end
 end

--- a/spec/inferno/web/serializers/test_spec.rb
+++ b/spec/inferno/web/serializers/test_spec.rb
@@ -44,4 +44,20 @@ RSpec.describe Inferno::Web::Serializers::Test do
       end
     end
   end
+
+  context 'when part of a session' do
+    let(:test) { RequirementsSuite::Suite.groups.last.tests.first }
+    let(:session) { repo_create(:test_session, test_suite_id: RequirementsSuite::Suite.id) }
+    let(:suite_requirement_ids) do
+      Inferno::Repositories::Requirements.new
+        .requirements_for_suite(session.test_suite_id, session.id)
+        .map(&:id)
+    end
+
+    it 'excludes requirements which not in the suite requirement sets' do
+      serialized_test = JSON.parse(described_class.render(test, suite_requirement_ids:))
+
+      expect(serialized_test['verifies_requirements']).to eq(['sample-criteria-proposal@6'])
+    end
+  end
 end

--- a/spec/inferno/web/serializers/test_suite_spec.rb
+++ b/spec/inferno/web/serializers/test_suite_spec.rb
@@ -101,4 +101,20 @@ RSpec.describe Inferno::Web::Serializers::TestSuite do
 
     expect(serialized_suite['requirement_sets'].length).to eq(2)
   end
+
+  context 'when part of a session' do
+    let(:suite) { RequirementsSuite::Suite }
+    let(:session) { repo_create(:test_session, test_suite_id: suite.id) }
+    let(:suite_requirement_ids) do
+      Inferno::Repositories::Requirements.new
+        .requirements_for_suite(session.test_suite_id, session.id)
+        .map(&:id)
+    end
+
+    it 'excludes requirements which not in the suite requirement sets' do
+      serialized_suite = JSON.parse(described_class.render(suite, suite_requirement_ids:, view: :full))
+
+      expect(serialized_suite['verifies_requirements']).to eq([])
+    end
+  end
 end


### PR DESCRIPTION
# Summary
This branch updates the suite/group/test serializers to filter `verifies_requirements` to only include the requirements which are part of the requirement sets defined in the suite.

On prod:
<img width="1353" height="937" alt="Screenshot 2025-07-18 at 8 02 13 AM" src="https://github.com/user-attachments/assets/5718d011-bb2c-4858-b1db-92449d1ae1ff" />

On this branch:
<img width="1345" height="933" alt="Screenshot 2025-07-18 at 8 03 33 AM" src="https://github.com/user-attachments/assets/942cc12b-c243-4669-8fb4-390511c23822" />

# Testing Guidance
You can follow the instructions in the Gemfile to load up g10 and verify that the requirements are filtered.

