### PR TITLE
FI-4253: Fix test suite API performance issue

### DIFF
--- a/lib/inferno/apps/web/serializers/test_suite.rb
+++ b/lib/inferno/apps/web/serializers/test_suite.rb
@@ -23,11 +23,6 @@ module Inferno
             suite.test_count(options[:suite_options])
           end
 
-          field :inputs do |suite, options|
-            suite_options = options[:suite_options]
-            Input.render_as_hash(suite.available_inputs(suite_options).values)
-          end
-
           association :suite_options, blueprint: SuiteOption
           association :presets, view: :summary, blueprint: Preset
         end
@@ -41,6 +36,10 @@ module Inferno
             TestGroup.render_as_hash(suite.groups(suite_options), suite_options:, suite_requirement_ids:)
           end
           field :configuration_messages
+          field :inputs do |suite, options|
+            suite_options = options[:suite_options]
+            Input.render_as_hash(suite.available_inputs(suite_options).values)
+          end
           field :requirement_sets, if: :field_present? do |suite, options|
             selected_options = options[:suite_options] || []
             requirement_sets = suite.requirement_sets.select do |requirement_set|

--- a/spec/inferno/web/serializers/test_suite_spec.rb
+++ b/spec/inferno/web/serializers/test_suite_spec.rb
@@ -16,12 +16,11 @@ RSpec.describe Inferno::Web::Serializers::TestSuite do
       'presets',
       'suite_options',
       'links',
-      'suite_summary',
-      'inputs'
+      'suite_summary'
     ]
   end
   let(:full_keys) do
-    summary_keys + ['configuration_messages', 'test_groups', 'verifies_requirements']
+    summary_keys + ['configuration_messages', 'test_groups', 'inputs', 'verifies_requirements']
   end
 
   it 'serializes a suite summary view' do


### PR DESCRIPTION
# Summary
This branch reverts the move of inputs from the full suite view to the summary view. The UI currently loads summaries for all suites when starting a session, and including the inputs makes this very slow.

# Testing Guidance
Use the instructions in the Gemfile to load g10 (I pointed to a local copy of `main` rather than the latest release). Open the network tab in your browser inspector and look at the performance of the suites call on this branch vs on `main`.

On `main`:
<img width="149" height="287" alt="Screenshot 2025-07-23 at 9 20 26 AM" src="https://github.com/user-attachments/assets/85a7cc34-d06e-4680-a8e0-47df62e7e633" />

On this branch:
<img width="125" height="235" alt="Screenshot 2025-07-23 at 9 19 12 AM" src="https://github.com/user-attachments/assets/eb6259a5-fdba-4253-ab8e-ec2362badaaa" />
