### PR TITLE
FI-3819: Update view only color

### DIFF
--- a/client/src/components/InputsModal/Auth/InputAuth.tsx
+++ b/client/src/components/InputsModal/Auth/InputAuth.tsx
@@ -13,6 +13,7 @@ import FieldLabel from '~/components/InputsModal/FieldLabel';
 import InputFields from '~/components/InputsModal/InputFields';
 import { isJsonString } from '~/components/InputsModal/InputHelpers';
 import { useTestSessionStore } from '~/store/testSession';
+import lightTheme from '~/styles/theme';
 import useStyles from '../styles';
 
 export interface InputAuthProps {
@@ -173,7 +174,12 @@ const InputAuth: FC<InputAuthProps> = ({ mode, input, index, inputsMap, setInput
 
   return (
     <ListItem>
-      <Card variant="outlined" tabIndex={0} className={classes.authCard}>
+      <Card
+        variant="outlined"
+        tabIndex={0}
+        className={classes.authCard}
+        sx={input.locked || viewOnly ? {} : { borderColor: lightTheme.palette.common.gray }}
+      >
         <CardContent>
           <InputLabel
             tabIndex={0}

--- a/client/src/components/InputsModal/InputOAuthCredentials.tsx
+++ b/client/src/components/InputsModal/InputOAuthCredentials.tsx
@@ -8,7 +8,6 @@ import {
   InputLabel,
   List,
   ListItem,
-  ListItemButton,
   Typography,
 } from '@mui/material';
 import Markdown from 'react-markdown';
@@ -122,12 +121,7 @@ const InputOAuthCredentials: FC<InputOAuthCredentialsProps> = ({
     );
 
     return (
-      <ListItemButton
-        disabled={field.locked || viewOnly}
-        key={field.name}
-        component="li"
-        className={classes.inputField}
-      >
+      <ListItem key={field.name} component="li" className={classes.inputField}>
         <FormControl
           component="fieldset"
           id={`input${index}_input`}
@@ -166,7 +160,7 @@ const InputOAuthCredentials: FC<InputOAuthCredentialsProps> = ({
             onChange={(event) => updateInputsMap(field, event.target.value)}
           />
         </FormControl>
-      </ListItemButton>
+      </ListItem>
     );
   };
 

--- a/client/src/components/InputsModal/InputOAuthCredentials.tsx
+++ b/client/src/components/InputsModal/InputOAuthCredentials.tsx
@@ -17,6 +17,7 @@ import { OAuthCredentials, TestInput } from '~/models/testSuiteModels';
 import FieldLabel from '~/components/InputsModal/FieldLabel';
 import RequiredInputWarning from '~/components/InputsModal/RequiredInputWarning';
 import { useTestSessionStore } from '~/store/testSession';
+import lightTheme from '~/styles/theme';
 import useStyles from './styles';
 
 export interface InputOAuthCredentialsProps {
@@ -171,7 +172,11 @@ const InputOAuthCredentials: FC<InputOAuthCredentialsProps> = ({
 
   return (
     <ListItem>
-      <Card variant="outlined" className={classes.authCard}>
+      <Card
+        variant="outlined"
+        className={classes.authCard}
+        sx={input.locked || viewOnly ? {} : { borderColor: lightTheme.palette.common.gray }}
+      >
         <CardContent>
           <InputLabel
             required={!input.optional}

--- a/client/src/components/InputsModal/styles.tsx
+++ b/client/src/components/InputsModal/styles.tsx
@@ -49,10 +49,6 @@ export default makeStyles()((theme: Theme) => ({
   },
   authCard: {
     width: '100%',
-    borderColor: theme.palette.common.gray,
-    '& :focus-within': {
-      borderColor: theme.palette.secondary.main,
-    },
   },
   serialInput: {
     height: 'max-content',

--- a/client/src/components/InputsModal/styles.tsx
+++ b/client/src/components/InputsModal/styles.tsx
@@ -16,9 +16,6 @@ export default makeStyles()((theme: Theme) => ({
     '& > label.Mui-focused': {
       color: theme.palette.secondary.main,
     },
-    '& > label.Mui-disabled': {
-      color: theme.palette.common.gray,
-    },
     '& > label.Mui-error': {
       color: theme.palette.error.main,
     },


### PR DESCRIPTION
# Summary

Corrects some color errors in the Auth and OAuth inputs, particularly in view-only mode.

# Testing Guidance

Check that these changes are visible:

### On focus in the OAuth input fields, the fields should no longer have a gray background

OLD

<img width="522" height="272" alt="Screenshot 2025-07-25 at 1 42 14 PM" src="https://github.com/user-attachments/assets/5719140f-23bf-4f7c-96e8-8474c94a272d" />


NEW

<img width="534" height="280" alt="Screenshot 2025-07-25 at 1 41 59 PM" src="https://github.com/user-attachments/assets/ab1ff07f-6bd1-4635-92ba-2f4148e3f12d" />

### In view-only mode in the OAuth and Auth input cards, the card border and field text should be a lighter gray

OLD

<img width="619" height="521" alt="Screenshot 2025-07-25 at 2 06 12 PM" src="https://github.com/user-attachments/assets/de5abc9a-33ec-4d75-9dac-9aefe76da87e" />


NEW

<img width="626" height="548" alt="Screenshot 2025-07-25 at 1 41 02 PM" src="https://github.com/user-attachments/assets/d2834409-1b1a-4c24-873a-dc07d6d9b775" />

