### PR TITLE
ID-179: Disable Validator Terminology Cache

### DIFF
--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -8,7 +8,7 @@
 #    - SESSION_CACHE_DURATION=-1
 #      - These enable the old session cache implementation, and configure the session cache to never expire sessions.
 #    - TERMINOLOGY_CLIENT_USE_CACHE_ID=false
-#      - This disable terminology caches on tx.fhir.org because they are not long-running like validator sessions in Inferno and were causing errors 
+#      - This disables terminology caches on tx.fhir.org because they are not long-running like validator sessions in Inferno and were causing errors 
 #    - VALIDATION_SERVICE_PRESETS_FILE_PATH=ignore-this-do-not-load-presets
 #      - This disables loading presets at service startup by pointing it to a non-existent file. (There is no other explicit value or setting for "do not load presets")
 # The validator-wrapper release to use is based on the PROJECT_VERSION build argument (required)

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -7,8 +7,11 @@
 #    - SESSION_CACHE_IMPLEMENTATION=PassiveExpiringSessionCache
 #    - SESSION_CACHE_DURATION=-1
 #      - These enable the old session cache implementation, and configure the session cache to never expire sessions.
-#
-# The software release to use is based on the PROJECT_VERSION build argument (required)
+#    - TERMINOLOGY_CLIENT_USE_CACHE_ID=false
+#      - This disable terminology caches on tx.fhir.org because they are not long-running like validator sessions in Inferno and were causing errors 
+#    - VALIDATION_SERVICE_PRESETS_FILE_PATH=ignore-this-do-not-load-presets
+#      - This disables loading presets at service startup by pointing it to a non-existent file. (There is no other explicit value or setting for "do not load presets")
+# The validator-wrapper release to use is based on the PROJECT_VERSION build argument (required)
 
 FROM eclipse-temurin:17-jre-jammy
 
@@ -34,6 +37,8 @@ RUN wget -O validator-wrapper.jar "https://github.com/hapifhir/org.hl7.fhir.vali
 ENV ENVIRONMENT=prod
 ENV SESSION_CACHE_IMPLEMENTATION=PassiveExpiringSessionCache
 ENV SESSION_CACHE_DURATION=-1
+# disable terminology caches on tx.fhir.org because they are not long-running like validator sessions
+ENV TERMINOLOGY_CLIENT_USE_CACHE_ID=false
 ENV VALIDATION_SERVICE_PRESETS_FILE_PATH=ignore-this-do-not-load-presets
 # By default, java will be run using the G10s GC and assigned 79% of the system's available memory
 ENV JAVA_OPTS="-XX:+UnlockExperimentalVMOptions -XX:InitialRAMPercentage=79 -XX:MinRAMPercentage=79 -XX:MaxRAMPercentage=79 -XX:+UseG1GC -XX:MaxGCPauseMillis=100 -XX:+UseStringDeduplication -XX:+CrashOnOutOfMemoryError "

--- a/validator/README.md
+++ b/validator/README.md
@@ -8,7 +8,7 @@ This Dockerfile is based on the Dockerfile for org.hl7.fhir.validator-wrapper (s
    - SESSION_CACHE_DURATION=-1
      - These enable the old session cache implementation, and configure the session cache to never expire sessions.
    - TERMINOLOGY_CLIENT_USE_CACHE_ID=false
-     - This disable terminology caches on tx.fhir.org because they are not long-running like validator sessions in Inferno and were causing errors 
+     - This disables terminology caches on tx.fhir.org because they are not long-running like validator sessions in Inferno and were causing errors 
    - VALIDATION_SERVICE_PRESETS_FILE_PATH=ignore-this-do-not-load-presets
      - This disables loading presets at service startup by pointing it to a non-existent file. (There is no other explicit value or setting for "do not load presets")
 

--- a/validator/README.md
+++ b/validator/README.md
@@ -2,12 +2,13 @@
 
 This Dockerfile is based on the Dockerfile for org.hl7.fhir.validator-wrapper (see https://github.com/hapifhir/org.hl7.fhir.validator-wrapper/blob/master/Dockerfile ) with the following differences relevant to Inferno:
 1. It fetches the built JAR from GitHub instead of locally, or building from source
-2. It adds MITRE certs, for ease of use by the MITRE development team
-3. It uses an Ubuntu-based base image instead of Alpine to support both AMD64 and ARM architectures
-4. It defaults the following environment variables:
+2. It uses an Ubuntu-based base image instead of Alpine to support both AMD64 and ARM architectures
+3. It defaults the following environment variables:
    - SESSION_CACHE_IMPLEMENTATION=PassiveExpiringSessionCache
    - SESSION_CACHE_DURATION=-1
      - These enable the old session cache implementation, and configure the session cache to never expire sessions.
+   - TERMINOLOGY_CLIENT_USE_CACHE_ID=false
+     - This disable terminology caches on tx.fhir.org because they are not long-running like validator sessions in Inferno and were causing errors 
    - VALIDATION_SERVICE_PRESETS_FILE_PATH=ignore-this-do-not-load-presets
      - This disables loading presets at service startup by pointing it to a non-existent file. (There is no other explicit value or setting for "do not load presets")
 
@@ -21,6 +22,7 @@ Since there are many test kits that depend on this validator service, the follow
 1. Watch https://github.com/hapifhir/org.hl7.fhir.validator-wrapper for new releases.
 2. When there is a new release, build this dockerfile locally and test g10 (all versions of US Core) against it by updating the version in `docker-compose.background.yml`
 3. If there are changes needed to this dockerfile, submit that PR first.
+4. Publish a pre-release version of this image and deploy to QA to verify behavior more broadly on a running system.
 4. Publish a new version of this image once it's ready. IMPORTANT: any test kit that doesn't pin a specific version of the validator will now use this latest image.
 5. Submit a PR on g10 to update the the version in `docker-compose.background.yml` and `lib/onc_certification_g10_test_kit/configuration_checker.rb`, and update the message filters if necessary.
 

--- a/validator/README.md
+++ b/validator/README.md
@@ -23,8 +23,8 @@ Since there are many test kits that depend on this validator service, the follow
 2. When there is a new release, build this dockerfile locally and test g10 (all versions of US Core) against it by updating the version in `docker-compose.background.yml`
 3. If there are changes needed to this dockerfile, submit that PR first.
 4. Publish a pre-release version of this image and deploy to QA to verify behavior more broadly on a running system.
-4. Publish a new version of this image once it's ready. IMPORTANT: any test kit that doesn't pin a specific version of the validator will now use this latest image.
-5. Submit a PR on g10 to update the the version in `docker-compose.background.yml` and `lib/onc_certification_g10_test_kit/configuration_checker.rb`, and update the message filters if necessary.
+5. Publish a new version of this image once it's ready. IMPORTANT: any test kit that doesn't pin a specific version of the validator will now use this latest image.
+6. Submit a PR on g10 to update the the version in `docker-compose.background.yml` and `lib/onc_certification_g10_test_kit/configuration_checker.rb`, and update the message filters if necessary.
 
 ## Publishing a new version
 A script `build_and_push.sh` is provided to assist with publishing a new version. The version of the wrapper service to use must be provided as a command-line argument (required).
@@ -44,8 +44,4 @@ To publish a pre-release image for testing before a full release, use the `--pre
 ./build_and_push.sh --pre-release 1.0.50
 ```
 
-When you are ready to do a full release, run the standard release command. It will automatically delete the `<version>-pre` tag from Docker Hub before pushing the release tags. Deletion requires `DOCKER_USERNAME` and `DOCKER_PASSWORD` (or a Docker Hub access token) to be set in the environment; if they are not set, deletion is skipped (perform manually within docker hub) and the release build proceeds normally.
-
-```sh
-DOCKER_USERNAME=myuser DOCKER_PASSWORD=mytoken ./build_and_push.sh 1.0.50
-```
+When you are ready to do a full release, run the standard release command above. The `<version>-pre` tag is not deleted automatically; remove it manually within Docker Hub if you'd like to clean it up.

--- a/validator/README.md
+++ b/validator/README.md
@@ -25,10 +25,25 @@ Since there are many test kits that depend on this validator service, the follow
 5. Submit a PR on g10 to update the the version in `docker-compose.background.yml` and `lib/onc_certification_g10_test_kit/configuration_checker.rb`, and update the message filters if necessary.
 
 ## Publishing a new version
-A script `build_and_push.sh` is provided to assist with publishing a new version. The version of the wrapper service to use must be provided as the first command-line argument (required).
+A script `build_and_push.sh` is provided to assist with publishing a new version. The version of the wrapper service to use must be provided as a command-line argument (required).
 The available versions are listed at https://github.com/hapifhir/org.hl7.fhir.validator-wrapper/releases .
-Replace `1.0.50` in the example below with the appropriate number and run the following command to build & push a multi-arch image to Docker Hub. Images will be tagged as both the provided version number and as `latest`
+
+### Standard release
+Replace `1.0.50` in the example below with the appropriate version number and run the following command to build & push a multi-arch image to Docker Hub. Images will be tagged as both the provided version number and as `latest`.
 
 ```sh
 ./build_and_push.sh 1.0.50
+```
+
+### Pre-release
+To publish a pre-release image for testing before a full release, use the `--pre-release` flag. This builds and pushes an image tagged as `<version>-pre` (e.g. `1.0.50-pre`) without updating the `latest` tag.
+
+```sh
+./build_and_push.sh --pre-release 1.0.50
+```
+
+When you are ready to do a full release, run the standard release command. It will automatically delete the `<version>-pre` tag from Docker Hub before pushing the release tags. Deletion requires `DOCKER_USERNAME` and `DOCKER_PASSWORD` (or a Docker Hub access token) to be set in the environment; if they are not set, deletion is skipped (perform manually within docker hub) and the release build proceeds normally.
+
+```sh
+DOCKER_USERNAME=myuser DOCKER_PASSWORD=mytoken ./build_and_push.sh 1.0.50
 ```

--- a/validator/build_and_push.sh
+++ b/validator/build_and_push.sh
@@ -1,12 +1,58 @@
 #!/bin/sh
 
-PROJECT_VERSION=$1
-if [ -z $PROJECT_VERSION ]; then
-    echo "Usage: $0 PROJECT_VERSION"
-    echo The available project versions are listed at https://github.com/hapifhir/org.hl7.fhir.validator-wrapper/releases 
+PRE_RELEASE=false
+PROJECT_VERSION=""
+
+for arg in "$@"; do
+    case "$arg" in
+        --pre-release) PRE_RELEASE=true ;;
+        *) PROJECT_VERSION="$arg" ;;
+    esac
+done
+
+if [ -z "$PROJECT_VERSION" ]; then
+    echo "Usage: $0 [--pre-release] PROJECT_VERSION"
+    echo The available project versions are listed at https://github.com/hapifhir/org.hl7.fhir.validator-wrapper/releases
     exit 1
 fi
 
+IMAGE="infernocommunity/inferno-resource-validator"
+PRE_RELEASE_TAG="${PROJECT_VERSION}-pre"
+
 echo Using PROJECT_VERSION $PROJECT_VERSION
 
-docker buildx build --platform linux/arm64,linux/amd64 --build-arg "PROJECT_VERSION=${PROJECT_VERSION}" --tag "infernocommunity/inferno-resource-validator:${PROJECT_VERSION}" --tag infernocommunity/inferno-resource-validator:latest --push .
+if [ "$PRE_RELEASE" = true ]; then
+    docker buildx build --platform linux/arm64,linux/amd64 \
+        --build-arg "PROJECT_VERSION=${PROJECT_VERSION}" \
+        --tag "${IMAGE}:${PRE_RELEASE_TAG}" \
+        --push .
+else
+    if [ -z "$DOCKER_USERNAME" ] || [ -z "$DOCKER_PASSWORD" ]; then
+        echo "Warning: DOCKER_USERNAME and DOCKER_PASSWORD must be set to delete pre-release tag"
+    else
+        LOGIN_PAYLOAD=$(printf '{"username":"%s","password":"%s"}' "$DOCKER_USERNAME" "$DOCKER_PASSWORD")
+        TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
+            -d "$LOGIN_PAYLOAD" \
+            https://hub.docker.com/v2/users/login/ | grep -o '"token":"[^"]*"' | cut -d'"' -f4)
+
+        if [ -z "$TOKEN" ]; then
+            echo "Warning: Failed to authenticate with Docker Hub, skipping pre-release tag deletion"
+        else
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE \
+                -H "Authorization: JWT ${TOKEN}" \
+                "https://hub.docker.com/v2/repositories/${IMAGE}/tags/${PRE_RELEASE_TAG}/")
+
+            case "$STATUS" in
+                204) echo "Deleted pre-release tag ${PRE_RELEASE_TAG}" ;;
+                404) echo "Pre-release tag ${PRE_RELEASE_TAG} not found, skipping deletion" ;;
+                *)   echo "Warning: Failed to delete pre-release tag (HTTP ${STATUS})" ;;
+            esac
+        fi
+    fi
+
+    docker buildx build --platform linux/arm64,linux/amd64 \
+        --build-arg "PROJECT_VERSION=${PROJECT_VERSION}" \
+        --tag "${IMAGE}:${PROJECT_VERSION}" \
+        --tag "${IMAGE}:latest" \
+        --push .
+fi

--- a/validator/build_and_push.sh
+++ b/validator/build_and_push.sh
@@ -17,39 +17,15 @@ if [ -z "$PROJECT_VERSION" ]; then
 fi
 
 IMAGE="infernocommunity/inferno-resource-validator"
-PRE_RELEASE_TAG="${PROJECT_VERSION}-pre"
 
 echo Using PROJECT_VERSION $PROJECT_VERSION
 
 if [ "$PRE_RELEASE" = true ]; then
     docker buildx build --platform linux/arm64,linux/amd64 \
         --build-arg "PROJECT_VERSION=${PROJECT_VERSION}" \
-        --tag "${IMAGE}:${PRE_RELEASE_TAG}" \
+        --tag "${IMAGE}:${PROJECT_VERSION}-pre" \
         --push .
 else
-    if [ -z "$DOCKER_USERNAME" ] || [ -z "$DOCKER_PASSWORD" ]; then
-        echo "Warning: DOCKER_USERNAME and DOCKER_PASSWORD must be set to delete pre-release tag"
-    else
-        LOGIN_PAYLOAD=$(printf '{"username":"%s","password":"%s"}' "$DOCKER_USERNAME" "$DOCKER_PASSWORD")
-        TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-            -d "$LOGIN_PAYLOAD" \
-            https://hub.docker.com/v2/users/login/ | grep -o '"token":"[^"]*"' | cut -d'"' -f4)
-
-        if [ -z "$TOKEN" ]; then
-            echo "Warning: Failed to authenticate with Docker Hub, skipping pre-release tag deletion"
-        else
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE \
-                -H "Authorization: JWT ${TOKEN}" \
-                "https://hub.docker.com/v2/repositories/${IMAGE}/tags/${PRE_RELEASE_TAG}/")
-
-            case "$STATUS" in
-                204) echo "Deleted pre-release tag ${PRE_RELEASE_TAG}" ;;
-                404) echo "Pre-release tag ${PRE_RELEASE_TAG} not found, skipping deletion" ;;
-                *)   echo "Warning: Failed to delete pre-release tag (HTTP ${STATUS})" ;;
-            esac
-        fi
-    fi
-
     docker buildx build --platform linux/arm64,linux/amd64 \
         --build-arg "PROJECT_VERSION=${PROJECT_VERSION}" \
         --tag "${IMAGE}:${PROJECT_VERSION}" \


### PR DESCRIPTION
# Summary

Starting with validator-wrapper version 1.0.80, Inferno's long-running validator sessions were erroring when their corresponding terminology cache on tx.fhir.org expired. Starting with validator-wrapper version 1.0.81 (current), Inferno is able to use an environment variable to disable that caching to prevent those errors. This PR updates the validator build and publish script to set that environment variable.

Additional changes:
- Added a pre-release option to create and push to dockerhub an image that can be deployed and tested on QA without making it automatically used by all test kits.
- Updated documentation

# Testing Guidance

- re-run the build command for the 1.0.81 prerelease version: In the `validator` directory, run `./build_and_push.sh --pre-release 1.0.81` (NOTE: the push to docker hub may fail if you don't have an account with permissions to infernocommunity - that's ok)
- check the local image to confirm the new environment variable is set in the image: `docker run --rm infernocommunity/inferno-resource-validator:1.0.81-pre env | grep TERMINOLOGY_CLIENT_USE_CACHE_ID`