### PR TITLE
Add countdown for wait modals, with error message when modal expires

### DIFF
--- a/bin/inferno
+++ b/bin/inferno
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+require 'bundler/setup'
 require 'pry'
 require_relative '../lib/inferno/config/application'
 require_relative '../lib/inferno/apps/cli'

--- a/client/src/components/TestSuite/TestSession.tsx
+++ b/client/src/components/TestSuite/TestSession.tsx
@@ -457,6 +457,7 @@ const TestSessionComponent: FC<TestSessionComponentProps> = ({
             cancelTestRun={cancelTestRun}
             message={waitingTestId ? resultsMap.get(waitingTestId)?.result_message : ''}
             modalVisible={!!waitingTestId}
+            waitTimeout={testRun?.wait_timeout}
           />
         </Box>
       </main>

--- a/client/src/components/_common/ActionModal.tsx
+++ b/client/src/components/_common/ActionModal.tsx
@@ -18,7 +18,12 @@ export interface ActionModalProps {
   waitTimeout?: string;
 }
 
-const ActionModal: FC<ActionModalProps> = ({ modalVisible, message, cancelTestRun, waitTimeout }) => {
+const ActionModal: FC<ActionModalProps> = ({
+  modalVisible,
+  message,
+  cancelTestRun,
+  waitTimeout,
+}) => {
   const [secondsRemaining, setSecondsRemaining] = useState<number | null>(null);
 
   useEffect(() => {
@@ -47,10 +52,7 @@ const ActionModal: FC<ActionModalProps> = ({ modalVisible, message, cancelTestRu
 
     if (secondsRemaining === 0) {
       return (
-        <Typography
-          variant="body2"
-          sx={{ fontWeight: 'bold', color: 'error.main' }}
-        >
+        <Typography variant="body2" sx={{ fontWeight: 'bold', color: 'error.main' }}>
           This test has expired. Click CANCEL to restart the test.
         </Typography>
       );
@@ -60,7 +62,9 @@ const ActionModal: FC<ActionModalProps> = ({ modalVisible, message, cancelTestRu
       <Typography variant="body2">
         {'This test will expire in '}
         <strong>{secondsRemaining} seconds</strong>
-        {'. Perform the needed action before the time expires or cancel the test to reset the timer.'}
+        {
+          '. Perform the needed action before the time expires or cancel the test to reset the timer.'
+        }
       </Typography>
     );
   };
@@ -73,7 +77,9 @@ const ActionModal: FC<ActionModalProps> = ({ modalVisible, message, cancelTestRu
           <Markdown remarkPlugins={[remarkGfm]}>{message || ''}</Markdown>
         </DialogContentText>
       </DialogContent>
-      <DialogActions sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+      <DialogActions
+        sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}
+      >
         {renderCountdown()}
         <Button
           color="secondary"

--- a/client/src/components/_common/ActionModal.tsx
+++ b/client/src/components/_common/ActionModal.tsx
@@ -5,8 +5,9 @@ import {
   DialogContent,
   DialogContentText,
   DialogTitle,
+  Typography,
 } from '@mui/material';
-import React, { FC } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
@@ -14,9 +15,56 @@ export interface ActionModalProps {
   modalVisible: boolean;
   message?: string;
   cancelTestRun: () => void;
+  waitTimeout?: string;
 }
 
-const ActionModal: FC<ActionModalProps> = ({ modalVisible, message, cancelTestRun }) => {
+const ActionModal: FC<ActionModalProps> = ({ modalVisible, message, cancelTestRun, waitTimeout }) => {
+  const [secondsRemaining, setSecondsRemaining] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!modalVisible || !waitTimeout) {
+      setSecondsRemaining(null);
+      return;
+    }
+
+    const expiryTime = new Date(waitTimeout).getTime();
+
+    const computeRemaining = () => Math.max(0, Math.floor((expiryTime - Date.now()) / 1000));
+
+    setSecondsRemaining(computeRemaining());
+
+    const interval = setInterval(() => {
+      const remaining = computeRemaining();
+      setSecondsRemaining(remaining);
+      if (remaining === 0) clearInterval(interval);
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [modalVisible, waitTimeout]);
+
+  const renderCountdown = () => {
+    if (secondsRemaining === null) return null;
+
+    if (secondsRemaining === 0) {
+      return (
+        <Typography
+          variant="body2"
+          sx={{ fontWeight: 'bold', color: 'error.main' }}
+        >
+          This test has expired. Click CANCEL to restart the test.
+        </Typography>
+      );
+    }
+
+    return (
+      <Typography variant="body2">
+        {'This test will expire in '}
+        <strong>{secondsRemaining} seconds</strong>
+        {'. Perform the needed action before the time expires or cancel the test to reset the timer.'}
+      </Typography>
+    );
+  };
+
   return (
     <Dialog open={modalVisible} fullWidth maxWidth="sm">
       <DialogTitle>User Action Required</DialogTitle>
@@ -25,14 +73,15 @@ const ActionModal: FC<ActionModalProps> = ({ modalVisible, message, cancelTestRu
           <Markdown remarkPlugins={[remarkGfm]}>{message || ''}</Markdown>
         </DialogContentText>
       </DialogContent>
-      <DialogActions>
+      <DialogActions sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        {renderCountdown()}
         <Button
           color="secondary"
           variant="contained"
           disableElevation
           onClick={cancelTestRun}
           data-testid="cancel-button"
-          sx={{ fontWeight: 'bold' }}
+          sx={{ fontWeight: 'bold', flexShrink: 0 }}
         >
           Cancel
         </Button>

--- a/client/src/components/_common/ActionModal.tsx
+++ b/client/src/components/_common/ActionModal.tsx
@@ -61,7 +61,9 @@ const ActionModal: FC<ActionModalProps> = ({
     return (
       <Typography variant="body2">
         {'This test run expires and will stop responding in '}
-        <strong>{secondsRemaining} {secondsRemaining === 1 ? 'second' : 'seconds'}.</strong>
+        <strong>
+          {secondsRemaining} {secondsRemaining === 1 ? 'second' : 'seconds'}.
+        </strong>
       </Typography>
     );
   };

--- a/client/src/components/_common/ActionModal.tsx
+++ b/client/src/components/_common/ActionModal.tsx
@@ -61,7 +61,7 @@ const ActionModal: FC<ActionModalProps> = ({
     return (
       <Typography variant="body2">
         {'This test run expires and will stop responding in '}
-        <strong>{secondsRemaining} seconds.</strong>
+        <strong>{secondsRemaining} {secondsRemaining === 1 ? 'second' : 'seconds'}.</strong>
       </Typography>
     );
   };

--- a/client/src/components/_common/ActionModal.tsx
+++ b/client/src/components/_common/ActionModal.tsx
@@ -53,18 +53,15 @@ const ActionModal: FC<ActionModalProps> = ({
     if (secondsRemaining === 0) {
       return (
         <Typography variant="body2" sx={{ fontWeight: 'bold', color: 'error.main' }}>
-          This test has expired. Click CANCEL to restart the test.
+          This test run has expired. Click CANCEL to continue the session.
         </Typography>
       );
     }
 
     return (
       <Typography variant="body2">
-        {'This test will expire in '}
-        <strong>{secondsRemaining} seconds</strong>
-        {
-          '. Perform the needed action before the time expires or cancel the test to reset the timer.'
-        }
+        {'This test run expires and will stop responding in '}
+        <strong>{secondsRemaining} seconds.</strong>
       </Typography>
     );
   };
@@ -78,7 +75,7 @@ const ActionModal: FC<ActionModalProps> = ({
         </DialogContentText>
       </DialogContent>
       <DialogActions
-        sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}
+        sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', pl: 3 }}
       >
         {renderCountdown()}
         <Button

--- a/client/src/components/_common/__tests__/ActionModal.test.tsx
+++ b/client/src/components/_common/__tests__/ActionModal.test.tsx
@@ -57,8 +57,8 @@ test('No countdown shown when waitTimeout prop is absent (component fallback)', 
     </ThemeProvider>,
   );
 
-  expect(screen.queryByText(/This test will expire in/)).toBeNull();
-  expect(screen.queryByText(/This test has expired/)).toBeNull();
+  expect(screen.queryByText(/This test run expires and will stop responding in/)).toBeNull();
+  expect(screen.queryByText(/This test run has expired/)).toBeNull();
 });
 
 describe('Countdown timer', () => {
@@ -86,9 +86,8 @@ describe('Countdown timer', () => {
       </ThemeProvider>,
     );
 
-    expect(screen.getByText(/This test will expire in/)).toBeVisible();
+    expect(screen.getByText(/This test run expires and will stop responding in/)).toBeVisible();
     expect(screen.getByText(/120 seconds/)).toBeVisible();
-    expect(screen.getByText(/Perform the needed action before the time expires/)).toBeVisible();
   });
 
   test('Countdown seconds value is rendered in a bold element', () => {
@@ -157,10 +156,10 @@ describe('Countdown timer', () => {
     });
 
     const expiredText = screen.getByText(
-      /This test has expired. Click CANCEL to restart the test./,
+      /This test run has expired. Click CANCEL to continue the session./,
     );
     expect(expiredText).toBeVisible();
-    expect(screen.queryByText(/This test will expire in/)).toBeNull();
+    expect(screen.queryByText(/This test run expires and will stop responding in/)).toBeNull();
   });
 
   test('No countdown shown when modal is not visible', () => {
@@ -179,7 +178,7 @@ describe('Countdown timer', () => {
       </ThemeProvider>,
     );
 
-    expect(screen.queryByText(/This test will expire in/)).toBeNull();
-    expect(screen.queryByText(/This test has expired/)).toBeNull();
+    expect(screen.queryByText(/This test run expires and will stop responding in/)).toBeNull();
+    expect(screen.queryByText(/This test run has expired/)).toBeNull();
   });
 });

--- a/client/src/components/_common/__tests__/ActionModal.test.tsx
+++ b/client/src/components/_common/__tests__/ActionModal.test.tsx
@@ -111,7 +111,7 @@ describe('Countdown timer', () => {
     expect(boldEl.tagName).toBe('STRONG');
   });
 
-  test('Countdown decrements after one second', async () => {
+  test('Countdown decrements after one second', () => {
     const waitTimeout = new Date(Date.now() + 120_000).toISOString();
 
     render(
@@ -129,14 +129,14 @@ describe('Countdown timer', () => {
 
     expect(screen.getByText(/120 seconds/)).toBeVisible();
 
-    await act(async () => {
+    act(() => {
       vi.advanceTimersByTime(1000);
     });
 
     expect(screen.getByText(/119 seconds/)).toBeVisible();
   });
 
-  test('Shows expired message when countdown reaches zero', async () => {
+  test('Shows expired message when countdown reaches zero', () => {
     const waitTimeout = new Date(Date.now() + 1000).toISOString();
 
     render(
@@ -152,11 +152,13 @@ describe('Countdown timer', () => {
       </ThemeProvider>,
     );
 
-    await act(async () => {
+    act(() => {
       vi.advanceTimersByTime(2000);
     });
 
-    const expiredText = screen.getByText(/This test has expired. Click CANCEL to restart the test./);
+    const expiredText = screen.getByText(
+      /This test has expired. Click CANCEL to restart the test./,
+    );
     expect(expiredText).toBeVisible();
     expect(screen.queryByText(/This test will expire in/)).toBeNull();
   });

--- a/client/src/components/_common/__tests__/ActionModal.test.tsx
+++ b/client/src/components/_common/__tests__/ActionModal.test.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { act } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ThemeProvider from 'components/ThemeProvider';
 import { SnackbarProvider } from 'notistack';
 
-import { expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import ActionModal from '../ActionModal';
 
 const cancelTestRunMock = vi.fn();
@@ -42,4 +42,142 @@ test('Pressing cancel hides the modal', async () => {
   const cancelButton = screen.getByTestId('cancel-button');
   await userEvent.click(cancelButton);
   expect(cancelTestRunMock).toHaveBeenCalled();
+});
+
+test('No countdown shown when waitTimeout prop is absent (component fallback)', () => {
+  render(
+    <ThemeProvider>
+      <SnackbarProvider>
+        <ActionModal
+          modalVisible={true}
+          message="Mock action message"
+          cancelTestRun={cancelTestRunMock}
+        />
+      </SnackbarProvider>
+    </ThemeProvider>,
+  );
+
+  expect(screen.queryByText(/This test will expire in/)).toBeNull();
+  expect(screen.queryByText(/This test has expired/)).toBeNull();
+});
+
+describe('Countdown timer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('Shows countdown text when waitTimeout is provided', () => {
+    const waitTimeout = new Date(Date.now() + 120_000).toISOString();
+
+    render(
+      <ThemeProvider>
+        <SnackbarProvider>
+          <ActionModal
+            modalVisible={true}
+            message="Mock action message"
+            cancelTestRun={cancelTestRunMock}
+            waitTimeout={waitTimeout}
+          />
+        </SnackbarProvider>
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByText(/This test will expire in/)).toBeVisible();
+    expect(screen.getByText(/120 seconds/)).toBeVisible();
+    expect(screen.getByText(/Perform the needed action before the time expires/)).toBeVisible();
+  });
+
+  test('Countdown seconds value is rendered in a bold element', () => {
+    const waitTimeout = new Date(Date.now() + 120_000).toISOString();
+
+    render(
+      <ThemeProvider>
+        <SnackbarProvider>
+          <ActionModal
+            modalVisible={true}
+            message="Mock action message"
+            cancelTestRun={cancelTestRunMock}
+            waitTimeout={waitTimeout}
+          />
+        </SnackbarProvider>
+      </ThemeProvider>,
+    );
+
+    const boldEl = screen.getByText(/120 seconds/);
+    expect(boldEl.tagName).toBe('STRONG');
+  });
+
+  test('Countdown decrements after one second', async () => {
+    const waitTimeout = new Date(Date.now() + 120_000).toISOString();
+
+    render(
+      <ThemeProvider>
+        <SnackbarProvider>
+          <ActionModal
+            modalVisible={true}
+            message="Mock action message"
+            cancelTestRun={cancelTestRunMock}
+            waitTimeout={waitTimeout}
+          />
+        </SnackbarProvider>
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByText(/120 seconds/)).toBeVisible();
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByText(/119 seconds/)).toBeVisible();
+  });
+
+  test('Shows expired message when countdown reaches zero', async () => {
+    const waitTimeout = new Date(Date.now() + 1000).toISOString();
+
+    render(
+      <ThemeProvider>
+        <SnackbarProvider>
+          <ActionModal
+            modalVisible={true}
+            message="Mock action message"
+            cancelTestRun={cancelTestRunMock}
+            waitTimeout={waitTimeout}
+          />
+        </SnackbarProvider>
+      </ThemeProvider>,
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    const expiredText = screen.getByText(/This test has expired. Click CANCEL to restart the test./);
+    expect(expiredText).toBeVisible();
+    expect(screen.queryByText(/This test will expire in/)).toBeNull();
+  });
+
+  test('No countdown shown when modal is not visible', () => {
+    const waitTimeout = new Date(Date.now() + 120_000).toISOString();
+
+    render(
+      <ThemeProvider>
+        <SnackbarProvider>
+          <ActionModal
+            modalVisible={false}
+            message="Mock action message"
+            cancelTestRun={cancelTestRunMock}
+            waitTimeout={waitTimeout}
+          />
+        </SnackbarProvider>
+      </ThemeProvider>,
+    );
+
+    expect(screen.queryByText(/This test will expire in/)).toBeNull();
+    expect(screen.queryByText(/This test has expired/)).toBeNull();
+  });
 });

--- a/client/src/models/testSuiteModels.ts
+++ b/client/src/models/testSuiteModels.ts
@@ -161,6 +161,7 @@ export interface TestRun {
   test_id?: string;
   test_session_id?: string;
   test_suite_id?: string;
+  wait_timeout?: string;
 }
 
 export interface TestSession {

--- a/dev_suites/dev_demo_ig_stu1/demo_suite.rb
+++ b/dev_suites/dev_demo_ig_stu1/demo_suite.rb
@@ -52,7 +52,8 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
       wait_test_fail_url: "#{Inferno::Application['base_url']}/custom/demo/resume_fail",
       wait_test_skip_url: "#{Inferno::Application['base_url']}/custom/demo/resume_skip",
       wait_test_omit_url: "#{Inferno::Application['base_url']}/custom/demo/resume_omit",
-      wait_test_cancel_url: "#{Inferno::Application['base_url']}/custom/demo/resume_cancel"
+      wait_test_cancel_url: "#{Inferno::Application['base_url']}/custom/demo/resume_cancel",
+      wait_expire_demo_url: "#{Inferno::Application['base_url']}/custom/demo/resume_expire_demo"
     }
 
     group do
@@ -605,6 +606,34 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
         input :patient_identifier_select, title: 'Patient ID (Select)', type: 'text', optional: true,
                                           enable_when: { input_name: 'get_type_select', value: 'summary_op' }
         run { pass }
+      end
+    end
+
+    group do
+      id 'wait_cancel_group'
+      title 'Wait Cancellation Group'
+      optional
+
+      resume_test_route :get, '/resume_expire_demo' do |request|
+        request.query_parameters['xyz']
+      end
+
+      test do
+        title 'Wait timeout expiry demo'
+        receives_request :resume_expire_demo
+
+        run do
+          identifier = 'expire_demo'
+
+          wait(
+            identifier:,
+            timeout: 3,
+            message: %(
+              This test is to show off the wait UI when time expires.
+              Watch the countdown below reach zero, then click CANCEL to finish the test.
+            )
+          )
+        end
       end
     end
   end

--- a/lib/inferno/apps/web/serializers/test_run.rb
+++ b/lib/inferno/apps/web/serializers/test_run.rb
@@ -16,6 +16,7 @@ module Inferno
         field :test_group_id, if: :field_present?
         field :test_suite_id, if: :field_present?
         field :test_id, if: :field_present?
+        field :wait_timeout, if: :field_present?
 
         association :results, blueprint: Result
         association :inputs, blueprint: Input


### PR DESCRIPTION
- Wait modals in test runs have been given a countdown timer to declare to the user that the wait will only last for X more seconds before the test fails
- If the test times out, a new message appears telling users to cancel and restart their test run
- Bonus fix: bin/inferno migrate did not have the authority to downgrade certain bundles if needed for running inferno core locally, so it has been granted the ability to perform `bundle exec` commands

<img width="1091" height="1051" alt="image" src="https://github.com/user-attachments/assets/053b989a-5c71-470c-b3d3-5ca85ea73fe3" />

<img width="1131" height="577" alt="image" src="https://github.com/user-attachments/assets/fd1b6017-c809-443f-a4c3-ce4430579de6" />
