### PR TITLE
Add around_test hook so instrumentation can be scoped per test

### DIFF
--- a/lib/inferno/test_runner.rb
+++ b/lib/inferno/test_runner.rb
@@ -111,6 +111,15 @@ module Inferno
     # or timing metric per test instead of one that spans the whole run. The default
     # implementation just yields.
     #
+    # An override is responsible for actually running the test, so it must call
+    # `yield` (or `super` when prepended as a module) exactly once and return that
+    # value unchanged: it is the test's result, and the caller uses it to roll up
+    # parent results. An override that never yields silently skips the test and
+    # persists no result for it, and one that yields twice runs the test twice.
+    # Exceptions from the block are test runner failures rather than test failures
+    # (test failures are already recorded as results), so an override should let
+    # them propagate, re-raising after recording if it needs to observe them.
+    #
     # @param test [Class] the test being run (an Inferno::Entities::Test subclass)
     # @yield executes the test and returns its result
     # @return the value returned by the block

--- a/lib/inferno/test_runner.rb
+++ b/lib/inferno/test_runner.rb
@@ -59,51 +59,63 @@ module Inferno
     end
 
     def run_test(test, scratch)
-      inputs = load_inputs(test)
-      input_json_string = inputs_as_json(test, inputs)
+      around_test(test) do
+        inputs = load_inputs(test)
+        input_json_string = inputs_as_json(test, inputs)
 
-      test_instance =
-        test.new(
-          inputs:,
-          test_session_id: test_session.id,
-          scratch:,
-          suite_options: test_session.suite_options_hash
-        )
+        test_instance =
+          test.new(
+            inputs:,
+            test_session_id: test_session.id,
+            scratch:,
+            suite_options: test_session.suite_options_hash
+          )
 
-      result = evaluate_runnable_result(test, test_instance, inputs)
+        result = evaluate_runnable_result(test, test_instance, inputs)
 
-      outputs = save_outputs(test_instance)
-      output_json_string = JSON.generate(outputs)
+        outputs = save_outputs(test_instance)
+        output_json_string = JSON.generate(outputs)
 
-      result_params = {
-        messages: test_instance.messages,
-        requests: test_instance.requests,
-        result:,
-        result_message: test_instance.result_message,
-        input_json: input_json_string,
-        output_json: output_json_string
-      }.merge(test.reference_hash)
+        result_params = {
+          messages: test_instance.messages,
+          requests: test_instance.requests,
+          result:,
+          result_message: test_instance.result_message,
+          input_json: input_json_string,
+          output_json: output_json_string
+        }.merge(test.reference_hash)
 
-      test_result =
-        if result == 'wait'
-          # The waiting status and the wait result must become visible to
-          # readers atomically, so that pollers never see the run waiting
-          # without the waiting test's result being present.
-          Inferno::Application['db.connection'].transaction do
-            test_runs_repo.mark_as_waiting(test_run.id, test_instance.identifier, test_instance.wait_timeout)
+        test_result =
+          if result == 'wait'
+            # The waiting status and the wait result must become visible to
+            # readers atomically, so that pollers never see the run waiting
+            # without the waiting test's result being present.
+            Inferno::Application['db.connection'].transaction do
+              test_runs_repo.mark_as_waiting(test_run.id, test_instance.identifier, test_instance.wait_timeout)
+              persist_result(result_params)
+            end
+          else
             persist_result(result_params)
           end
-        else
-          persist_result(result_params)
-        end
 
-      # If running a single test, update its parents' results. If running a
-      # group or suite, #run_group handles updating the parents.
-      return test_result if test_run.test_id.blank?
+        # If running a single test, update its parents' results. If running a
+        # group or suite, #run_group handles updating the parents.
+        update_parent_result(test.parent) if test_run.test_id.present?
 
-      update_parent_result(test.parent)
+        test_result
+      end
+    end
 
-      test_result
+    # Wraps the execution of a single test. Override or prepend this method to run
+    # instrumentation around each test, for example to emit a distinct trace, span,
+    # or timing metric per test instead of one that spans the whole run. The default
+    # implementation just yields.
+    #
+    # @param test [Class] the test being run (an Inferno::Entities::Test subclass)
+    # @yield executes the test and returns its result
+    # @return the value returned by the block
+    def around_test(_test)
+      yield
     end
 
     def check_inputs(test, _test_instance, inputs)

--- a/lib/inferno/test_runner.rb
+++ b/lib/inferno/test_runner.rb
@@ -106,13 +106,13 @@ module Inferno
       end
     end
 
-    # Wraps the execution of a single test. Override or prepend this method to run
-    # instrumentation around each test, for example to emit a distinct trace, span,
-    # or timing metric per test instead of one that spans the whole run.
+    # Wraps the execution of a single test. Prepend a module overriding this method
+    # to run instrumentation around each test, for example to emit a distinct trace,
+    # span, or timing metric per test instead of one that spans the whole run.
     #
-    # An override must `yield` (or `super`) exactly once and return that value
-    # unchanged: it is the test's result, and parent results are rolled up from it.
-    # An override that does not yield silently skips the test.
+    # An override must call `super` exactly once and return its value unchanged:
+    # it is the test's result, and parent results are rolled up from it. An
+    # override that does not call `super` silently skips the test.
     #
     # @param test [Class] the test being run (an Inferno::Entities::Test subclass)
     # @yield executes the test and returns its result

--- a/lib/inferno/test_runner.rb
+++ b/lib/inferno/test_runner.rb
@@ -108,17 +108,11 @@ module Inferno
 
     # Wraps the execution of a single test. Override or prepend this method to run
     # instrumentation around each test, for example to emit a distinct trace, span,
-    # or timing metric per test instead of one that spans the whole run. The default
-    # implementation just yields.
+    # or timing metric per test instead of one that spans the whole run.
     #
-    # An override is responsible for actually running the test, so it must call
-    # `yield` (or `super` when prepended as a module) exactly once and return that
-    # value unchanged: it is the test's result, and the caller uses it to roll up
-    # parent results. An override that never yields silently skips the test and
-    # persists no result for it, and one that yields twice runs the test twice.
-    # Exceptions from the block are test runner failures rather than test failures
-    # (test failures are already recorded as results), so an override should let
-    # them propagate, re-raising after recording if it needs to observe them.
+    # An override must `yield` (or `super`) exactly once and return that value
+    # unchanged: it is the test's result, and parent results are rolled up from it.
+    # An override that does not yield silently skips the test.
     #
     # @param test [Class] the test being run (an Inferno::Entities::Test subclass)
     # @yield executes the test and returns its result

--- a/spec/inferno/test_runner_spec.rb
+++ b/spec/inferno/test_runner_spec.rb
@@ -93,6 +93,35 @@ RSpec.describe Inferno::TestRunner do
         expect(output['type']).to be_present
       end
     end
+
+    it 'wraps each test with #around_test' do
+      wrapped = []
+      allow(runner).to receive(:around_test).and_wrap_original do |_original, test, &block|
+        wrapped << test
+        block.call
+      end
+
+      results = runner.start
+      test_results = results.select { |result| result.runnable < Inferno::Entities::Test }
+
+      expect(wrapped).to_not be_empty
+      expect(wrapped).to all(be < Inferno::Entities::Test)
+      expect(wrapped.length).to eq(test_results.length)
+    end
+  end
+
+  describe '#around_test' do
+    let(:test_run) do
+      repo_create(:test_run, runnable: { test_group_id: 'demo-simple_group' }, test_session_id: test_session.id)
+    end
+
+    it 'yields by default' do
+      expect { |block| runner.around_test(nil, &block) }.to yield_control
+    end
+
+    it 'returns the value of the block by default' do
+      expect(runner.around_test(nil) { :test_result }).to eq(:test_result)
+    end
   end
 
   describe 'when running wait group' do


### PR DESCRIPTION
## Summary

Adds an overridable `TestRunner#around_test(test)` hook so instrumentation can be scoped to a single test. Addresses #796.

## Motivation

`TestRunner` runs an entire test run in one call stack (`Inferno::Jobs::ExecuteTestRun#perform` -> `TestRunner#start` -> recursive `#run`). When a deployment adds distributed tracing (for example OpenTelemetry auto-instrumentation around the Sidekiq worker), the span at the top of that job becomes the trace root and every downstream request the run makes nests under it, so the whole run collapses into a single trace.

That trace is long-lived (many minutes) and very large (we have seen roughly 10,000 spans in one run), which is hard to use for two reasons that are independent of any particular backend:

- A trace is meant to represent one logical operation. A multi-minute waterfall with thousands of spans is not something a trace UI renders well or a person reads usefully.
- Trace stores impose a per-trace size limit (for example Grafana Tempo's `max_bytes_per_trace`, 5 MB by default) and silently drop spans past it, so the tail of a large run is lost.

The natural unit for a test runner is the test, but there is currently no seam to hang per-test instrumentation on without monkeypatching `run_test`'s body (which is fragile against internal changes).

## Change

- Add `around_test(test)`, which yields by default and can be overridden or prepended to wrap each test's execution (a distinct span or trace per test, a timing metric, and so on).
- Wrap the body of `run_test` in `around_test(test) { ... }`.
- Fold the single-test early return into `update_parent_result(test.parent) if test_run.test_id.present?` so the wrapped block always runs to completion (behaviour is unchanged; it just avoids a `return` unwinding out of the hook block).

No new dependencies. The hook is generic: tracing is the motivating case, but it works equally for metrics, timing, or logging.

## Example (downstream, OpenTelemetry)

```ruby
module PerTestTraceRoot
  SPAN_NAME = 'inferno.test'.freeze

  def around_test(test)
    tracer = OpenTelemetry.tracer_provider.tracer('inferno')
    # Detach from the enclosing run/job span so each test starts its own trace.
    OpenTelemetry::Context.with_current(OpenTelemetry::Context.empty) do
      tracer.in_span(SPAN_NAME,
                     attributes: {
                       'inferno.test_run_id' => test_run.id,
                       'inferno.test_session_id' => test_session.id,
                       'inferno.test_id' => test.id
                     }.compact) do
        super
      end
    end
  end
end
Inferno::TestRunner.prepend(PerTestTraceRoot)
```

This turns one unbounded per-run trace into one bounded, queryable trace per test, correlated by `inferno.test_run_id`.

Note the constant span name, with identity in attributes. An earlier version of this example interpolated the test id into the span name, which we have since found to be actively harmful in practice: tracing backends treat the span name as a low-cardinality dimension and generate metrics keyed on it, so naming the span after the test yields one metric series per test, per suite, per suite version. On our deployment that was over 1,400 distinct span names, and each of those series is useless by construction, since a test emits one span per run and `rate()` or `increase()` over a single observation returns zero. The documentation PR below covers this.

## Documentation

Per review feedback: [inferno-framework.github.io#116](https://github.com/inferno-framework/inferno-framework.github.io/pull/116) adds an *Instrumenting Test Execution* page under Advanced Features, covering why run-scoped instrumentation is not useful for a long run, how to override the hook, the contract an override has to honour, the worked OpenTelemetry example above, and the span-naming pitfall. The Debugging page links to it, since that page covers the separate concern of investigating a single test interactively.

The `around_test` doc comment here states the override contract: yield (or `super`) exactly once and return that value unchanged, since an override that does not yield silently skips the test. The longer reasoning, including why exceptions should be left to propagate, lives on the documentation page rather than in the source.

## Tests

- `around_test` yields and returns the block's value by default.
- `around_test` is invoked once per executed test during a run.

`bundle exec rspec spec/inferno/test_runner_spec.rb` passes (18 examples, 0 failures) and `bundle exec rubocop` is clean on the changed files.
