### PR TITLE
Move metadata extractor upgrades to Core

### DIFF
--- a/lib/inferno/dsl/must_support_metadata_extractor.rb
+++ b/lib/inferno/dsl/must_support_metadata_extractor.rb
@@ -198,22 +198,7 @@ module Inferno
             system: pattern_element.patternCoding.system
           }
         elsif pattern_element.patternIdentifier
-          identifier_type_coding = pattern_element.patternIdentifier.type&.coding&.first
-          if identifier_type_coding
-            type_path = runtime_path.present? ? "#{runtime_path}.type" : 'type'
-            {
-              type: 'patternCodeableConcept',
-              path: type_path,
-              code: identifier_type_coding.code,
-              system: identifier_type_coding.system
-            }
-          else
-            {
-              type: 'patternIdentifier',
-              path: runtime_path,
-              system: pattern_element.patternIdentifier.system
-            }
-          end
+          save_pattern_identifier_slice(pattern_element.patternIdentifier, runtime_path)
         elsif required_binding_pattern?(pattern_element)
           {
             type: 'requiredBinding',
@@ -231,6 +216,25 @@ module Inferno
 
       def required_binding_pattern?(pattern_element)
         pattern_element.binding&.strength == 'required' && pattern_element.binding&.valueSet
+      end
+
+      def save_pattern_identifier_slice(pattern_identifier, runtime_path)
+        identifier_type_coding = pattern_identifier.type&.coding&.first
+        if identifier_type_coding
+          type_path = runtime_path.present? ? "#{runtime_path}.type" : 'type'
+          {
+            type: 'patternCodeableConcept',
+            path: type_path,
+            code: identifier_type_coding.code,
+            system: identifier_type_coding.system
+          }
+        else
+          {
+            type: 'patternIdentifier',
+            path: runtime_path,
+            system: pattern_identifier.system
+          }
+        end
       end
 
       def extract_required_binding_values(pattern_element, metadata)

--- a/lib/inferno/dsl/must_support_metadata_extractor.rb
+++ b/lib/inferno/dsl/must_support_metadata_extractor.rb
@@ -198,11 +198,22 @@ module Inferno
             system: pattern_element.patternCoding.system
           }
         elsif pattern_element.patternIdentifier
-          {
-            type: 'patternIdentifier',
-            path: runtime_path,
-            system: pattern_element.patternIdentifier.system
-          }
+          identifier_type_coding = pattern_element.patternIdentifier.type&.coding&.first
+          if identifier_type_coding
+            type_path = runtime_path.present? ? "#{runtime_path}.type" : 'type'
+            {
+              type: 'patternCodeableConcept',
+              path: type_path,
+              code: identifier_type_coding.code,
+              system: identifier_type_coding.system
+            }
+          else
+            {
+              type: 'patternIdentifier',
+              path: runtime_path,
+              system: pattern_element.patternIdentifier.system
+            }
+          end
         elsif required_binding_pattern?(pattern_element)
           {
             type: 'requiredBinding',

--- a/spec/inferno/dsl/must_support_metadata_extractor_spec.rb
+++ b/spec/inferno/dsl/must_support_metadata_extractor_spec.rb
@@ -384,6 +384,52 @@ RSpec.describe Inferno::DSL::MustSupportMetadataExtractor do
         }
       )
     end
+
+    it 'emits a patternCodeableConcept discriminator for a patternIdentifier slice with type.coding' do
+      discriminator = FHIR::ElementDefinition::Slicing::Discriminator.new(type: 'value', path: '$this')
+      slicing = FHIR::ElementDefinition::Slicing.new(discriminator: [discriminator])
+      identifier_type = FHIR::CodeableConcept.new(
+        coding: [FHIR::Coding.new(system: 'http://terminology.hl7.org/CodeSystem/v2-0203', code: 'PI')]
+      )
+      profile_elements = [
+        FHIR::ElementDefinition.new(
+          id: 'Organization.identifier',
+          path: 'Organization.identifier',
+          mustSupport: false,
+          slicing:
+        ),
+        FHIR::ElementDefinition.new(
+          id: 'Organization.identifier:PI',
+          path: 'Organization.identifier',
+          sliceName: 'PI',
+          mustSupport: true,
+          patternIdentifier: FHIR::Identifier.new(type: identifier_type)
+        )
+      ]
+      org_profile = instance_double(
+        FHIR::StructureDefinition,
+        baseDefinition: 'baseDefinition',
+        name: 'organization',
+        type: 'Organization',
+        version: '2.2.0'
+      )
+
+      slices = described_class.new(profile_elements, org_profile, 'Organization', ig_resources).value_slices
+
+      expect(slices).to contain_exactly(
+        {
+          slice_id: 'Organization.identifier:PI',
+          slice_name: 'PI',
+          path: 'identifier',
+          discriminator: {
+            type: 'patternCodeableConcept',
+            path: 'type',
+            code: 'PI',
+            system: 'http://terminology.hl7.org/CodeSystem/v2-0203'
+          }
+        }
+      )
+    end
   end
 
   describe '#must_support_elements' do


### PR DESCRIPTION
Several metadata extractor enhancements were made to a custom extension to the service in the Davinci PAS test kit. These enhancements were found to be useful for all kits, so they have been moved to Inferno Core for direct use through the base class.

To Test:
- Check out this branch locally and run bundle
- Check out the `support-v2.2.0` branch of the PAS test kit
- In the PAS kit, add `gem 'inferno_core', path: 'relative/path/to/local/repo'` to the gemfile and run `bundle`
  - You might also need to delete the existing inferno_core reference in the gemspec file for this local reference to work
- Run the pas suites (server and client) against each other. Ensure everything passes