### PR TITLE
Bump concurrent-ruby to 1.3.7 (fixes CVE-2026-54906)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       activesupport (~> 7.2.3.1)
       base62-rb (= 0.3.1)
       blueprinter (= 0.25.2)
-      concurrent-ruby (= 1.3.4)
+      concurrent-ruby (~> 1.3, >= 1.3.7)
       csv (~> 3.3.5)
       dotenv (~> 2.7)
       dry-configurable (= 1.0.0)
@@ -52,8 +52,10 @@ GEM
       tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    anonymous_loader (0.1.2)
+      version_gem (~> 1.1, >= 1.1.13)
     ast (2.4.2)
-    auth-sanitizer (0.2.1)
+    auth-sanitizer (0.2.2)
       version_gem (~> 1.1, >= 1.1.10)
     backports (3.25.0)
     base62-rb (0.3.1)
@@ -63,11 +65,11 @@ GEM
     benchmark (0.5.0)
     bigdecimal (4.1.2)
     blueprinter (0.25.2)
-    byebug (11.1.3)
+    byebug (12.0.0)
     codecov (0.5.2)
       simplecov (>= 0.15, < 0.22)
     coderay (1.1.3)
-    concurrent-ruby (1.3.4)
+    concurrent-ruby (1.3.7)
     connection_pool (2.4.1)
     crack (1.0.0)
       bigdecimal
@@ -103,11 +105,12 @@ GEM
       dry-configurable (~> 1.0, < 2)
       dry-core (~> 1.0, < 2)
       dry-inflector (~> 1.0, < 2)
-    dry-transformer (1.0.1)
+    dry-transformer (1.1.0)
+      bigdecimal
       zeitwerk (~> 2.6)
     factory_bot (6.5.0)
       activesupport (>= 5.0.0)
-    faraday (1.10.5)
+    faraday (1.10.6)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -168,7 +171,7 @@ GEM
       mustermann (~> 1.0)
       mustermann-contrib (~> 1.0)
       rack (~> 2.0)
-    hanami-utils (2.1.0)
+    hanami-utils (2.2.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.0, < 2)
       dry-transformer (~> 1.0, < 2)
@@ -177,7 +180,7 @@ GEM
     hashie (5.1.0)
       logger
     http-accept (1.7.0)
-    http-cookie (1.0.7)
+    http-cookie (1.1.6)
       domain_name (~> 0.5)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
@@ -195,10 +198,10 @@ GEM
     language_server-protocol (3.17.0.3)
     logger (1.7.0)
     method_source (1.1.0)
-    mime-types (3.6.0)
+    mime-types (3.7.0)
       logger
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2024.1001)
+      mime-types-data (~> 3.2025, >= 3.2025.0507)
+    mime-types-data (3.2026.0701)
     minitest (5.25.1)
     multi_xml (0.9.1)
       bigdecimal (>= 3.1, < 5)
@@ -211,21 +214,22 @@ GEM
     mutex_m (0.3.0)
     netrc (0.11.0)
     nio4r (2.7.5)
-    nokogiri (1.19.3-arm64-darwin)
+    nokogiri (1.19.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.3-x86_64-darwin)
+    nokogiri (1.19.4-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.3-x86_64-linux-gnu)
+    nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
-    oauth2 (2.0.23)
-      auth-sanitizer (~> 0.2, >= 0.2.1)
+    oauth2 (2.0.24)
+      anonymous_loader (~> 0.1, >= 0.1.1)
+      auth-sanitizer (~> 0.2, >= 0.2.2)
       faraday (>= 0.17.3, < 4.0)
       jwt (>= 1.0, < 4.0)
       logger (~> 1.2)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 4)
       snaky_hash (~> 2.0, >= 2.0.6)
-      version_gem (~> 1.1, >= 1.1.11)
+      version_gem (~> 1.1, >= 1.1.12)
     oj (3.17.3)
       bigdecimal (>= 3.0)
       ostruct (>= 0.2)
@@ -236,12 +240,12 @@ GEM
       racc
     pastel (0.8.0)
       tty-color (~> 0.5)
-    pry (0.14.2)
+    pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.10.1)
-      byebug (~> 11.0)
-      pry (>= 0.13, < 0.15)
+    pry-byebug (3.11.0)
+      byebug (~> 12.0)
+      pry (>= 0.13, < 0.16)
     psych (5.1.2)
       stringio
     public_suffix (6.0.1)
@@ -252,10 +256,10 @@ GEM
     rack-test (2.1.0)
       rack (>= 1.3)
     rainbow (3.1.1)
-    rake (13.2.1)
+    rake (13.4.2)
     rdoc (6.7.0)
       psych (>= 4.0.0)
-    redis-client (0.29.0)
+    redis-client (0.30.0)
       connection_pool
     regexp_parser (2.9.2)
     reline (0.5.10)
@@ -269,7 +273,7 @@ GEM
     roo (2.10.1)
       nokogiri (~> 1)
       rubyzip (>= 1.3.0, < 3.0.0)
-    rouge (4.4.0)
+    rouge (4.7.0)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -333,8 +337,8 @@ GEM
       unicode-display_width (>= 1.5, < 3.0)
       unicode_utils (~> 1.4)
     strings-ansi (0.2.0)
-    thor (1.4.0)
-    tilt (2.4.0)
+    thor (1.5.0)
+    tilt (2.8.0)
     tty-color (0.6.0)
     tty-markdown (0.7.2)
       kramdown (>= 1.16.2, < 3.0)
@@ -348,7 +352,7 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.6.0)
     unicode_utils (1.4.0)
-    version_gem (1.1.12)
+    version_gem (1.1.13)
     webmock (3.24.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -359,18 +363,13 @@ GEM
       ostruct
       rainbow
       yard
-    zeitwerk (2.6.18)
+    zeitwerk (2.8.2)
 
 PLATFORMS
-  arm64-darwin-21
   arm64-darwin-22
-  arm64-darwin-23
   arm64-darwin-24
-  arm64-darwin-25
   x86_64-darwin-20
-  x86_64-darwin-22
   x86_64-darwin-23
-  x86_64-darwin-24
   x86_64-darwin-25
   x86_64-linux
 

--- a/inferno_core.gemspec
+++ b/inferno_core.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport', '~> 7.2.3.1'
   spec.add_dependency 'base62-rb', '0.3.1'
   spec.add_dependency 'blueprinter', '0.25.2'
-  spec.add_dependency 'concurrent-ruby', '1.3.4' # Fix activesupport https://github.com/rails/rails/issues/54272
+  spec.add_dependency 'concurrent-ruby', '~> 1.3', '>= 1.3.7' # CVE-2026-54906: ReadWriteLock release/counter bug, fixed in 1.3.7
   spec.add_dependency 'csv', '~> 3.3.5'
   spec.add_dependency 'dotenv', '~> 2.7'
   spec.add_dependency 'dry-configurable', '1.0.0'


### PR DESCRIPTION
# Summary
Bumped concurrent-ruby to 1.3.7 (fixes CVE-2026-54906). Originally was pinned to 1.3.4 to deal with a rails issue which has been fixed. 

Bundle install also performed unrelated patch level updates. Sorry y'all.

# Testing Guidance

