### PR TITLE
ID-119: Add non-must-support element check (CRD conf-10/13, PAS conf-12)

### DIFF
--- a/lib/inferno/dsl/must_support_assessment.rb
+++ b/lib/inferno/dsl/must_support_assessment.rb
@@ -32,6 +32,44 @@ module Inferno
         end
       end
 
+      # Find any non-Must-Support elements that ARE present in the given resources.
+      #
+      # Implements the Da Vinci Burden Reduction conformance rules (CRD conf-10/13,
+      # PAS conf-12) for client requests: a conforming client must not depend on
+      # non-must-support elements, which we verify by ensuring it does not populate
+      # them. Reports both populated non-MS elements and any extensions whose URLs
+      # are not defined as must-support in the profile.
+      #
+      # The metadata schema mirrors {#missing_must_support_elements}: entries in
+      # `must_supports[:elements]` are treated as non-MS when tagged with
+      # `must_support: false`. Entries without the flag are assumed to be MS, which
+      # preserves the behavior of existing metadata generated before this method
+      # was added.
+      #
+      # @param resources [Array<FHIR::Resource>]
+      # @param profile_url [String]
+      # @param validator_name [Symbol]
+      # @param metadata [Hash] Pre-built metadata (skips re-extraction)
+      # @param requirement_extension [String]
+      # @yield [Metadata] Customize the metadata before running the check
+      # @return [Array<String>] non-MS element paths and unexpected extension URLs that were found
+      def non_must_support_elements_present(resources, profile_url, validator_name: :default, metadata: nil,
+                                            requirement_extension: nil, &)
+        debug_metadata = config.options[:debug_must_support_metadata]
+
+        if metadata.present?
+          InternalMustSupportLogic.new
+            .perform_non_must_support_check_with_metadata(resources, metadata, debug_metadata:)
+        else
+          ig, profile = find_ig_and_profile(profile_url, validator_name)
+          test_impl = InternalMustSupportLogic.new
+          profile_metadata = test_impl.extract_metadata(profile, ig, requirement_extension:)
+          yield profile_metadata if block_given?
+
+          test_impl.perform_non_must_support_check_with_metadata(resources, profile_metadata, debug_metadata:)
+        end
+      end
+
       # perform_must_support_assessment allows customizing the metadata with a block.
       # Customizing the metadata may add, modify, or remove items.
       # For instance, US Core 3.1.1 Patient "Previous Name" is defined as MS only in narrative.
@@ -187,6 +225,89 @@ module Inferno
             missing_extensions.map { |extension_definition| extension_definition[:id] }
         end
 
+        # Run the non-must-support presence check (CRD conf-10/13, PAS conf-12).
+        # If the metadata has no entries explicitly flagged as must_support: false,
+        # the check is skipped entirely so that callers using pre-existing metadata
+        # (which never carried non-MS entries) continue to behave as before.
+        # @param resources [Array<FHIR::Model>]
+        # @param profile_metadata [Metadata]
+        # @param debug_metadata [Boolean]
+        # @return [Array<String>] paths/URLs of non-MS elements or undefined extensions that were found
+        def perform_non_must_support_check_with_metadata(resources, profile_metadata, debug_metadata: false)
+          return [] if resources.blank?
+
+          @metadata = profile_metadata
+
+          write_metadata_for_debugging if debug_metadata
+
+          return [] unless metadata_opts_into_non_must_support_check?
+
+          present_non_must_support_elements(resources) + unexpected_extensions(resources)
+        end
+
+        # Metadata produced by the current extractor enumerates non-MS entries with
+        # `must_support: false`. Older metadata (or metadata customized to suppress
+        # the check) has no such entries, in which case we don't run the analysis.
+        def metadata_opts_into_non_must_support_check?
+          metadata.must_supports[:elements].any? { |element| element[:must_support] == false }
+        end
+
+        # @return [Array<String>] paths of non-MS elements found in any resource
+        def present_non_must_support_elements(resources)
+          present = non_must_support_elements.select do |element_definition|
+            resources.any? { |resource| resource_populates_element?(resource, element_definition) }
+          end
+          present.map { |element_definition| missing_element_string(element_definition) }
+        end
+
+        # @return [Array<String>] URLs of extensions present on any resource that are
+        #   not declared as must-support in the profile metadata. Recursively walks
+        #   sibling/child FHIR elements, but does NOT recurse into the internal
+        #   structure of an extension - sub-extensions of a complex extension belong
+        #   to the parent extension's definition and would otherwise produce noise
+        #   (e.g., `ombCategory` inside `us-core-race`).
+        def unexpected_extensions(resources)
+          allowed_urls = must_support_extensions.to_set { |extension| normalized_extension_url(extension[:url]) }
+
+          resources.flat_map { |resource| collect_extension_urls(resource) }
+            .uniq
+            .reject { |url| allowed_urls.include?(normalized_extension_url(url)) }
+        end
+
+        def collect_extension_urls(element)
+          return [] unless element.is_a?(FHIR::Model)
+
+          urls = direct_extension_urls(element)
+
+          non_extension_child_models(element).each do |child|
+            urls.concat(collect_extension_urls(child))
+          end
+
+          urls
+        end
+
+        def direct_extension_urls(element)
+          urls = []
+          [:extension, :modifierExtension].each do |field|
+            next unless element.respond_to?(field)
+
+            Array.wrap(element.public_send(field)).each do |extension|
+              urls << extension.url if extension.respond_to?(:url) && extension.url.present?
+            end
+          end
+          urls
+        end
+
+        def non_extension_child_models(element)
+          element.instance_variables.flat_map do |name|
+            next [] if [:@extension, :@modifierExtension].include?(name)
+
+            Array.wrap(element.instance_variable_get(name)).select do |value|
+              value.is_a?(FHIR::Model) && !value.is_a?(FHIR::Extension)
+            end
+          end
+        end
+
         def missing_element_string(element_definition)
           if element_definition[:fixed_value].present?
             "#{element_definition[:path]}:#{element_definition[:fixed_value]}"
@@ -196,7 +317,7 @@ module Inferno
         end
 
         def must_support_extensions
-          metadata.must_supports[:extensions]
+          metadata.must_supports[:extensions].reject { |extension| extension[:must_support] == false }
         end
 
         def missing_extensions(resources = [])
@@ -223,7 +344,11 @@ module Inferno
         end
 
         def must_support_elements
-          metadata.must_supports[:elements]
+          metadata.must_supports[:elements].reject { |element| element[:must_support] == false }
+        end
+
+        def non_must_support_elements
+          metadata.must_supports[:elements].select { |element| element[:must_support] == false }
         end
 
         def missing_elements(resources = [])

--- a/lib/inferno/dsl/must_support_metadata_extractor.rb
+++ b/lib/inferno/dsl/must_support_metadata_extractor.rb
@@ -24,13 +24,18 @@ module Inferno
         self.requirement_extension_url = requirement_extension_url
       end
 
-      # Retrieval method for the must support metadata
+      # Retrieval method for the must support metadata.
+      #
+      # The :elements list now includes both must-support entries (no must_support flag,
+      # defaulting to true) and non-must-support entries (explicitly tagged
+      # must_support: false) - see {#non_must_support_elements}. Consumers that only
+      # want MS entries must filter on `entry[:must_support] != false`.
       # @return [Hash]
       def must_supports
         @must_supports ||= {
           extensions: must_support_extensions,
           slices: must_support_slices,
-          elements: must_support_elements
+          elements: must_support_elements + non_must_support_elements
         }
       end
 
@@ -478,6 +483,53 @@ module Inferno
         must_support_elements_metadata.delete_if do |metadata|
           metadata[:path] == current_metadata[:path] && metadata[:fixed_value].blank?
         end
+      end
+
+      # Enumerate non-must-support, non-required profile elements that are direct
+      # children of either the resource root or a must-support element. These are
+      # the elements a conforming client request must NOT contain (see Da Vinci
+      # CRD conf-10 / conf-13 and PAS conf-12).
+      #
+      # Each entry is tagged `must_support: false` so consumers can distinguish
+      # them from the must-support entries that share the same list.
+      # @return [Array<Hash>]
+      def non_must_support_elements
+        ms_element_ids = all_must_support_elements.to_set(&:id)
+        allowed_parent_ids = ms_element_ids + [resource]
+
+        candidate_non_ms_elements.filter_map do |element|
+          parent_id = parent_element_id(element.id)
+          next unless allowed_parent_ids.include?(parent_id)
+
+          { path: element.id.gsub("#{resource}.", ''), must_support: false }
+        end
+      end
+
+      def candidate_non_ms_elements
+        profile_elements.reject { |element| skip_for_non_ms_check?(element) }
+      end
+
+      def skip_for_non_ms_check?(element)
+        element.id == resource ||
+          element.path.end_with?('xtension') ||
+          element.sliceName.present? ||
+          element.mustSupport ||
+          by_requirement_extension_only?(element) ||
+          required_element?(element)
+      end
+
+      def required_element?(element)
+        element.min.is_a?(Integer) && element.min.positive?
+      end
+
+      def parent_element_id(id)
+        # Drop the last '.' segment to get the parent id. Slice suffixes (":sliceName")
+        # remain attached to their segment, so allowed-parent comparisons still work
+        # because we built the allowed set from element ids.
+        parts = id.split('.')
+        return nil if parts.length <= 1
+
+        parts[0..-2].join('.')
       end
     end
   end

--- a/spec/inferno/dsl/must_support_assessment_spec.rb
+++ b/spec/inferno/dsl/must_support_assessment_spec.rb
@@ -1402,4 +1402,188 @@ RSpec.describe Inferno::DSL::MustSupportAssessment do
       expect(result).to include('subject')
     end
   end
+
+  describe 'non-must-support element check (CRD conf-10/13, PAS conf-12)' do
+    def run_non_ms_with_metadata(resources, metadata)
+      test_impl.non_must_support_elements_present(resources, nil, metadata:)
+    end
+
+    let(:patient_metadata) do
+      OpenStruct.new(
+        must_supports: {
+          extensions: [
+            {
+              id: 'Patient.extension:race',
+              path: 'extension',
+              url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race'
+            }
+          ],
+          slices: [],
+          elements: [
+            { path: 'identifier' },
+            { path: 'name' },
+            { path: 'name.family' },
+            { path: 'gender' },
+            { path: 'communication', must_support: false },
+            { path: 'birthDate', must_support: false }
+          ]
+        }
+      )
+    end
+
+    let(:bare_patient) do
+      FHIR::Patient.new(
+        identifier: [{ system: 'system', value: 'value' }],
+        name: [{ family: 'family' }],
+        gender: 'male',
+        extension: [
+          {
+            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race',
+            extension: [{ url: 'ombCategory', valueCoding: { display: 'display' } }]
+          }
+        ]
+      )
+    end
+
+    it 'passes when only must-support elements are populated' do
+      result = run_non_ms_with_metadata([bare_patient], patient_metadata)
+      expect(result).to be_empty
+    end
+
+    it 'flags a populated non-must-support element' do
+      bare_patient.birthDate = '2020-01-01'
+
+      result = run_non_ms_with_metadata([bare_patient], patient_metadata)
+      expect(result).to include('birthDate')
+    end
+
+    it 'flags multiple populated non-must-support elements' do
+      bare_patient.birthDate = '2020-01-01'
+      bare_patient.communication = [{ language: { text: 'en' } }]
+
+      result = run_non_ms_with_metadata([bare_patient], patient_metadata)
+      expect(result).to include('birthDate', 'communication')
+    end
+
+    it 'passes when metadata has no explicit must_support flags (backwards compatibility)' do
+      legacy_metadata = OpenStruct.new(
+        must_supports: {
+          extensions: [],
+          slices: [],
+          elements: [
+            { path: 'identifier' },
+            { path: 'name' },
+            { path: 'gender' }
+          ]
+        }
+      )
+
+      bare_patient.birthDate = '2020-01-01'
+
+      result = run_non_ms_with_metadata([bare_patient], legacy_metadata)
+      expect(result).to be_empty
+    end
+
+    it 'flags an extension whose url is not defined as must-support' do
+      bare_patient.extension << FHIR::Extension.new(
+        url: 'http://example.org/StructureDefinition/undefined-extension',
+        valueString: 'value'
+      )
+
+      result = run_non_ms_with_metadata([bare_patient], patient_metadata)
+      expect(result).to include('http://example.org/StructureDefinition/undefined-extension')
+    end
+
+    it 'does not flag an extension defined as must-support' do
+      result = run_non_ms_with_metadata([bare_patient], patient_metadata)
+      expect(result).to_not include('http://hl7.org/fhir/us/core/StructureDefinition/us-core-race')
+    end
+
+    it 'matches must-support extensions even when the url carries a canonical version' do
+      versioned_metadata = OpenStruct.new(
+        must_supports: {
+          extensions: [
+            {
+              id: 'Patient.extension:race',
+              path: 'extension',
+              url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race|1.0.0'
+            }
+          ],
+          slices: [],
+          elements: []
+        }
+      )
+
+      result = run_non_ms_with_metadata([bare_patient], versioned_metadata)
+      expect(result).to_not include(a_string_starting_with('http://hl7.org/fhir/us/core/StructureDefinition/us-core-race'))
+    end
+
+    it 'does not flag sub-extensions inside a known must-support complex extension' do
+      # `ombCategory` is a sub-slice of us-core-race; it is part of the extension's
+      # own definition, not a separate extension used by the client.
+      result = run_non_ms_with_metadata([bare_patient], patient_metadata)
+      expect(result).to_not include('ombCategory')
+    end
+
+    it 'flags an unknown extension nested on a non-extension sub-element' do
+      bare_patient.name.first.extension = [
+        FHIR::Extension.new(
+          url: 'http://example.org/StructureDefinition/name-quirk',
+          valueString: 'value'
+        )
+      ]
+
+      result = run_non_ms_with_metadata([bare_patient], patient_metadata)
+      expect(result).to include('http://example.org/StructureDefinition/name-quirk')
+    end
+
+    it 'returns an empty array when no resources are provided' do
+      result = run_non_ms_with_metadata([], patient_metadata)
+      expect(result).to eq([])
+    end
+
+    it 'does not flag entries explicitly marked must_support: true' do
+      explicit_ms_metadata = OpenStruct.new(
+        must_supports: {
+          extensions: [],
+          slices: [],
+          elements: [
+            { path: 'gender', must_support: true },
+            { path: 'identifier', must_support: true },
+            { path: 'name', must_support: true }
+          ]
+        }
+      )
+
+      result = run_non_ms_with_metadata([bare_patient], explicit_ms_metadata)
+      expect(result).to_not include('gender', 'identifier', 'name')
+    end
+  end
+
+  describe 'non_must_support_elements via the metadata extractor' do
+    let(:patient_profile) { fixture('StructureDefinition-us-core-patient.json') }
+    let(:patient_extractor) do
+      Inferno::DSL::MustSupportMetadataExtractor.new(
+        patient_profile.snapshot.element, patient_profile, patient_profile.type, nil
+      )
+    end
+
+    it 'enumerates non-MS elements with the must_support: false flag' do
+      non_ms = patient_extractor.non_must_support_elements
+
+      expect(non_ms).to be_an(Array)
+      expect(non_ms).to all(include(must_support: false))
+      # US Core 3 patient does not mark `active` as MS; it should appear in the non-MS list.
+      expect(non_ms.map { |entry| entry[:path] }).to include('active')
+    end
+
+    it 'merges must-support and non-must-support entries into must_supports[:elements]' do
+      elements = patient_extractor.must_supports[:elements]
+      ms_paths = elements.reject { |entry| entry[:must_support] == false }.map { |entry| entry[:path] }
+      non_ms_paths = elements.select { |entry| entry[:must_support] == false }.map { |entry| entry[:path] }
+
+      expect(ms_paths).to include('identifier', 'name', 'gender')
+      expect(non_ms_paths).to include('active')
+    end
+  end
 end


### PR DESCRIPTION
### Summary

Implements the Da Vinci Burden Reduction client-side conformance rule that client requests SHALL NOT contain non-must-support elements (CRD [conf-10](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/conformance.html#ci-c-conf-10), [conf-13](https://hl7.org/fhir/us/davinci-crd/2.2.1/en/conformance.html#ci-c-conf-13), PAS [conf-12](https://hl7.org/fhir/us/davinci-pas/2.2.1/en/conformance.html#ci-c-conf-12)).

The change extends the inferno-core must-support DSL with a new analysis step that enumerates non-must-support elements from a profile and reports any that are populated in the resource(s) under test.

### What changed

- `lib/inferno/dsl/must_support_metadata_extractor.rb`
  - New `non_must_support_elements` enumerates non-must-support, non-required profile elements whose parent is the resource root or a must-support element. Entries are tagged `must_support: false`.
  - `must_supports[:elements]` now holds both must-support and non-must-support entries in a single list, matching the design decision in the ticket  ("keep everything in one structure").

- `lib/inferno/dsl/must_support_assessment.rb`
  - New public DSL method  `non_must_support_elements_present(resources, profile_url, ...)`. Same signature shape as `missing_must_support_elements` (validator, metadata, requirement_extension, and customization block all supported).
  - Internal `must_support_elements` and `must_support_extensions` accessors now filter out entries flagged `must_support: false` so the existing  "missing MS" path is unaffected.
  - New `present_non_must_support_elements` reuses the existing  `resource_populates_element?` navigation.
  - New `unexpected_extensions` walks the resource (and non-extension children) for extension URLs that are not in the must-support extensions list. Sub-extensions of an MS complex extension are intentionally not recursed into, since they belong to that extension's own definition (for example, `ombCategory` inside `us-core-race`).

- `spec/inferno/dsl/must_support_assessment_spec.rb`
  - 12 new examples for the assessment path: pure-MS request passes, populated non-MS elements flagged, multiple non-MS at once, legacy metadata is a no-op (backwards compatibility), unknown extensions flagged, versioned canonical URLs matched, MS complex-extension internals ignored, unknown extensions on non-extension sub-elements flagged, empty input handled, explicit `must_support: true` honored.
  - 2 new examples on the extractor: shape of `non_must_support_elements` and merge into `must_supports[:elements]`.
  
### Backwards compatibility

Critical for the ticket and exercised by a dedicated spec:

- Any metadata entry without an explicit `must_support` flag is treated as `must_support: true`. Existing metadata (which carries no flag) keeps the same behavior under the existing must-support checks.
- The new check is a no-op when the supplied metadata contains zero `must_support: false` entries. Older metadata never carried such entries, so calling the new DSL against it returns an empty list rather than reporting spurious extension violations.

### Tests

```
bundle exec rspec
bundle exec rubocop
```

### UI testing steps

These steps exercise the new DSL end-to-end through the Da Vinci CRD Client v2.2.1 Test Suite. They require the companion `davinci-crd-test-kit` branch `id-119-integration-non-ms-check` (helper plus a new test wired into the order-sign group).

#### Prerequisites

- Local checkout of `inferno-core` on branch `id-119-non-ms-element-check`.
- Local checkout of `davinci-crd-test-kit` on branch `id-119-integration-non-ms-check`, with its `Gemfile` pointing at the inferno-core checkout via `gem 'inferno_core', path: '../inferno-core'`.

#### Start the kit

The UI is then at `http://localhost:4567`.

#### Running the CRD Client and Server Suites Against Each Other

[Running Suites Against Each Other](https://github.com/inferno-framework/davinci-crd-test-kit/wiki/Running-Suites-Against-Each-Other).

#### Run the client suite

1. Open `http://localhost:4567` and create a session of "Da Vinci CRD Client v2.2.1 Test Suite" (any US Core option).
2. From the Preset dropdown in the upper left, select "Run against the CRD Server Suite".
3. Run group `1.1 Registration`. It should pass.

#### Drive an order-sign hook

1. Run client group `1.2.6 order-sign` until the "User Action Required" dialog appears.
2. In the CRD Server suite tab(s), run the matching server group `3.6 order-sign` to invoke the hook against Inferno's mock client.
3. Return to the client tab and click the continuation link in the "User Action Required" dialog. Attest to card display in the second dialog that appears.

#### Where to see the change

After step 3, navigate to:

```
1 Hook Invocation
  1.2 Hooks
    1.2.6 order-sign
      1.2.6.3 Requests
```

The new test appears as:

- ID: `crd_v221_hook_request_no_non_ms`
- Position in the UI tree: `1.2.6.3.04`
- Title: "Client hook requests contain no non-must-support elements"
- Verifies requirements: `hl7.fhir.us.davinci-crd_2.2.1@conf-10`, `hl7.fhir.us.davinci-crd_2.2.1@conf-13`

Click the test row to expand the detail panel. Results are visible in three
places:

1. The status icon next to the test row (pass, fail, or skip).
2. The summary line directly under the test title in the collapsed row (for example, "Requests 1, 2, 3, 4, 5, and 6: Hook request resources contained non-must-support elements. See Messages for details.").
3. The Messages tab inside the expanded detail panel. Each violation is listed as a separate row of type `error`, in the format:

   `(Request N) Prefetch Template '<template_name>' - non-must-support element present: <path or extension url>`

   Bundles add a `Bundle entry M` segment to the prefix.

   Soft-fallback warnings (for example, when a profile cannot be loaded for metadata extraction) appear as `warning` rows in the same panel and do not fail the test on their own.

#### Expected results

- Test passes (green check) when none of the captured prefetch resources populate any non-must-support element of the corresponding CRD profile.
- Test fails (red x) with one Messages entry per violation when at least one resource populates at least one non-MS element or carries an extension URL not declared as must-support in the profile.

<img width="1582" height="971" alt="Screenshot 2026-06-02 at 1 55 42 PM" src="https://github.com/user-attachments/assets/b650afbd-b89c-45d0-84e0-0e84d31f8caa" />