### PR TITLE
ID-95: Update Validator-Wrapper container generation

### DIFF
--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -2,7 +2,7 @@
 # https://github.com/hapifhir/org.hl7.fhir.validator-wrapper/blob/master/Dockerfile
 # with the following differences:
 # 1. It fetches the built JAR from GitHub instead of locally, or building from source
-# 2. It adds MITRE certs, for ease of use by the MITRE development team
+# 2. It adds MITRE certs, for ease of use by the MITRE development team (DEPRECATED)
 # 3. It uses an Ubuntu-based base image instead of Alpine to support both AMD64 and ARM architectures
 # 4. It defaults the following environment variables:
 #    - SESSION_CACHE_IMPLEMENTATION=PassiveExpiringSessionCache
@@ -11,10 +11,10 @@
 #
 # The software release to use is based on the PROJECT_VERSION build argument (required)
 
-FROM eclipse-temurin:11-jre-jammy
+FROM eclipse-temurin:17-jre-jammy
 
-RUN wget https://gitlab.mitre.org/mitre-scripts/mitre-pki/-/raw/master/os_scripts/install_certs.sh -O - | MODE=ubuntu sh \
- && wget https://gitlab.mitre.org/mitre-scripts/mitre-pki/-/raw/master/tool_scripts/install_certs.sh -O - | MODE=java sh
+# RUN wget https://gitlab.mitre.org/mitre-scripts/mitre-pki/-/raw/master/os_scripts/install_certs.sh -O - | MODE=ubuntu sh \
+#  && wget https://gitlab.mitre.org/mitre-scripts/mitre-pki/-/raw/master/tool_scripts/install_certs.sh -O - | MODE=java sh
 
 ARG PROJECT_VERSION
 RUN echo "Project version set to -> ${PROJECT_VERSION}"
@@ -32,7 +32,7 @@ USER $APPLICATION_USER
 
 # These lines copy the packaged application into the Docker image and sets the working directory to where it was copied.
 WORKDIR /app
-RUN wget -O validator-wrapper.jar "https://github.com/hapifhir/org.hl7.fhir.validator-wrapper/releases/download/${PROJECT_VERSION}/validator_cli.jar"
+RUN wget -O validator-wrapper.jar "https://github.com/hapifhir/org.hl7.fhir.validator-wrapper/releases/download/${PROJECT_VERSION}/validator-wrapper.jar"
 
 # Environment vars here
 ENV ENVIRONMENT=prod


### PR DESCRIPTION
TODO: need to add a snomed CT version to at least US core tests - add to the validator context: `snomedCT: "731000124108",`

# Summary

This PR updates the Docker file used to build Inferno-specific images for the HL7 [fhir-validator-wrapper](https://github.com/hapifhir/org.hl7.fhir.validator-wrapper) project to match changes made in that project in recent versions
1. Require Java 17.
2. Use a different name for the downloadable jar file.

Additionally, the lines to pull MITRE certificates were commented out as the project no longer is run by that team and we don't have access to the scripts any longer.

Notes:
- A nice bonus of this version update appears to be a significant improvement in package load times. Complex IGs like DTR and CRD were very slow in the latest Inferno version released.
- This fixes some specific issues observed within the DTR test kit, both in [2.0.1 profiles](https://github.com/inferno-framework/davinci-dtr-test-kit/issues/81) and 2.2.0 profiles.

# Testing Guidance

Since we are testing in QA this week, a 1.0.73 image version was generated and pushed, but not tagged with latest for use in testing. The latest tag and g10 updates will be added once this is merged.

1. Update the `hl7_validator_service` entry in the `docker-compose.background.yml` file to use `image: infernocommunity/inferno-resource-validator:1.0.73`
2. Update the gemfile and demo dev suite to import the g10 test kit.
3.  TODO: finish these instructions