### PR TITLE
rename view only to read only

### DIFF
--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -34,7 +34,7 @@ const Header: FC<HeaderProps> = ({
   const { classes } = useStyles();
   const headerHeight = useAppStore((state) => state.headerHeight);
   const windowIsSmall = useAppStore((state) => state.windowIsSmall);
-  const viewOnly = useTestSessionStore((state) => state.viewOnly);
+  const readOnly = useTestSessionStore((state) => state.readOnly);
   const [showHelpModal, setShowHelpModal] = React.useState(false);
 
   // Use window navigation instead of React router to trigger new page request
@@ -99,13 +99,13 @@ const Header: FC<HeaderProps> = ({
                 className={classes.homeLink}
               >
                 {suiteTitle}
-                {viewOnly ? ' (View Only)' : ''}
+                {readOnly ? ' (Read Only)' : ''}
               </RouterLink>
             </Typography>
             {suiteVersion && (
               <Typography variant="overline" className={classes.version}>
                 {`v.${suiteVersion}`}
-                {viewOnly ? ' (Read-Only Mode)' : ''}
+                {readOnly ? ' (Read-Only Mode)' : ''}
               </Typography>
             )}
           </Box>

--- a/client/src/components/Header/ShareSessionButton.tsx
+++ b/client/src/components/Header/ShareSessionButton.tsx
@@ -24,31 +24,31 @@ const ShareSessionButton: FC<unknown> = () => {
   const openShareMenu = Boolean(anchorEl);
 
   // Adds and removes '/view' from the URL when necessary
-  const composeUrl = (viewOnly?: boolean): string => {
-    let viewOnlyUrlEnding = location.hash;
+  const composeUrl = (readOnly?: boolean): string => {
+    let readOnlyUrlEnding = location.hash;
     // Remove trailing /
-    while (viewOnlyUrlEnding.endsWith('/')) {
-      viewOnlyUrlEnding = viewOnlyUrlEnding.slice(0, -1);
+    while (readOnlyUrlEnding.endsWith('/')) {
+      readOnlyUrlEnding = readOnlyUrlEnding.slice(0, -1);
     }
-    if (viewOnly && !viewOnlyUrlEnding.includes('/view')) {
-      viewOnlyUrlEnding += '/view';
+    if (readOnly && !readOnlyUrlEnding.includes('/view')) {
+      readOnlyUrlEnding += '/view';
     }
-    if (!viewOnly && viewOnlyUrlEnding.includes('/view')) {
-      const viewStringIndex = viewOnlyUrlEnding.indexOf('/view');
-      viewOnlyUrlEnding = viewOnlyUrlEnding.substring(0, viewStringIndex);
+    if (!readOnly && readOnlyUrlEnding.includes('/view')) {
+      const viewStringIndex = readOnlyUrlEnding.indexOf('/view');
+      readOnlyUrlEnding = readOnlyUrlEnding.substring(0, viewStringIndex);
     }
     // Adding a trailing slash causes re-render
-    return `${window.location.origin}${(window.location.pathname + '/').replace(/\/\/$/, '')}${viewOnlyUrlEnding}`;
+    return `${window.location.origin}${(window.location.pathname + '/').replace(/\/\/$/, '')}${readOnlyUrlEnding}`;
   };
 
-  const copyLink = (viewOnly?: boolean) => {
+  const copyLink = (readOnly?: boolean) => {
     handleMenuClose();
-    const url = composeUrl(viewOnly);
+    const url = composeUrl(readOnly);
     void navigator.clipboard
       .writeText(url)
       .then(() => {
         setCopySuccess({ ...copySuccess, [url]: true });
-        enqueueSnackbar(`Successfully copied ${viewOnly ? 'read-only ' : ''}session link`, {
+        enqueueSnackbar(`Successfully copied ${readOnly ? 'read-only ' : ''}session link`, {
           variant: 'success',
         });
         setTimeout(() => {

--- a/client/src/components/InputsModal/Auth/InputAuth.tsx
+++ b/client/src/components/InputsModal/Auth/InputAuth.tsx
@@ -25,7 +25,7 @@ export interface InputAuthProps {
 
 const InputAuth: FC<InputAuthProps> = ({ mode, input, index, inputsMap, setInputsMap }) => {
   const { classes } = useStyles();
-  const viewOnly = useTestSessionStore((state) => state.viewOnly);
+  const readOnly = useTestSessionStore((state) => state.readOnly);
   // authValues is a version of inputsMap used exclusively in this component
   const [authValues, setAuthValues] = React.useState<Map<string, unknown>>(new Map());
   const [authValuesPopulated, setAuthValuesPopulated] = React.useState<boolean>(false);
@@ -178,8 +178,8 @@ const InputAuth: FC<InputAuthProps> = ({ mode, input, index, inputsMap, setInput
           <InputLabel
             tabIndex={0}
             required={!input.optional}
-            disabled={input.locked || viewOnly}
-            aria-disabled={input.locked || viewOnly}
+            disabled={input.locked || readOnly}
+            aria-disabled={input.locked || readOnly}
             className={classes.inputLabel}
           >
             <FieldLabel input={input} />

--- a/client/src/components/InputsModal/InputCheckboxGroup.tsx
+++ b/client/src/components/InputsModal/InputCheckboxGroup.tsx
@@ -28,7 +28,7 @@ const InputCheckboxGroup: FC<InputCheckboxGroupProps> = ({
   setInputsMap,
 }) => {
   const { classes } = useStyles();
-  const viewOnly = useTestSessionStore((state) => state.viewOnly);
+  const readOnly = useTestSessionStore((state) => state.readOnly);
   const [hasBeenModified, setHasBeenModified] = React.useState(false);
 
   const [values, setValues] = React.useState<CheckboxValues>(() => {
@@ -101,8 +101,8 @@ const InputCheckboxGroup: FC<InputCheckboxGroupProps> = ({
         component="fieldset"
         id={`requirement${index}_input`}
         tabIndex={0}
-        disabled={input.locked || viewOnly}
-        aria-disabled={input.locked || viewOnly}
+        disabled={input.locked || readOnly}
+        aria-disabled={input.locked || readOnly}
         required={!input.optional}
         error={isMissingInput}
         fullWidth
@@ -125,8 +125,8 @@ const InputCheckboxGroup: FC<InputCheckboxGroupProps> = ({
                   color="secondary"
                   name={option.value}
                   tabIndex={0}
-                  disabled={input.locked || !!option.locked || viewOnly}
-                  aria-disabled={input.locked || viewOnly}
+                  disabled={input.locked || !!option.locked || readOnly}
+                  aria-disabled={input.locked || readOnly}
                   checked={values[option.value as keyof CheckboxValues] || false}
                   onBlur={(e) => {
                     if (e.currentTarget === e.target) {

--- a/client/src/components/InputsModal/InputCombobox.tsx
+++ b/client/src/components/InputsModal/InputCombobox.tsx
@@ -23,7 +23,7 @@ const InputCombobox: FC<InputComboboxProps> = ({
   disableClear,
 }) => {
   const { classes } = useStyles();
-  const viewOnly = useTestSessionStore((state) => state.viewOnly);
+  const readOnly = useTestSessionStore((state) => state.readOnly);
 
   const getDefaultValue = (): InputOption | null => {
     const options = input.options?.list_options;
@@ -43,8 +43,8 @@ const InputCombobox: FC<InputComboboxProps> = ({
         component="fieldset"
         id={`input${index}_control`}
         tabIndex={0}
-        disabled={input.locked || viewOnly}
-        aria-disabled={input.locked || viewOnly}
+        disabled={input.locked || readOnly}
+        aria-disabled={input.locked || readOnly}
         required={!input.optional}
         fullWidth
         className={classes.inputField}
@@ -62,8 +62,8 @@ const InputCombobox: FC<InputComboboxProps> = ({
           options={input.options?.list_options || []}
           defaultValue={getDefaultValue()}
           tabIndex={0}
-          disabled={input.locked || viewOnly}
-          aria-disabled={input.locked || viewOnly}
+          disabled={input.locked || readOnly}
+          aria-disabled={input.locked || readOnly}
           disableClearable={disableClear}
           isOptionEqualToValue={(option, value) => option.value === value.value}
           renderInput={(params) => (

--- a/client/src/components/InputsModal/InputOAuthCredentials.tsx
+++ b/client/src/components/InputsModal/InputOAuthCredentials.tsx
@@ -33,7 +33,7 @@ const InputOAuthCredentials: FC<InputOAuthCredentialsProps> = ({
   setInputsMap,
 }) => {
   const { classes } = useStyles();
-  const viewOnly = useTestSessionStore((state) => state.viewOnly);
+  const readOnly = useTestSessionStore((state) => state.readOnly);
   const [hasBeenModified, setHasBeenModified] = React.useState({});
 
   // Convert OAuth string to Object
@@ -122,7 +122,7 @@ const InputOAuthCredentials: FC<InputOAuthCredentialsProps> = ({
 
     return (
       <ListItemButton
-        disabled={field.locked || viewOnly}
+        disabled={field.locked || readOnly}
         key={field.name}
         component="li"
         className={classes.inputField}
@@ -131,8 +131,8 @@ const InputOAuthCredentials: FC<InputOAuthCredentialsProps> = ({
           component="fieldset"
           id={`input${index}_input`}
           tabIndex={0}
-          disabled={input.locked || viewOnly}
-          aria-disabled={input.locked || viewOnly}
+          disabled={input.locked || readOnly}
+          aria-disabled={input.locked || readOnly}
           required={!input.optional}
           error={getIsMissingInput(field)}
           fullWidth
@@ -148,8 +148,8 @@ const InputOAuthCredentials: FC<InputOAuthCredentialsProps> = ({
           )}
           <Input
             tabIndex={0}
-            disabled={input.locked || viewOnly}
-            aria-disabled={input.locked || viewOnly}
+            disabled={input.locked || readOnly}
+            aria-disabled={input.locked || readOnly}
             required={!field.optional}
             error={getIsMissingInput(field)}
             id={`input${index}_${field.name}`}
@@ -176,8 +176,8 @@ const InputOAuthCredentials: FC<InputOAuthCredentialsProps> = ({
           <InputLabel
             required={!input.optional}
             tabIndex={0}
-            disabled={input.locked || viewOnly}
-            aria-disabled={input.locked || viewOnly}
+            disabled={input.locked || readOnly}
+            aria-disabled={input.locked || readOnly}
             className={classes.inputLabel}
           >
             <FieldLabel input={input} />

--- a/client/src/components/InputsModal/InputRadioGroup.tsx
+++ b/client/src/components/InputsModal/InputRadioGroup.tsx
@@ -23,7 +23,7 @@ export interface InputRadioGroupProps {
 
 const InputRadioGroup: FC<InputRadioGroupProps> = ({ input, index, inputsMap, setInputsMap }) => {
   const { classes } = useStyles();
-  const viewOnly = useTestSessionStore((state) => state.viewOnly);
+  const readOnly = useTestSessionStore((state) => state.readOnly);
   const firstOptionValue =
     input.options?.list_options && input.options?.list_options?.length > 0
       ? input.options?.list_options[0]?.value
@@ -43,8 +43,8 @@ const InputRadioGroup: FC<InputRadioGroupProps> = ({ input, index, inputsMap, se
         component="fieldset"
         id={`input${index}_control`}
         tabIndex={0}
-        disabled={input.locked || viewOnly}
-        aria-disabled={input.locked || viewOnly}
+        disabled={input.locked || readOnly}
+        aria-disabled={input.locked || readOnly}
         fullWidth
         className={classes.inputField}
       >
@@ -73,7 +73,7 @@ const InputRadioGroup: FC<InputRadioGroupProps> = ({ input, index, inputsMap, se
               label={option.label}
               key={`radio-button-${i}`}
               tabIndex={0}
-              aria-disabled={input.locked || viewOnly}
+              aria-disabled={input.locked || readOnly}
             />
           ))}
         </RadioGroup>

--- a/client/src/components/InputsModal/InputSingleCheckbox.tsx
+++ b/client/src/components/InputsModal/InputSingleCheckbox.tsx
@@ -21,7 +21,7 @@ const InputSingleCheckbox: FC<InputSingleCheckboxProps> = ({
   setInputsMap,
 }) => {
   const { classes } = useStyles();
-  const viewOnly = useTestSessionStore((state) => state.viewOnly);
+  const readOnly = useTestSessionStore((state) => state.readOnly);
   const [hasBeenModified, setHasBeenModified] = React.useState(false);
   const [value, setValue] = React.useState<boolean>(false);
 
@@ -55,8 +55,8 @@ const InputSingleCheckbox: FC<InputSingleCheckboxProps> = ({
         component="fieldset"
         id={`input${index}_control`}
         tabIndex={0}
-        disabled={input.locked || viewOnly}
-        aria-disabled={input.locked || viewOnly}
+        disabled={input.locked || readOnly}
+        aria-disabled={input.locked || readOnly}
         required={!input.optional}
         error={isMissingInput}
         fullWidth

--- a/client/src/components/InputsModal/InputTextField.tsx
+++ b/client/src/components/InputsModal/InputTextField.tsx
@@ -16,7 +16,7 @@ export interface InputTextFieldProps {
 
 const InputTextField: FC<InputTextFieldProps> = ({ input, index, inputsMap, setInputsMap }) => {
   const { classes } = useStyles();
-  const viewOnly = useTestSessionStore((state) => state.viewOnly);
+  const readOnly = useTestSessionStore((state) => state.readOnly);
   const [hasBeenModified, setHasBeenModified] = React.useState(false);
 
   const isMissingInput = hasBeenModified && !input.optional && !inputsMap.get(input.name);
@@ -27,8 +27,8 @@ const InputTextField: FC<InputTextFieldProps> = ({ input, index, inputsMap, setI
         component="fieldset"
         id={`input${index}_control`}
         tabIndex={0}
-        disabled={input.locked || viewOnly}
-        aria-disabled={input.locked || viewOnly}
+        disabled={input.locked || readOnly}
+        aria-disabled={input.locked || readOnly}
         required={!input.optional}
         error={isMissingInput}
         fullWidth
@@ -44,8 +44,8 @@ const InputTextField: FC<InputTextFieldProps> = ({ input, index, inputsMap, setI
         )}
         <Input
           tabIndex={0}
-          disabled={input.locked || viewOnly}
-          aria-disabled={input.locked || viewOnly}
+          disabled={input.locked || readOnly}
+          aria-disabled={input.locked || readOnly}
           required={!input.optional}
           error={isMissingInput}
           id={`input${index}_text`}

--- a/client/src/components/InputsModal/InputsModal.tsx
+++ b/client/src/components/InputsModal/InputsModal.tsx
@@ -62,7 +62,7 @@ const InputsModal: FC<InputsModalProps> = ({
   createTestRun,
 }) => {
   const { classes } = useStyles();
-  const viewOnly = useTestSessionStore((state) => state.viewOnly);
+  const readOnly = useTestSessionStore((state) => state.readOnly);
   const [inputsEdited, setInputsEdited] = React.useState<boolean>(false);
   const [inputsMap, setInputsMap] = React.useState<Map<string, unknown>>(new Map());
   const [inputType, setInputType] = React.useState<string>('Field');
@@ -176,9 +176,9 @@ const InputsModal: FC<InputsModalProps> = ({
         <Box display="flex" justifyContent="space-between">
           <Typography component="h1" variant="h6">
             {runnable?.title || 'Test'}
-            {viewOnly ? ' (View Only)' : ''}
+            {readOnly ? ' (Read Only)' : ''}
           </Typography>
-          <CustomTooltip title={`Cancel${viewOnly ? '' : ' - Inputs will be lost'}`}>
+          <CustomTooltip title={`Cancel${readOnly ? '' : ' - Inputs will be lost'}`}>
             <IconButton
               onClick={() => closeModal()}
               aria-label="cancel"
@@ -209,7 +209,7 @@ const InputsModal: FC<InputsModalProps> = ({
                 value={serialInput}
                 error={invalidInput}
                 label={invalidInput ? `ERROR: INVALID ${inputType}` : inputType}
-                disabled={viewOnly}
+                disabled={readOnly}
                 slotProps={{
                   input: {
                     classes: {
@@ -272,7 +272,7 @@ const InputsModal: FC<InputsModalProps> = ({
             variant="contained"
             disableElevation
             onClick={submitClicked}
-            disabled={missingRequiredInput || invalidInput || viewOnly}
+            disabled={missingRequiredInput || invalidInput || readOnly}
             sx={{ fontWeight: 'bold' }}
           >
             Submit

--- a/client/src/components/PresetsSelector/PresetsSelector.tsx
+++ b/client/src/components/PresetsSelector/PresetsSelector.tsx
@@ -23,7 +23,7 @@ export interface PresetsModalProps {
 
 const PresetsSelector: FC<PresetsModalProps> = ({ presets, testSessionId, getSessionData }) => {
   const { enqueueSnackbar } = useSnackbar();
-  const viewOnly = useTestSessionStore((state) => state.viewOnly);
+  const readOnly = useTestSessionStore((state) => state.readOnly);
   const null_preset = { id: 'NULL_PRESET', title: 'None' };
   const presetTitleToIdMap: { [key: string]: string } = presets.reduce(
     (reducedObj, preset) => ({ ...reducedObj, [preset.title]: preset.id }),
@@ -87,7 +87,7 @@ const PresetsSelector: FC<PresetsModalProps> = ({ presets, testSessionId, getSes
       <TextField
         id="preset-select"
         label="Preset"
-        disabled={viewOnly}
+        disabled={readOnly}
         size="small"
         fullWidth
         select

--- a/client/src/components/TestSuite/Requirements/RequirementContent.tsx
+++ b/client/src/components/TestSuite/Requirements/RequirementContent.tsx
@@ -20,8 +20,8 @@ const RequirementContent: FC<RequirementContentProps> = ({
   requirementToTests,
 }) => {
   const { classes } = useStyles();
-  const viewOnly = useTestSessionStore((state) => state.viewOnly);
-  const viewOnlyUrl = viewOnly ? '/view' : '';
+  const readOnly = useTestSessionStore((state) => state.readOnly);
+  const readOnlyUrl = readOnly ? '/view' : '';
 
   // Reduce list of requirements into map of specification -> url -> list of requirements
   const requirementsByUrl = requirements.reduce(
@@ -80,7 +80,7 @@ const RequirementContent: FC<RequirementContentProps> = ({
               {testIds?.map((id, i) => {
                 return (
                   <span key={id}>
-                    <Link variant="body2" href={`#${id}${viewOnlyUrl}`} color="secondary">
+                    <Link variant="body2" href={`#${id}${readOnlyUrl}`} color="secondary">
                       {id}
                     </Link>
                     {i !== testIds.length - 1 ? ', ' : ''} {/* Separate values with commas */}

--- a/client/src/components/TestSuite/TestRunButton/TestRunButton.tsx
+++ b/client/src/components/TestSuite/TestRunButton/TestRunButton.tsx
@@ -22,7 +22,7 @@ const TestRunButton: FC<TestRunButtonProps> = ({
   buttonText,
 }) => {
   const currentRunnables = useTestSessionStore((state) => state.currentRunnables);
-  const viewOnly = useTestSessionStore((state) => state.viewOnly);
+  const readOnly = useTestSessionStore((state) => state.readOnly);
   const showRunButton = (runnable as TestGroup).user_runnable !== false;
   const inProgress = testRunInProgress(currentRunnables, useLocation().pathname);
 
@@ -36,7 +36,7 @@ const TestRunButton: FC<TestRunButtonProps> = ({
       onClick={() => {
         runTests(runnableType, runnable.id);
       }}
-      startIcon={viewOnly ? <Visibility /> : <PlayArrow />}
+      startIcon={readOnly ? <Visibility /> : <PlayArrow />}
       data-testid={`runButton-${runnable.id}`}
     >
       {buttonText}
@@ -109,7 +109,7 @@ const TestRunButton: FC<TestRunButtonProps> = ({
   if (!showRunButton) {
     return <></>;
   } else if (!buttonText) {
-    return viewOnly ? viewIconButton : runIconButton;
+    return readOnly ? viewIconButton : runIconButton;
   } else {
     return textButton;
   }

--- a/client/src/components/TestSuite/TestRunProgressBar/TestRunProgressBar.tsx
+++ b/client/src/components/TestSuite/TestRunProgressBar/TestRunProgressBar.tsx
@@ -86,7 +86,7 @@ const TestRunProgressBar: FC<TestRunProgressBarProps> = ({
 }) => {
   const { classes } = useStyles();
   const footerHeight = useAppStore((state) => state.footerHeight);
-  const viewOnly = useTestSessionStore((state) => state.viewOnly);
+  const readOnly = useTestSessionStore((state) => state.readOnly);
   const cancellable = testRun?.status !== 'cancelling' && testRun?.status !== 'done';
   const statusIndicator = StatusIndicator(testRun?.status);
   const testCount = testRun?.test_count || 0;
@@ -137,7 +137,7 @@ const TestRunProgressBar: FC<TestRunProgressBarProps> = ({
         <CustomTooltip title="Cancel Test Run">
           <IconButton
             aria-label="cancel"
-            disabled={!cancellable || viewOnly}
+            disabled={!cancellable || readOnly}
             color="primary"
             onClick={cancelTestRun}
             className={classes.cancelButton}

--- a/client/src/components/TestSuite/TestSession.tsx
+++ b/client/src/components/TestSuite/TestSession.tsx
@@ -76,7 +76,7 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
   const currentRunnables = useTestSessionStore((state) => state.currentRunnables);
   const setCurrentRunnables = useTestSessionStore((state) => state.setCurrentRunnables);
   const setTestRunId = useTestSessionStore((state) => state.setTestRunId);
-  const viewOnly = useTestSessionStore((state) => state.viewOnly);
+  const readOnly = useTestSessionStore((state) => state.readOnly);
 
   const [inputModalVisible, setInputModalVisible] = React.useState(false);
   const [waitingTestId, setWaitingTestId] = React.useState<string | null>();
@@ -287,7 +287,7 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
       createTestRun(runnableType, runnableId, runnable?.inputs);
     } else if (runnable?.inputs && runnable.inputs.length > 0) {
       showInputsModal(runnable, runnableType);
-    } else if (viewOnly) {
+    } else if (readOnly) {
       enqueueSnackbar(`${runnable?.title} has no inputs`, { variant: 'info' });
     } else {
       createTestRun(runnableType, runnableId, []);

--- a/client/src/components/TestSuite/TestSessionWrapper.tsx
+++ b/client/src/components/TestSuite/TestSessionWrapper.tsx
@@ -32,8 +32,8 @@ const TestSessionWrapper: FC<unknown> = () => {
   const navigate = useNavigate();
   const { enqueueSnackbar } = useSnackbar();
   const testSuites = useAppStore((state) => state.testSuites);
-  const viewOnly = useTestSessionStore((state) => state.viewOnly);
-  const setViewOnlySession = useTestSessionStore((state) => state.setViewOnly);
+  const readOnly = useTestSessionStore((state) => state.readOnly);
+  const setReadOnlySession = useTestSessionStore((state) => state.setReadOnly);
   const [testRun, setTestRun] = React.useState<TestRun | null>(null);
   const [testSession, setTestSession] = React.useState<TestSession>();
   const [testResults, setTestResults] = React.useState<Result[]>();
@@ -46,10 +46,10 @@ const TestSessionWrapper: FC<unknown> = () => {
   const [coreVersion, setCoreVersion] = React.useState<string>('');
   const [drawerOpen, setDrawerOpen] = React.useState(false);
 
-  // Set view-only session status based on URL ending
+  // Set read-only session status based on URL ending
   const locationHash = useLocation().hash;
   const splitLocation = locationHash.replace('#', '').split('/');
-  const viewOnlyUrl = viewOnly ? '/view' : '';
+  const readOnlyUrl = readOnly ? '/view' : '';
 
   useEffect(() => {
     getCoreVersion()
@@ -59,13 +59,13 @@ const TestSessionWrapper: FC<unknown> = () => {
       .catch(() => {
         setCoreVersion('');
       });
-    setViewOnlySession(splitLocation.includes('view'));
+    setReadOnlySession(splitLocation.includes('view'));
   }, []);
 
   useEffect(() => {
     // If navigating to a test session URL with no suite ID value, add suite ID
     if (!locationHash && testSession) {
-      void navigate(`#${testSession?.test_suite_id}${viewOnlyUrl}`);
+      void navigate(`#${testSession?.test_suite_id}${readOnlyUrl}`);
     }
   }, [testSession]);
 

--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupCard.tsx
@@ -23,9 +23,9 @@ interface TestGroupCardProps {
 
 const TestGroupCard: FC<TestGroupCardProps> = ({ children, runnable, runTests, view }) => {
   const { classes } = useStyles();
-  const viewOnly = useTestSessionStore((state) => state.viewOnly);
+  const readOnly = useTestSessionStore((state) => state.readOnly);
 
-  const buttonText = `${viewOnly ? 'View' : 'Run'}${runnable.run_as_group ? '' : ' All'}${viewOnly ? ' Inputs' : ' Tests'}`;
+  const buttonText = `${readOnly ? 'View' : 'Run'}${runnable.run_as_group ? '' : ' All'}${readOnly ? ' Inputs' : ' Tests'}`;
 
   // render markdown once on mount - it's too slow with re-rendering
   const description = useMemo(() => {

--- a/client/src/components/TestSuite/TestSuiteDetails/TestGroupListItem/NavigableGroupListItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestGroupListItem/NavigableGroupListItem.tsx
@@ -13,7 +13,7 @@ interface NavigableGroupListItemProps {
 
 const NavigableGroupListItem: FC<NavigableGroupListItemProps> = ({ testGroup }) => {
   const { classes } = useStyles();
-  const viewOnly = useTestSessionStore((state) => state.viewOnly);
+  const readOnly = useTestSessionStore((state) => state.readOnly);
 
   return (
     <>
@@ -36,7 +36,7 @@ const NavigableGroupListItem: FC<NavigableGroupListItemProps> = ({ testGroup }) 
                   <Link
                     color="secondary.dark"
                     fontWeight="bold"
-                    href={`${location.pathname}#${testGroup.id}${viewOnly ? '/view' : ''}`}
+                    href={`${location.pathname}#${testGroup.id}${readOnly ? '/view' : ''}`}
                     data-testid="navigable-group-item"
                   >
                     {testGroup.title}

--- a/client/src/components/TestSuite/TestSuiteDetails/TestSuiteMessages.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestSuiteMessages.tsx
@@ -13,7 +13,7 @@ interface TestSuiteMessagesProps {
 const TestSuiteMessages: FC<TestSuiteMessagesProps> = ({ messages, testSuiteId }) => {
   const navigate = useNavigate();
   const { classes } = useStyles();
-  const viewOnly = useTestSessionStore((state) => state.viewOnly);
+  const readOnly = useTestSessionStore((state) => state.readOnly);
 
   const errorMessages = messages.filter((message) => message.type === 'error');
   const warningMessages = messages.filter((message) => message.type === 'warning');
@@ -26,11 +26,11 @@ const TestSuiteMessages: FC<TestSuiteMessagesProps> = ({ messages, testSuiteId }
         severity={severity}
         variant="filled"
         onClick={() => {
-          void navigate(`#${testSuiteId || ''}/config${viewOnly ? '/view' : ''}`);
+          void navigate(`#${testSuiteId || ''}/config${readOnly ? '/view' : ''}`);
         }}
         onKeyDown={(e) => {
           if (e.key === 'Enter') {
-            void navigate(`#${testSuiteId || ''}/config${viewOnly ? '/view' : ''}`);
+            void navigate(`#${testSuiteId || ''}/config${readOnly ? '/view' : ''}`);
           }
         }}
         className={classes.alert}

--- a/client/src/components/_common/CustomTreeItem.tsx
+++ b/client/src/components/_common/CustomTreeItem.tsx
@@ -45,8 +45,8 @@ const CustomContent = React.forwardRef(function CustomContent(
   } = useTreeItemState(itemId);
 
   const navigate = useNavigate();
-  const viewOnly = useTestSessionStore((state) => state.viewOnly);
-  const viewOnlyUrl = viewOnly ? '/view' : '';
+  const readOnly = useTestSessionStore((state) => state.readOnly);
+  const readOnlyUrl = readOnly ? '/view' : '';
 
   const icon = iconProp || expansionIcon || displayIcon;
 
@@ -75,7 +75,7 @@ const CustomContent = React.forwardRef(function CustomContent(
     event: React.MouseEvent<HTMLDivElement, MouseEvent> | React.KeyboardEvent<HTMLDivElement>,
   ) => {
     handleSelection(event as React.MouseEvent<HTMLDivElement, MouseEvent>);
-    if (testId) void navigate(`#${testId}${viewOnlyUrl}`);
+    if (testId) void navigate(`#${testId}${readOnlyUrl}`);
   };
 
   return (

--- a/client/src/components/_common/UploadFileButton.tsx
+++ b/client/src/components/_common/UploadFileButton.tsx
@@ -9,7 +9,7 @@ export interface UploadFileButtonProps {
 }
 
 const UploadFileButton: FC<UploadFileButtonProps> = ({ onUpload }) => {
-  const viewOnly = useTestSessionStore((state) => state.viewOnly);
+  const readOnly = useTestSessionStore((state) => state.readOnly);
   const [fileName, setFileName] = React.useState<string>('');
 
   const uploadFile = (e: ChangeEvent<HTMLInputElement>) => {
@@ -46,7 +46,7 @@ const UploadFileButton: FC<UploadFileButtonProps> = ({ onUpload }) => {
         component="label"
         color="secondary"
         aria-label="file-upload"
-        disabled={viewOnly}
+        disabled={readOnly}
         startIcon={<FileUploadOutlined />}
         disableElevation
         sx={{ flexShrink: 0 }}

--- a/client/src/store/testSession.ts
+++ b/client/src/store/testSession.ts
@@ -8,11 +8,11 @@ interface CurrentRunnables {
 }
 
 type TestSessionStore = {
-  viewOnly: boolean;
+  readOnly: boolean;
   currentRunnables: CurrentRunnables;
   runnableId: string;
   testRunId: string | undefined;
-  setViewOnly: (viewOnly: boolean) => void;
+  setReadOnly: (readOnly: boolean) => void;
   setCurrentRunnables: (currentRunnables: CurrentRunnables) => void;
   setRunnableId: (runnableId: string) => void;
   setTestRunId: (testRunId: string | undefined) => void;
@@ -22,11 +22,11 @@ export const useTestSessionStore = create<TestSessionStore>()(
   persist(
     devtoolsInDev(
       (set, _get): TestSessionStore => ({
-        viewOnly: false,
+        readOnly: false,
         currentRunnables: {},
         runnableId: '',
         testRunId: undefined,
-        setViewOnly: (viewOnly: boolean) => set({ viewOnly: viewOnly }),
+        setReadOnly: (readOnly: boolean) => set({ readOnly: readOnly }),
         setCurrentRunnables: (currentRunnables: CurrentRunnables) =>
           set({ currentRunnables: { ...currentRunnables } }),
         setRunnableId: (runnableId: string) => set({ runnableId: runnableId }),


### PR DESCRIPTION
# Summary

Renames instances of view-only and viewOnly to read-only and readOnly. The URL remains unchanged.

# Testing Guidance

Read-only mode should work as expected.
