### PR TITLE
Added Attestation banner

### DIFF
--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/AttestationBadge.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/AttestationBadge.tsx
@@ -1,0 +1,23 @@
+import React, { FC } from 'react';
+import { Chip } from '@mui/material';
+import PersonIcon from '@mui/icons-material/Person';
+import CustomTooltip from '~/components/_common/CustomTooltip';
+
+import useStyles from './styles';
+
+const AttestationBadge: FC = () => {
+  const { classes } = useStyles();
+
+  return (
+    <CustomTooltip title="Inferno cannot independently verify this behavior.">
+      <Chip
+        icon={<PersonIcon />}
+        label="Attestation"
+        size="small"
+        className={classes.attestationChip}
+      />
+    </CustomTooltip>
+  );
+};
+
+export default AttestationBadge;

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/TestListItem.tsx
@@ -23,6 +23,7 @@ import RequestList from './RequestList';
 import ResultIcon from '../ResultIcon';
 import ProblemBadge from './ProblemBadge';
 import SimulationVerificationBadge from './SimulationVerificationBadge';
+import AttestationBadge from './AttestationBadge';
 import TestRunDetail from './TestRunDetail';
 import type { TabProps } from './TestRunDetail';
 import { MessageCounts, countMessageTypes } from './helper';
@@ -80,6 +81,7 @@ const TestListItem: FC<TestListItemProps> = ({
       {test.optional && <Typography className={classes.optionalLabel}>{'Optional '}</Typography>}
       <Typography className={classes.labelText}>{test.title}</Typography>
       {test.is_simulation_verification && <SimulationVerificationBadge />}
+      {test.is_attestation && <AttestationBadge />}
     </>
   );
 

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/__tests__/AttestationBadge.test.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/__tests__/AttestationBadge.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import ThemeProvider from 'components/ThemeProvider';
 import { describe, expect, test } from 'vitest';
 
@@ -14,7 +14,7 @@ describe('The AttestationBadge component', () => {
     );
 
     const badge = screen.getByText('Attestation');
-    expect(badge).toBeDefined();
+    expect(badge).not.toBeNull();
   });
 
   test('it renders with a person icon', () => {
@@ -25,17 +25,20 @@ describe('The AttestationBadge component', () => {
     );
 
     const icon = container.querySelector('.MuiChip-icon');
-    expect(icon).toBeDefined();
+    expect(icon).not.toBeNull();
   });
 
-  test('it renders the tooltip with the correct text', () => {
+  test('it renders the tooltip with the correct text', async () => {
     render(
       <ThemeProvider>
         <AttestationBadge />
       </ThemeProvider>,
     );
 
-    const chip = screen.getByText('Attestation').closest('.MuiChip-root');
-    expect(chip).toBeDefined();
+    const chip = screen.getByText('Attestation').closest('.MuiChip-root') as Element;
+    fireEvent.mouseOver(chip);
+
+    const tooltip = await screen.findByText('Inferno cannot independently verify this behavior.');
+    expect(tooltip).not.toBeNull();
   });
 });

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/__tests__/AttestationBadge.test.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/__tests__/AttestationBadge.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ThemeProvider from 'components/ThemeProvider';
+import { describe, expect, test } from 'vitest';
+
+import AttestationBadge from '../AttestationBadge';
+
+describe('The AttestationBadge component', () => {
+  test('it renders the badge with correct label', () => {
+    render(
+      <ThemeProvider>
+        <AttestationBadge />
+      </ThemeProvider>,
+    );
+
+    const badge = screen.getByText('Attestation');
+    expect(badge).toBeDefined();
+  });
+
+  test('it renders with a person icon', () => {
+    const { container } = render(
+      <ThemeProvider>
+        <AttestationBadge />
+      </ThemeProvider>,
+    );
+
+    const icon = container.querySelector('.MuiChip-icon');
+    expect(icon).toBeDefined();
+  });
+
+  test('it renders the tooltip with the correct text', () => {
+    render(
+      <ThemeProvider>
+        <AttestationBadge />
+      </ThemeProvider>,
+    );
+
+    const chip = screen.getByText('Attestation').closest('.MuiChip-root');
+    expect(chip).toBeDefined();
+  });
+});

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/__tests__/TestListItem.test.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/__tests__/TestListItem.test.tsx
@@ -264,4 +264,74 @@ describe('The TestListItem component', () => {
       expect(screen.queryByText('Simulation Verification')).not.toBeInTheDocument();
     });
   });
+
+  describe('Attestation Badge', () => {
+    const outputs: TestOutput[] = [{ name: 'One', value: 'one' }];
+    const inputs: TestInput[] = [{ name: 'two', value: 'two' }];
+
+    it('renders the badge when is_attestation is true', () => {
+      const test: Test = {
+        id: 'test_id',
+        title: 'Test Title',
+        inputs: inputs,
+        short_id: 'short_id',
+        outputs: outputs,
+        user_runnable: false,
+        is_attestation: true,
+      };
+
+      render(
+        <BrowserRouter>
+          <ThemeProvider>
+            <TestListItem test={test} view="run" />
+          </ThemeProvider>
+        </BrowserRouter>,
+      );
+
+      expect(screen.getByText('Attestation')).toBeInTheDocument();
+    });
+
+    it('does not render the badge when is_attestation is false', () => {
+      const test: Test = {
+        id: 'test_id',
+        title: 'Test Title',
+        inputs: inputs,
+        short_id: 'short_id',
+        outputs: outputs,
+        user_runnable: false,
+        is_attestation: false,
+      };
+
+      render(
+        <BrowserRouter>
+          <ThemeProvider>
+            <TestListItem test={test} view="run" />
+          </ThemeProvider>
+        </BrowserRouter>,
+      );
+
+      expect(screen.queryByText('Attestation')).not.toBeInTheDocument();
+    });
+
+    it('does not render the badge when is_attestation is undefined', () => {
+      const test: Test = {
+        id: 'test_id',
+        title: 'Test Title',
+        inputs: inputs,
+        short_id: 'short_id',
+        outputs: outputs,
+        user_runnable: false,
+      };
+
+      render(
+        <BrowserRouter>
+          <ThemeProvider>
+            <TestListItem test={test} view="run" />
+          </ThemeProvider>
+        </BrowserRouter>,
+      );
+
+      expect(screen.queryByText('Attestation')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/client/src/components/TestSuite/TestSuiteDetails/TestListItem/styles.tsx
+++ b/client/src/components/TestSuite/TestSuiteDetails/TestListItem/styles.tsx
@@ -170,4 +170,14 @@ export default makeStyles()((theme: Theme) => ({
       color: theme.palette.common.orangeDark,
     },
   },
+  attestationChip: {
+    backgroundColor: theme.palette.common.yellowLight,
+    color: theme.palette.common.yellowDark,
+    fontWeight: 'bold',
+    marginLeft: '8px',
+    height: '24px',
+    '& .MuiChip-icon': {
+      color: theme.palette.common.yellowDark,
+    },
+  },
 }));

--- a/client/src/models/testSuiteModels.ts
+++ b/client/src/models/testSuiteModels.ts
@@ -202,6 +202,7 @@ export type Test = Runnable & {
   outputs: TestOutput[];
   user_runnable?: boolean;
   is_simulation_verification?: boolean;
+  is_attestation?: boolean;
 };
 
 export type TestGroup = Runnable & {

--- a/client/src/styles/theme.tsx
+++ b/client/src/styles/theme.tsx
@@ -7,6 +7,8 @@ declare module '@mui/material/styles/createPalette' {
     orangeLight: string;
     orange: string;
     orangeDark: string;
+    yellowLight: string;
+    yellowDark: string;
     blueLightest: string;
     blueLight: string;
     blue: string;
@@ -21,6 +23,8 @@ const colors = {
   orangeLight: '#fbe2cd',
   orange: '#f77a25',
   orangeDark: '#c05702',
+  yellowLight: '#feedce',
+  yellowDark: '#9a6500',
   blueLightest: '#f1f8ff',
   blueLight: '#9ad2f0',
   blue: '#316DB1',

--- a/dev_suites/dev_demo_ig_stu1/demo_suite.rb
+++ b/dev_suites/dev_demo_ig_stu1/demo_suite.rb
@@ -53,7 +53,9 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
       wait_test_skip_url: "#{Inferno::Application['base_url']}/custom/demo/resume_skip",
       wait_test_omit_url: "#{Inferno::Application['base_url']}/custom/demo/resume_omit",
       wait_test_cancel_url: "#{Inferno::Application['base_url']}/custom/demo/resume_cancel",
-      wait_expire_demo_url: "#{Inferno::Application['base_url']}/custom/demo/resume_expire_demo"
+      wait_expire_demo_url: "#{Inferno::Application['base_url']}/custom/demo/resume_expire_demo",
+      attest_true_url: "#{Inferno::Application['base_url']}/custom/demo/resume_attest",
+      attest_false_url: "#{Inferno::Application['base_url']}/custom/demo/resume_attest_fail"
     }
 
     group do
@@ -531,6 +533,60 @@ module DemoIG_STU1 # rubocop:disable Naming/ClassAndModuleCamelCase
         end
       end
     end
+
+    group do
+      id 'attestation_group'
+      title 'Attestation Group'
+      description %(
+        This group demonstrates attestation-style tests where a user manually
+        attests to a behavior that Inferno cannot independently verify.
+      )
+
+      resume_test_route :get, '/resume_attest' do |request|
+        request.query_parameters['xyz']
+      end
+
+      resume_test_route :get, '/resume_attest_fail', result: 'fail' do |request|
+        request.query_parameters['xyz']
+      end
+
+      test do
+        title 'Attest to system behavior'
+        description %(
+          Since Inferno cannot independently verify this behavior, this test provides
+          testers with an opportunity to attest to whether their system supports it.
+        )
+        attestation
+
+        output :attest_true_url
+        output :attest_false_url
+
+        run do
+          identifier = 'attest_demo'
+          url_suffix = "?xyz=#{identifier}"
+          attest_true_url = "#{config.options[:attest_true_url]}#{url_suffix}"
+          attest_false_url = "#{config.options[:attest_false_url]}#{url_suffix}"
+
+          output(attest_true_url:)
+          output(attest_false_url:)
+
+          wait(
+            identifier:,
+            message: %(
+              **Attestation**:
+
+              I attest that the system supports a behavior that Inferno cannot
+              independently verify.
+
+              [Click here](#{attest_true_url}) if the above statement is **true**.
+
+              [Click here](#{attest_false_url}) if the above statement is **false**.
+            )
+          )
+        end
+      end
+    end
+
     group do
       id 'message_normalization_sort_group'
       title 'Execute Script Message Normalization Sort Group'

--- a/execution_scripts/demo/demo_message_normalization_sort.yaml
+++ b/execution_scripts/demo/demo_message_normalization_sort.yaml
@@ -23,7 +23,7 @@ comparison_config:
 steps:
   - status: created
     start_run:
-      runnable: 12
+      runnable: 13
       inputs:
         normalization_sort_url: 'http://zzz.example.com'
 

--- a/execution_scripts/demo/demo_message_normalization_sort.yaml
+++ b/execution_scripts/demo/demo_message_normalization_sort.yaml
@@ -28,5 +28,5 @@ steps:
         normalization_sort_url: 'http://zzz.example.com'
 
   - status: done
-    last_completed: 12
+    last_completed: 13
     action: END_SCRIPT

--- a/lib/inferno/apps/web/serializers/test.rb
+++ b/lib/inferno/apps/web/serializers/test.rb
@@ -22,6 +22,7 @@ module Inferno
         field :user_runnable?, name: :user_runnable
         field :optional?, name: :optional
         field :simulation_verification?, name: :is_simulation_verification
+        field :attestation?, name: :is_attestation
         field :verifies_requirements, if: :field_present?, extractor: RequirementsFilteringExtractor
       end
     end

--- a/lib/inferno/dsl/runnable.rb
+++ b/lib/inferno/dsl/runnable.rb
@@ -324,6 +324,21 @@ module Inferno
         !!@is_simulation_verification
       end
 
+      # Mark as attestation. Tests are not attestation by default.
+      #
+      # @param attestation [Boolean]
+      # @return [void]
+      def attestation(attestation = true) # rubocop:disable Style/OptionalBooleanParameter
+        @is_attestation = attestation
+      end
+
+      # The test is attestation if true
+      #
+      # @return [Boolean]
+      def attestation?
+        !!@is_attestation
+      end
+
       # @private
       def default_id
         to_s

--- a/spec/inferno/dsl/test_creation_spec.rb
+++ b/spec/inferno/dsl/test_creation_spec.rb
@@ -193,6 +193,22 @@ RSpec.describe InfrastructureTest::Suite do
 
         expect(sim_group.tests.first.simulation_verification?).to be(true)
       end
+
+      it 'sets attestation when declared on a test' do
+        attest_group = Class.new(Inferno::TestGroup) do
+          id 'attest_group'
+
+          test do
+            title 'Attestation test'
+            id 'attest_test'
+            attestation
+
+            run { pass }
+          end
+        end
+
+        expect(attest_group.tests.first.attestation?).to be(true)
+      end
     end
 
     describe 'inner inline group' do

--- a/spec/inferno/web/serializers/test_spec.rb
+++ b/spec/inferno/web/serializers/test_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Inferno::Web::Serializers::Test do
 
     expected_keys = ['id', 'short_id', 'description', 'inputs', 'outputs', 'title',
                      'user_runnable', 'optional', 'short_description', 'short_title',
-                     'input_instructions', 'verifies_requirements', 'is_simulation_verification']
+                     'input_instructions', 'verifies_requirements', 'is_simulation_verification',
+                     'is_attestation']
 
     expect(serialized_test.keys).to match_array(expected_keys)
     expect(serialized_test['id']).to eq(test.id.to_s)


### PR DESCRIPTION
**Add Attestation badge for tests**

Introduces an `attestation` flag for `Inferno::Test` (parallel to the existing `simulation_verification` flag) that renders a yellow chip badge in the test UI for tests that require user attestation of a behavior Inferno cannot independently verify.

**Backend**
- Added `attestation` / `attestation?` DSL methods to `Inferno::DSL::Runnable`
- Added `is_attestation` field to the `Test` serializer (test-only; not exposed on groups)

**Frontend**
- Added `yellowLight` / `yellowDark` color tokens to the theme, derived from the yellow in the Inferno logo (`#F9BE50`)
- Created `AttestationBadge` component — a `PersonIcon` chip with the tooltip _"Inferno cannot independently verify this behavior."_
- Added `is_attestation` to the `Test` TypeScript model
- Rendered `AttestationBadge` in `TestListItem` when `is_attestation` is true

**Demo**
- Added an _Attestation Group_ to the demo suite with a wait-based attestation test using the new `attestation` DSL flag

**Tests**
- `AttestationBadge.test.tsx` — component unit tests
- TestListItem.test.tsx — badge renders/hides correctly based on `is_attestation`
- test_creation_spec.rb — verifies `attestation?` is set correctly via DSL
- test_spec.rb — `is_attestation` included in serialized test keys

<img width="771" height="145" alt="image" src="https://github.com/user-attachments/assets/f5799bc9-6e06-4024-a21f-432d857755b0" />
