### PR TITLE
Fix publish script

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -2,7 +2,7 @@
 set -e
 
 npm install
-rm -f lib/inferno/public/*.js
+rm -f lib/inferno/public/*bundle.js
 npm run build
 gem build inferno_core.gemspec
 gem push inferno_core*.gem


### PR DESCRIPTION
Some new js files have been added to `lib/inferno/public/`, so the gem publishing script needs to be updated so that it doesn't delete them.