### PR TITLE
Release 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.1
+* Allow checkbox inputs to be suppressed by the enable_when feature by @karlnaden in https://github.com/inferno-framework/inferno-core/pull/784
+
 ## 1.3.0
 * Add enable_when attribute to the input by @projkov in https://github.com/inferno-framework/inferno-core/pull/758
 * ID-45: Improve session compare csv file by @karlnaden in https://github.com/inferno-framework/inferno-core/pull/780

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    inferno_core (1.3.0)
+    inferno_core (1.3.1)
       activesupport (~> 7.2.3.1)
       base62-rb (= 0.3.1)
       blueprinter (= 0.25.2)

--- a/client/src/components/InputsModal/InputHelpers.ts
+++ b/client/src/components/InputsModal/InputHelpers.ts
@@ -219,7 +219,7 @@ export const conditionalShowInput = (
   inputsMap: Map<string, unknown>,
 ): boolean => {
   const enableWhen = input.enable_when;
-  if (!enableWhen?.input_name || input.type === 'checkbox') {
+  if (!enableWhen?.input_name) {
     return true;
   }
   const inputValue = inputsMap.get(enableWhen.input_name);

--- a/client/src/components/InputsModal/__tests__/InputHelpers.test.ts
+++ b/client/src/components/InputsModal/__tests__/InputHelpers.test.ts
@@ -101,7 +101,10 @@ describe('conditionalShowInput', () => {
   });
 
   it('respects enable_when when the input itself is type checkbox', () => {
-    const input = makeInput({ type: 'checkbox', enable_when: { input_name: 'ctrl', value: 'yes' } });
+    const input = makeInput({
+      type: 'checkbox',
+      enable_when: { input_name: 'ctrl', value: 'yes' },
+    });
     expect(conditionalShowInput(input, new Map([['ctrl', 'no']]))).toBe(false);
     expect(conditionalShowInput(input, new Map([['ctrl', 'yes']]))).toBe(true);
   });

--- a/client/src/components/InputsModal/__tests__/InputHelpers.test.ts
+++ b/client/src/components/InputsModal/__tests__/InputHelpers.test.ts
@@ -99,6 +99,12 @@ describe('conditionalShowInput', () => {
     const input = makeInput({ enable_when: { input_name: 'ctrl', value: '["a","b"]' } });
     expect(conditionalShowInput(input, new Map([['ctrl', ['b', 'a']]]))).toBe(true);
   });
+
+  it('respects enable_when when the input itself is type checkbox', () => {
+    const input = makeInput({ type: 'checkbox', enable_when: { input_name: 'ctrl', value: 'yes' } });
+    expect(conditionalShowInput(input, new Map([['ctrl', 'no']]))).toBe(false);
+    expect(conditionalShowInput(input, new Map([['ctrl', 'yes']]))).toBe(true);
+  });
 });
 
 describe('showInput', () => {

--- a/lib/inferno/version.rb
+++ b/lib/inferno/version.rb
@@ -1,4 +1,4 @@
 module Inferno
   # Standard patterns for gem versions: https://guides.rubygems.org/patterns/
-  VERSION = '1.3.0'.freeze
+  VERSION = '1.3.1'.freeze
 end


### PR DESCRIPTION
`enable_when` functionality mistakenly prevented checkbox inputs from being controlled by the behavior.