### PR TITLE
ID-97: allow a result_message to be provided on resume routes

### DIFF
--- a/dev_suites/dev_demo_ig_stu1/demo_suite.rb
+++ b/dev_suites/dev_demo_ig_stu1/demo_suite.rb
@@ -230,12 +230,13 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
         receives_request :resume
 
         run do
+          msg = 'message=User%20clicked%20fail'
           wait(
             identifier: 'abc',
             message: %(
               [Follow this link to pass the test and proceed](#{config.options[:wait_test_url]}?xyz=abc).
 
-              [Follow this link to fail the test and proceed](#{config.options[:wait_test_fail_url]}?xyz=abc).
+              [Follow this link to fail the test and proceed](#{config.options[:wait_test_fail_url]}?xyz=abc&#{msg}).
 
               [Follow this link to skip the test and proceed](#{config.options[:wait_test_skip_url]}?xyz=abc).
 
@@ -247,7 +248,7 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
 
               ```#{config.options[:wait_test_url]}?xyz=abc```,
 
-              ```#{config.options[:wait_test_fail_url]}?xyz=abc```,
+              ```#{config.options[:wait_test_fail_url]}?xyz=abc&#{msg}```,
 
               ```#{config.options[:wait_test_skip_url]}?xyz=abc```,
 

--- a/lib/inferno/dsl/resume_test_route.rb
+++ b/lib/inferno/dsl/resume_test_route.rb
@@ -44,8 +44,8 @@ module Inferno
       end
 
       # @private
-      def update_result(waiting_result)
-        results_repo.update_result(waiting_result.id, result)
+      def update_result(waiting_result, message)
+        results_repo.update_result(waiting_result.id, result, message)
       end
 
       # @private
@@ -80,6 +80,7 @@ module Inferno
         request = Inferno::Entities::Request.from_hanami_request(req)
 
         test_run_identifier = instance_exec(request, &test_run_identifier_block)
+        result_message = request.query_parameters['message']
 
         test_run = find_test_run(test_run_identifier)
 
@@ -90,7 +91,7 @@ module Inferno
         waiting_result = find_waiting_result(test_run)
         test = find_test(waiting_result)
 
-        update_result(waiting_result)
+        update_result(waiting_result, result_message)
         persist_request(request, test_run, waiting_result, test)
 
         Jobs.perform(Jobs::ResumeTestRun, test_run.id)

--- a/spec/inferno/dsl/runnable_spec.rb
+++ b/spec/inferno/dsl/runnable_spec.rb
@@ -109,6 +109,15 @@ RSpec.describe Inferno::DSL::Runnable do
 
         expect(updated_result.result).to eq('cancel')
       end
+
+      it 'includes a result_message when specified' do
+        get '/custom/demo/resume_fail?xyz=IDENTIFIER&message=failure%20reason'
+
+        updated_result = Inferno::Repositories::Results.new.find(result.id)
+
+        expect(updated_result.result).to eq('fail')
+        expect(updated_result.result_message).to eq('failure reason')
+      end
     end
   end
 


### PR DESCRIPTION
# Summary

Previously, the resume route functionality used to resume wait tests could only update the test result (pass, fail, etc). Now, a result_message can be passed in as well using the `message` url parameter.

# Testing Guidance

1. Start an instance of the Demonstration Suite
2. Run 5.02 (Wait Test) and hover over the failure link in the resulting wait dialog - confirm that the link contains a `message` url parameter.
3. Click the failure link and confirm that the test fails with result message `User clicked fail`

Additionally check the [documentation PR](https://github.com/inferno-framework/inferno-framework.github.io/pull/112).