### PR TITLE
FI-4252: Use a temporary redirect for root test kit page

### DIFF
--- a/lib/inferno/apps/web/router.rb
+++ b/lib/inferno/apps/web/router.rb
@@ -79,7 +79,7 @@ module Inferno
             local_test_kit = Inferno::Repositories::TestKits.new.local_test_kit
             if local_test_kit.present?
               base = Inferno::Application['base_path'].present? ? "/#{Inferno::Application['base_path']}" : ''
-              [301, { 'Location' => "#{base}/#{local_test_kit.url_fragment}" }, []]
+              [302, { 'Location' => "#{base}/#{local_test_kit.url_fragment}" }, []]
             else
               CLIENT_PAGE_RESPONSE.call(env)
             end

--- a/lib/inferno/apps/web/router.rb
+++ b/lib/inferno/apps/web/router.rb
@@ -79,7 +79,14 @@ module Inferno
             local_test_kit = Inferno::Repositories::TestKits.new.local_test_kit
             if local_test_kit.present?
               base = Inferno::Application['base_path'].present? ? "/#{Inferno::Application['base_path']}" : ''
-              [302, { 'Location' => "#{base}/#{local_test_kit.url_fragment}" }, []]
+              [
+                302,
+                {
+                  'Cache-Control' => 'no-cache',
+                  'Location' => "#{base}/#{local_test_kit.url_fragment}"
+                },
+                []
+              ]
             else
               CLIENT_PAGE_RESPONSE.call(env)
             end


### PR DESCRIPTION
Use a temporary rather than permanent redirect and add cache-control header for the test kit page to prevent the browser from caching the redirect.