### PR TITLE
ID-45: session compare - sort based on normalized messages (fix)

### DIFF
--- a/dev_suites/dev_demo_ig_stu1/demo_suite.rb
+++ b/dev_suites/dev_demo_ig_stu1/demo_suite.rb
@@ -530,5 +530,29 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
         end
       end
     end
+    group do
+      id 'message_normalization_sort_group'
+      title 'Execute Script Message Normalization Sort Group'
+      description %(
+        This group demonstrates that messages are sorted based on their normalized
+        content when comparing runs within a script execution.
+      )
+
+      test do
+        title 'Messages where normalized sort order differs from raw sort order'
+        input :normalization_sort_url,
+              title: 'Normalization Sort URL',
+              description: 'A URL included in messages. Use http://aaa.example.com for ' \
+                           'expected results and http://zzz.example.com for the comparison ' \
+                           'run to exercise normalization-based sort ordering.',
+              default: 'http://aaa.example.com'
+
+        run do
+          add_message('info', "#{normalization_sort_url}: response received")
+          add_message('info', 'http://middle.example.com: fixed message')
+          pass
+        end
+      end
+    end
   end
 end

--- a/execution_scripts/demo/demo_message_normalization_sort.yaml
+++ b/execution_scripts/demo/demo_message_normalization_sort.yaml
@@ -1,0 +1,32 @@
+# Exercises normalization-based message sort ordering.
+#
+# The test adds two messages:
+#   1. "#{normalization_sort_url}: response received"  (varies by run)
+#   2. "http://middle.example.com: fixed message"      (constant)
+#
+# With the expected URL (http://aaa.example.com), message 1 sorts before message 2
+# in raw alphabetical order ('a' < 'm' after "http://"). With the URL used here
+# (http://zzz.example.com), message 1 sorts after message 2 ('z' > 'm'). After
+# normalization both URLs become '<NORMALIZED>', which sorts before "http://middle..."
+# ('<' < 'h'), so the normalized order is the same in both runs.
+#
+# Run with --compare-messages to exercise this behavior.
+
+sessions:
+  - suite: demo
+
+comparison_config:
+  normalized_strings:
+    - 'http://aaa.example.com'
+    - 'http://zzz.example.com'
+
+steps:
+  - status: created
+    start_run:
+      runnable: 12
+      inputs:
+        normalization_sort_url: 'http://zzz.example.com'
+
+  - status: done
+    last_completed: 12
+    action: END_SCRIPT

--- a/execution_scripts/demo/demo_message_normalization_sort_expected.json
+++ b/execution_scripts/demo/demo_message_normalization_sort_expected.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "created_at": "2026-01-01T00:00:00.000-05:00",
+    "inputs": [
+      {
+        "name": "normalization_sort_url",
+        "type": "text",
+        "value": "http://aaa.example.com"
+      }
+    ],
+    "messages": [
+      {
+        "message": "http://aaa.example.com: response received",
+        "type": "info"
+      },
+      {
+        "message": "http://middle.example.com: fixed message",
+        "type": "info"
+      }
+    ],
+    "optional": false,
+    "outputs": [],
+    "requests": [],
+    "result": "pass",
+    "test_id": "demo-message_normalization_sort_group-Test01",
+    "test_run_id": "00000000-0000-0000-0000-000000000002",
+    "test_session_id": "AAAAAAAAA",
+    "updated_at": "2026-01-01T00:00:00.000-05:00"
+  },
+  {
+    "id": "00000000-0000-0000-0000-000000000003",
+    "created_at": "2026-01-01T00:00:00.000-05:00",
+    "inputs": [],
+    "optional": false,
+    "outputs": [],
+    "requests": [],
+    "result": "pass",
+    "test_group_id": "demo-message_normalization_sort_group",
+    "test_run_id": "00000000-0000-0000-0000-000000000002",
+    "test_session_id": "AAAAAAAAA",
+    "updated_at": "2026-01-01T00:00:00.000-05:00"
+  }
+]

--- a/lib/inferno/apps/cli/session/session_compare.rb
+++ b/lib/inferno/apps/cli/session/session_compare.rb
@@ -278,7 +278,8 @@ module Inferno
 
           def sorted_messages(result)
             Array(result&.dig('messages')).sort_by do |m|
-              [MESSAGE_TYPE_ORDER.fetch(m['type'].to_s, UNKNOWN_MESSAGE_TYPE_ORDER), m['message'].to_s]
+              [MESSAGE_TYPE_ORDER.fetch(m['type'].to_s, UNKNOWN_MESSAGE_TYPE_ORDER),
+               normalize_string(m['message'].to_s)]
             end
           end
 

--- a/spec/inferno/cli/session/session_compare_spec.rb
+++ b/spec/inferno/cli/session/session_compare_spec.rb
@@ -461,5 +461,30 @@ RSpec.describe Inferno::CLI::Session::SessionCompare do
           .to raise_error(an_instance_of(SystemExit).and(having_attributes(status: 0)))
       end.to output(/.+/).to_stdout
     end
+
+    it 'passes when messages only differ in normalized strings but would sort differently without normalization' do
+      # 'aaa_server' sorts before the fixed message alphabetically ('a' < 'm')
+      # 'zzz_server' sorts after the fixed message alphabetically ('z' > 'm')
+      # Both normalize to '<NORMALIZED>' which sorts before the fixed message ('<' < 'm'),
+      # so normalization-based sorting produces the same order for expected and actual.
+      # Without normalization in sorting, the pairs are mismatched and the comparison fails.
+      fixed_msg = 'Msg: m_something'
+      expected = test_result_base.merge(messages: [
+                                          { message: 'Msg: aaa_server/path', type: 'info' },
+                                          { message: fixed_msg, type: 'info' }
+                                        ])
+      actual = test_result_base.merge(messages: [
+                                        { message: 'Msg: zzz_server/path', type: 'info' },
+                                        { message: fixed_msg, type: 'info' }
+                                      ])
+      stub_results(actual:, expected:)
+
+      options = { inferno_base_url: inferno_host, expected_results_session: expected_results_session_id,
+                  compare_messages: true, normalized_strings: ['aaa_server', 'zzz_server'] }
+      expect do
+        expect { described_class.new(actual_results_session_id, options).run }
+          .to raise_error(an_instance_of(SystemExit).and(having_attributes(status: 0)))
+      end.to output(/.+/).to_stdout
+    end
   end
 end

--- a/spec/inferno/utils/preset_template_generator_spec.rb
+++ b/spec/inferno/utils/preset_template_generator_spec.rb
@@ -139,7 +139,15 @@ RSpec.describe Inferno::Utils::PresetTemplateGenerator do
         { name: 'cancel_pause_time', _type: 'text', value: '30' },
         { name: 'url1', _type: 'text', value: nil },
         { name: 'custom_bearer_token', _type: 'text',
-          _description: 'This bearer token will be used to identify the incoming request', value: nil }
+          _description: 'This bearer token will be used to identify the incoming request', value: nil },
+        {
+          name: 'normalization_sort_url',
+          _description: 'A URL included in messages. Use http://aaa.example.com for expected results and ' \
+                        'http://zzz.example.com for the comparison run to exercise normalization-based sort ordering.',
+          _title: 'Normalization Sort URL',
+          _type: 'text',
+          value: 'http://aaa.example.com'
+        }
       ] }
   end
 


### PR DESCRIPTION
# Summary

Previously, when comparing messages on tests within the `session compare` CLI, messages were sorted raw and then compared normalized. This cause failures in cases where the sort order would be different after normalization. Now, messages are sorted based on their normalized version.

# Testing Guidance

Added an execution script `execution_scripts/demo/demo_message_normalization_sort.yaml` that demonstrates this behavior:
- the expected results has a two raw messages that starts with a and m
- the script will execute such that the actual results will have two raw messages that start with m and z
- the script's comparison config normalizes the messages starting with a and z to a common string
- If the sorting happened on the raw strings, then the comparison would fail because expected [a,m] would be compared to actual [m,z].

Run this execution script to verify that it doesn't fail:
- start inferno services and test kit
- run `bundle exec inferno execute_script execution_scripts/demo/demo_message_normalization_sort.yaml`
