### PR TITLE
ID-167 suite endpoint error response customization

### DIFF
--- a/dev_suites/dev_infrastructure_test/blank_identifier_test_endpoint.rb
+++ b/dev_suites/dev_infrastructure_test/blank_identifier_test_endpoint.rb
@@ -1,0 +1,2 @@
+class BlankIdentifierTestEndpoint < Inferno::DSL::SuiteEndpoint
+end

--- a/dev_suites/dev_infrastructure_test/custom_no_session_response_test_endpoint.rb
+++ b/dev_suites/dev_infrastructure_test/custom_no_session_response_test_endpoint.rb
@@ -1,0 +1,15 @@
+class CustomNoSessionResponseTestEndpoint < Inferno::DSL::SuiteEndpoint
+  def test_run_identifier
+    'NONEXISTENT_IDENTIFIER'
+  end
+
+  def no_session_response
+    response.status = 404
+    response.format = :json
+    response.body = { error: 'no matching session' }.to_json
+  end
+
+  def make_response
+    response.body = 'SHOULD_NOT_BE_REACHED'
+  end
+end

--- a/dev_suites/dev_infrastructure_test/exception_operation_outcome_test_endpoint.rb
+++ b/dev_suites/dev_infrastructure_test/exception_operation_outcome_test_endpoint.rb
@@ -1,0 +1,11 @@
+class ExceptionOperationOutcomeTestEndpoint < Inferno::DSL::SuiteEndpoint
+  error_response_format :operation_outcome
+
+  def test_run_identifier
+    'ABC'
+  end
+
+  def make_response
+    raise StandardError, 'BOOM_MAKE_RESPONSE'
+  end
+end

--- a/dev_suites/dev_infrastructure_test/exception_test_endpoint.rb
+++ b/dev_suites/dev_infrastructure_test/exception_test_endpoint.rb
@@ -1,0 +1,9 @@
+class ExceptionTestEndpoint < Inferno::DSL::SuiteEndpoint
+  def test_run_identifier
+    'ABC'
+  end
+
+  def make_response
+    raise StandardError, 'BOOM_MAKE_RESPONSE'
+  end
+end

--- a/dev_suites/dev_infrastructure_test/identifier_description_test_endpoint.rb
+++ b/dev_suites/dev_infrastructure_test/identifier_description_test_endpoint.rb
@@ -1,0 +1,9 @@
+class IdentifierDescriptionTestEndpoint < Inferno::DSL::SuiteEndpoint
+  def test_run_identifier
+    'NONEXISTENT_IDENTIFIER'
+  end
+
+  def test_run_identifier_description
+    "the 'code' query parameter"
+  end
+end

--- a/dev_suites/dev_infrastructure_test/identifier_description_test_endpoint.rb
+++ b/dev_suites/dev_infrastructure_test/identifier_description_test_endpoint.rb
@@ -3,7 +3,7 @@ class IdentifierDescriptionTestEndpoint < Inferno::DSL::SuiteEndpoint
     'NONEXISTENT_IDENTIFIER'
   end
 
-  def test_run_identifier_description
+  def test_run_identifier_location_description
     "the 'code' query parameter"
   end
 end

--- a/dev_suites/dev_infrastructure_test/identifier_error_operation_outcome_test_endpoint.rb
+++ b/dev_suites/dev_infrastructure_test/identifier_error_operation_outcome_test_endpoint.rb
@@ -1,0 +1,7 @@
+class IdentifierErrorOperationOutcomeTestEndpoint < Inferno::DSL::SuiteEndpoint
+  error_response_format :operation_outcome
+
+  def test_run_identifier
+    raise StandardError, 'BOOM_IDENTIFIER'
+  end
+end

--- a/dev_suites/dev_infrastructure_test/identifier_error_test_endpoint.rb
+++ b/dev_suites/dev_infrastructure_test/identifier_error_test_endpoint.rb
@@ -1,0 +1,5 @@
+class IdentifierErrorTestEndpoint < Inferno::DSL::SuiteEndpoint
+  def test_run_identifier
+    raise StandardError, 'BOOM_IDENTIFIER'
+  end
+end

--- a/dev_suites/dev_infrastructure_test/infrastructure_test_suite.rb
+++ b/dev_suites/dev_infrastructure_test/infrastructure_test_suite.rb
@@ -7,6 +7,7 @@ require_relative 'exception_operation_outcome_test_endpoint'
 require_relative 'exception_test_endpoint'
 require_relative 'identifier_error_operation_outcome_test_endpoint'
 require_relative 'identifier_error_test_endpoint'
+require_relative 'identifier_description_test_endpoint'
 require_relative 'json_test_endpoint'
 require_relative 'no_session_test_endpoint'
 require_relative 'operation_outcome_test_endpoint'
@@ -45,6 +46,7 @@ module InfrastructureTest
     suite_endpoint :post, '/exception_operation_outcome_test', ExceptionOperationOutcomeTestEndpoint
     suite_endpoint :post, '/identifier_error_test', IdentifierErrorTestEndpoint
     suite_endpoint :post, '/identifier_error_operation_outcome_test', IdentifierErrorOperationOutcomeTestEndpoint
+    suite_endpoint :post, '/identifier_description_test', IdentifierDescriptionTestEndpoint
     suite_endpoint :post, '/no_session_test', NoSessionTestEndpoint
     suite_endpoint :post, '/operation_outcome_test', OperationOutcomeTestEndpoint
 

--- a/dev_suites/dev_infrastructure_test/infrastructure_test_suite.rb
+++ b/dev_suites/dev_infrastructure_test/infrastructure_test_suite.rb
@@ -11,6 +11,7 @@ require_relative 'identifier_description_test_endpoint'
 require_relative 'json_test_endpoint'
 require_relative 'no_session_test_endpoint'
 require_relative 'operation_outcome_test_endpoint'
+require_relative 'resume_test_endpoint'
 require_relative 'mixed_optional_group'
 require_relative 'passing_optional_group'
 
@@ -49,6 +50,7 @@ module InfrastructureTest
     suite_endpoint :post, '/identifier_description_test', IdentifierDescriptionTestEndpoint
     suite_endpoint :post, '/no_session_test', NoSessionTestEndpoint
     suite_endpoint :post, '/operation_outcome_test', OperationOutcomeTestEndpoint
+    suite_endpoint :post, '/resume_test', ResumeTestEndpoint
 
     input :suite_input
     output :suite_output

--- a/dev_suites/dev_infrastructure_test/infrastructure_test_suite.rb
+++ b/dev_suites/dev_infrastructure_test/infrastructure_test_suite.rb
@@ -3,6 +3,10 @@ require_relative 'external_outer_group'
 require_relative 'failing_optional_group'
 require_relative 'blank_identifier_test_endpoint'
 require_relative 'custom_no_session_response_test_endpoint'
+require_relative 'exception_operation_outcome_test_endpoint'
+require_relative 'exception_test_endpoint'
+require_relative 'identifier_error_operation_outcome_test_endpoint'
+require_relative 'identifier_error_test_endpoint'
 require_relative 'json_test_endpoint'
 require_relative 'no_session_test_endpoint'
 require_relative 'operation_outcome_test_endpoint'
@@ -37,6 +41,10 @@ module InfrastructureTest
     suite_endpoint :post, '/json_test', JSONTestEndpoint
     suite_endpoint :post, '/blank_identifier_test', BlankIdentifierTestEndpoint
     suite_endpoint :post, '/custom_no_session_response_test', CustomNoSessionResponseTestEndpoint
+    suite_endpoint :post, '/exception_test', ExceptionTestEndpoint
+    suite_endpoint :post, '/exception_operation_outcome_test', ExceptionOperationOutcomeTestEndpoint
+    suite_endpoint :post, '/identifier_error_test', IdentifierErrorTestEndpoint
+    suite_endpoint :post, '/identifier_error_operation_outcome_test', IdentifierErrorOperationOutcomeTestEndpoint
     suite_endpoint :post, '/no_session_test', NoSessionTestEndpoint
     suite_endpoint :post, '/operation_outcome_test', OperationOutcomeTestEndpoint
 

--- a/dev_suites/dev_infrastructure_test/infrastructure_test_suite.rb
+++ b/dev_suites/dev_infrastructure_test/infrastructure_test_suite.rb
@@ -14,7 +14,6 @@ require_relative 'operation_outcome_test_endpoint'
 require_relative 'resume_test_endpoint'
 require_relative 'mixed_optional_group'
 require_relative 'passing_optional_group'
-require_relative 'resume_test_endpoint'
 
 module InfrastructureTest
   class Suite < Inferno::TestSuite

--- a/dev_suites/dev_infrastructure_test/infrastructure_test_suite.rb
+++ b/dev_suites/dev_infrastructure_test/infrastructure_test_suite.rb
@@ -1,7 +1,11 @@
 require_relative 'empty_group'
 require_relative 'external_outer_group'
 require_relative 'failing_optional_group'
+require_relative 'blank_identifier_test_endpoint'
+require_relative 'custom_no_session_response_test_endpoint'
 require_relative 'json_test_endpoint'
+require_relative 'no_session_test_endpoint'
+require_relative 'operation_outcome_test_endpoint'
 require_relative 'mixed_optional_group'
 require_relative 'passing_optional_group'
 
@@ -31,6 +35,10 @@ module InfrastructureTest
     ]
 
     suite_endpoint :post, '/json_test', JSONTestEndpoint
+    suite_endpoint :post, '/blank_identifier_test', BlankIdentifierTestEndpoint
+    suite_endpoint :post, '/custom_no_session_response_test', CustomNoSessionResponseTestEndpoint
+    suite_endpoint :post, '/no_session_test', NoSessionTestEndpoint
+    suite_endpoint :post, '/operation_outcome_test', OperationOutcomeTestEndpoint
 
     input :suite_input
     output :suite_output

--- a/dev_suites/dev_infrastructure_test/no_session_test_endpoint.rb
+++ b/dev_suites/dev_infrastructure_test/no_session_test_endpoint.rb
@@ -1,0 +1,5 @@
+class NoSessionTestEndpoint < Inferno::DSL::SuiteEndpoint
+  def test_run_identifier
+    'NONEXISTENT_IDENTIFIER'
+  end
+end

--- a/dev_suites/dev_infrastructure_test/operation_outcome_test_endpoint.rb
+++ b/dev_suites/dev_infrastructure_test/operation_outcome_test_endpoint.rb
@@ -1,5 +1,5 @@
 class OperationOutcomeTestEndpoint < Inferno::DSL::SuiteEndpoint
-  no_session_response_format :operation_outcome
+  error_response_format :operation_outcome
 
   def test_run_identifier
     'NONEXISTENT_IDENTIFIER'

--- a/dev_suites/dev_infrastructure_test/operation_outcome_test_endpoint.rb
+++ b/dev_suites/dev_infrastructure_test/operation_outcome_test_endpoint.rb
@@ -1,0 +1,7 @@
+class OperationOutcomeTestEndpoint < Inferno::DSL::SuiteEndpoint
+  no_session_response_format :operation_outcome
+
+  def test_run_identifier
+    'NONEXISTENT_IDENTIFIER'
+  end
+end

--- a/dev_suites/dev_infrastructure_test/resume_test_endpoint.rb
+++ b/dev_suites/dev_infrastructure_test/resume_test_endpoint.rb
@@ -1,0 +1,14 @@
+class ResumeTestEndpoint < Inferno::DSL::SuiteEndpoint
+  def test_run_identifier
+    'ABC'
+  end
+
+  def update_result
+    results_repo.update(result.id, result: 'pass')
+  end
+
+  def make_response
+    response.format = :json
+    response.body = { test_id: test.id, requests_repo_class: requests_repo.class.name }.to_json
+  end
+end

--- a/lib/inferno/dsl/resume_test_route.rb
+++ b/lib/inferno/dsl/resume_test_route.rb
@@ -84,7 +84,10 @@ module Inferno
 
         test_run = find_test_run(test_run_identifier)
 
-        halt 500, "Unable to find test run with identifier '#{test_run_identifier}'." if test_run.nil?
+        if test_run.nil?
+          halt 500, "Unable to find test run with identifier '#{test_run_identifier}' " \
+                    "on request to '#{request.url}'."
+        end
 
         test_runs_repo.mark_as_no_longer_waiting(test_run.id)
 

--- a/lib/inferno/dsl/suite_endpoint.rb
+++ b/lib/inferno/dsl/suite_endpoint.rb
@@ -119,6 +119,22 @@ module Inferno
         nil
       end
 
+      # Override this method to provide a short narrative description of
+      # where the test run identifier is expected to be found in an
+      # incoming request. When provided, this description is appended to
+      # the {#no_session_message} to help implementers debug requests that
+      # don't match a waiting test run.
+      #
+      # @return [String]
+      #
+      # @example
+      #   def test_run_identifier_description
+      #     "the 'code' query parameter"
+      #   end
+      def test_run_identifier_description
+        ''
+      end
+
       # Override this method to build the response.
       #
       # @return [Void]
@@ -278,12 +294,18 @@ module Inferno
       end
 
       # @private
+      def log_error(error, url: request.url)
+        session_prefix = @test_run ? " session=#{@test_run.test_session_id}" : ''
+        logger.error("[#{url}]#{session_prefix} #{error.full_message}")
+      end
+
+      # @private
       def find_test_run_identifier
         return @test_run_identifier if defined?(@test_run_identifier) # handle memoization in the nil case
 
         @test_run_identifier = test_run_identifier
       rescue StandardError => e
-        logger.error(e.full_message)
+        log_error(e)
         render_error_and_halt do
           error_response(
             'An error occurred while determining the test run identifier for this request.',
@@ -295,11 +317,16 @@ module Inferno
 
       # @private
       def no_session_message
-        if find_test_run_identifier.blank?
-          'No test identifier found.'
-        else
-          "Unable to find test run with identifier '#{find_test_run_identifier}'."
-        end
+        message =
+          if find_test_run_identifier.blank?
+            "No test identifier found on request to '#{request.url}'."
+          else
+            "Unable to find test run with identifier '#{find_test_run_identifier}' " \
+              "on request to '#{request.url}'."
+          end
+
+        description = test_run_identifier_description
+        description.present? ? "#{message} Expected in #{description}." : message
       end
 
       # @private
@@ -394,7 +421,7 @@ module Inferno
 
         make_response
       rescue StandardError => e
-        logger.error(e.full_message)
+        log_error(e)
         render_error_and_halt do
           error_response(
             'An error occurred while processing this request.',
@@ -406,7 +433,6 @@ module Inferno
 
       # @private
       def add_persistence_callback # rubocop:disable Metrics/CyclomaticComplexity
-        logger = Application['logger']
         env = req.env
         env['rack.after_reply'] ||= []
         env['rack.after_reply'] << proc do
@@ -452,7 +478,7 @@ module Inferno
             Inferno::Jobs.perform(Jobs::ResumeTestRun, test_run_id)
           end
         rescue StandardError => e
-          logger.error(e.full_message)
+          log_error(e, url:)
         end
       end
     end

--- a/lib/inferno/dsl/suite_endpoint.rb
+++ b/lib/inferno/dsl/suite_endpoint.rb
@@ -1,5 +1,6 @@
 require 'hanami/controller'
 require 'rack/request'
+require 'fhir_models'
 require_relative '../ext/rack'
 
 module Inferno
@@ -14,6 +15,8 @@ module Inferno
     #       def test_run_identifier
     #         request.headers['authorization']&.delete_prefix('Bearer ')
     #       end
+    #
+    #       no_session_response_format :operation_outcome
     #
     #       # Return a json FHIR Patient resource
     #       def make_response
@@ -57,8 +60,49 @@ module Inferno
     #         end
     #       end
     #     end
+    #
+    # If no waiting test session can be found for an incoming request, Inferno
+    # returns a `500` response with a plain text message by default. Call
+    # `no_session_response_format :operation_outcome` in a subclass to return a
+    # FHIR `OperationOutcome` as `application/fhir+json` instead, or override
+    # {#no_session_response} for full control.
     class SuiteEndpoint < Hanami::Action
       attr_reader :req, :res
+
+      # The built-in options for `no_session_response_format`
+      NO_SESSION_RESPONSE_FORMATS = [:text, :operation_outcome].freeze
+
+      class << self
+        # Select one of Inferno's standard responses to be returned when no
+        # waiting test session can be found for the incoming request.
+        # Override {#no_session_response} if neither option is appropriate.
+        #
+        # * `:text` (default): a `500` response with a plain text message
+        # * `:operation_outcome`: a `500` response with a FHIR
+        #   `OperationOutcome` serialized as `application/fhir+json`
+        #
+        # @param format [Symbol] `:text` or `:operation_outcome`
+        # @return [void]
+        #
+        # @example
+        #   class MyEndpoint < Inferno::DSL::SuiteEndpoint
+        #     no_session_response_format :operation_outcome
+        #   end
+        def no_session_response_format(format)
+          unless NO_SESSION_RESPONSE_FORMATS.include?(format)
+            raise ArgumentError,
+                  "Unknown no_session_response_format `#{format.inspect}`. " \
+                  "Must be one of #{NO_SESSION_RESPONSE_FORMATS.join(', ')}."
+          end
+
+          @no_session_response_format_value = format
+        end
+
+        # @private
+        def no_session_response_format_value
+          @no_session_response_format_value ||= :text
+        end
+      end
 
       # @!group Overrides These methods should be overridden by subclasses to
       #   define the behavior of the endpoint
@@ -128,6 +172,31 @@ module Inferno
         true
       end
 
+      # Override this method to fully customize the response returned when no
+      # waiting test run/session can be found for the incoming request. Set
+      # `response.status` and `response.body` (and `response.content_type`, if
+      # needed) — Inferno halts the request with those values. By default, this
+      # dispatches to one of Inferno's standard responses based on the format
+      # selected with `no_session_response_format` (a plain text `500`
+      # response if none was selected).
+      #
+      # @return [Void]
+      #
+      # @example
+      #   def no_session_response
+      #     response.status = 404
+      #     response.format = :json
+      #     response.body = { error: 'no matching session' }.to_json
+      #   end
+      def no_session_response
+        case self.class.no_session_response_format_value
+        when :operation_outcome
+          operation_outcome_no_session_response
+        else
+          text_no_session_response
+        end
+      end
+
       # @!endgroup
 
       # @private
@@ -192,7 +261,10 @@ module Inferno
       def test_run
         @test_run ||=
           test_runs_repo.find_latest_waiting_by_identifier(find_test_run_identifier).tap do |test_run|
-            halt 500, "Unable to find test run with identifier '#{test_run_identifier}'." if test_run.nil?
+            if test_run.nil?
+              no_session_response
+              halt response.status, response.body.join
+            end
           end
       end
 
@@ -221,6 +293,38 @@ module Inferno
         @test_run_identifier ||= test_run_identifier
       rescue StandardError => e
         halt 500, "Unable to determine test run identifier:\n#{e.full_message}"
+      end
+
+      # @private
+      def no_session_message
+        if test_run_identifier.blank?
+          'No test identifier found.'
+        else
+          "Unable to find test run with identifier '#{test_run_identifier}'."
+        end
+      end
+
+      # @private
+      def text_no_session_response
+        response.status = 500
+        response.body = no_session_message
+      end
+
+      # @private
+      def operation_outcome_no_session_response
+        outcome = FHIR::OperationOutcome.new(
+          issue: [
+            FHIR::OperationOutcome::Issue.new(
+              severity: 'fatal',
+              code: 'not-found',
+              details: FHIR::CodeableConcept.new(text: no_session_message)
+            )
+          ]
+        )
+
+        response.status = 500
+        response.content_type = 'application/fhir+json'
+        response.body = outcome.to_json
       end
 
       # @private

--- a/lib/inferno/dsl/suite_endpoint.rb
+++ b/lib/inferno/dsl/suite_endpoint.rb
@@ -16,7 +16,7 @@ module Inferno
     #         request.headers['authorization']&.delete_prefix('Bearer ')
     #       end
     #
-    #       no_session_response_format :operation_outcome
+    #       error_response_format :operation_outcome
     #
     #       # Return a json FHIR Patient resource
     #       def make_response
@@ -61,21 +61,18 @@ module Inferno
     #       end
     #     end
     #
-    # If no waiting test session can be found for an incoming request, Inferno
-    # returns a `500` response with a plain text message by default. Call
-    # `no_session_response_format :operation_outcome` in a subclass to return a
-    # FHIR `OperationOutcome` as `application/fhir+json` instead, or override
-    # {#no_session_response} for full control.
     class SuiteEndpoint < Hanami::Action
       attr_reader :req, :res
 
-      # The built-in options for `no_session_response_format`
-      NO_SESSION_RESPONSE_FORMATS = [:text, :operation_outcome].freeze
+      # The built-in options for `error_response_format`
+      ERROR_RESPONSE_FORMATS = [:text, :operation_outcome].freeze
 
       class << self
-        # Select one of Inferno's standard responses to be returned when no
-        # waiting test session can be found for the incoming request.
-        # Override {#no_session_response} if neither option is appropriate.
+        # Select one of Inferno's standard response formats to be returned
+        # whenever Inferno has to render an error response of its own due
+        # to problems finding the target session or an unhandled exception.
+        # You can override {#no_session_response} to customize the response
+        # in the no-session case.
         #
         # * `:text` (default): a `500` response with a plain text message
         # * `:operation_outcome`: a `500` response with a FHIR
@@ -86,21 +83,21 @@ module Inferno
         #
         # @example
         #   class MyEndpoint < Inferno::DSL::SuiteEndpoint
-        #     no_session_response_format :operation_outcome
+        #     error_response_format :operation_outcome
         #   end
-        def no_session_response_format(format)
-          unless NO_SESSION_RESPONSE_FORMATS.include?(format)
+        def error_response_format(format)
+          unless ERROR_RESPONSE_FORMATS.include?(format)
             raise ArgumentError,
-                  "Unknown no_session_response_format `#{format.inspect}`. " \
-                  "Must be one of #{NO_SESSION_RESPONSE_FORMATS.join(', ')}."
+                  "Unknown error_response_format `#{format.inspect}`. " \
+                  "Must be one of #{ERROR_RESPONSE_FORMATS.join(', ')}."
           end
 
-          @no_session_response_format_value = format
+          @error_response_format_value = format
         end
 
         # @private
-        def no_session_response_format_value
-          @no_session_response_format_value ||= :text
+        def error_response_format_value
+          @error_response_format_value ||= :text
         end
       end
 
@@ -175,10 +172,10 @@ module Inferno
       # Override this method to fully customize the response returned when no
       # waiting test run/session can be found for the incoming request. Set
       # `response.status` and `response.body` (and `response.content_type`, if
-      # needed) — Inferno halts the request with those values. By default, this
-      # dispatches to one of Inferno's standard responses based on the format
-      # selected with `no_session_response_format` (a plain text `500`
-      # response if none was selected).
+      # needed) — Inferno halts the request with those values. By default,
+      # this renders one of Inferno's standard responses based on the format
+      # selected with `error_response_format` (a plain text `500` response if
+      # none was selected).
       #
       # @return [Void]
       #
@@ -189,12 +186,7 @@ module Inferno
       #     response.body = { error: 'no matching session' }.to_json
       #   end
       def no_session_response
-        case self.class.no_session_response_format_value
-        when :operation_outcome
-          operation_outcome_no_session_response
-        else
-          text_no_session_response
-        end
+        error_response(no_session_message, code: 'not-found')
       end
 
       # @!endgroup
@@ -261,10 +253,7 @@ module Inferno
       def test_run
         @test_run ||=
           test_runs_repo.find_latest_waiting_by_identifier(find_test_run_identifier).tap do |test_run|
-            if test_run.nil?
-              no_session_response
-              halt response.status, response.body.join
-            end
+            render_error_and_halt { no_session_response } if test_run.nil?
           end
       end
 
@@ -292,7 +281,14 @@ module Inferno
       def find_test_run_identifier
         @test_run_identifier ||= test_run_identifier
       rescue StandardError => e
-        halt 500, "Unable to determine test run identifier:\n#{e.full_message}"
+        logger.error(e.full_message)
+        render_error_and_halt do
+          error_response(
+            'An error occurred while determining the test run identifier for this request.',
+            code: 'exception',
+            diagnostics: e.full_message
+          )
+        end
       end
 
       # @private
@@ -305,26 +301,48 @@ module Inferno
       end
 
       # @private
-      def text_no_session_response
-        response.status = 500
-        response.body = no_session_message
+      # Yields to build the response, then halts with whatever ended up in
+      # `response.status`/`response.body`. Centralizing the halt here means
+      # overrides of the response-building hooks (e.g. #no_session_response)
+      # never need to remember to call `halt` themselves.
+      def render_error_and_halt
+        yield
+        halt response.status, response.body.join
       end
 
       # @private
-      def operation_outcome_no_session_response
-        outcome = FHIR::OperationOutcome.new(
-          issue: [
-            FHIR::OperationOutcome::Issue.new(
-              severity: 'fatal',
-              code: 'not-found',
-              details: FHIR::CodeableConcept.new(text: no_session_message)
-            )
-          ]
+      # `message` is a short, human-readable summary (goes in the
+      # OperationOutcome issue's `details.text`, or stands alone as the whole
+      # plain text body). `diagnostics`, if given, is technical detail — e.g.
+      # an exception's full backtrace — that goes in the issue's
+      # `diagnostics` element, or is appended to the plain text body.
+      def error_response(message, code:, diagnostics: nil)
+        case self.class.error_response_format_value
+        when :operation_outcome
+          operation_outcome_error_response(message, code:, diagnostics:)
+        else
+          text_error_response(message, diagnostics:)
+        end
+      end
+
+      # @private
+      def text_error_response(message, diagnostics: nil)
+        response.status = 500
+        response.body = diagnostics ? "#{message}\n#{diagnostics}" : message
+      end
+
+      # @private
+      def operation_outcome_error_response(message, code:, diagnostics: nil)
+        issue = FHIR::OperationOutcome::Issue.new(
+          severity: 'fatal',
+          code:,
+          details: FHIR::CodeableConcept.new(text: message)
         )
+        issue.diagnostics = diagnostics if diagnostics
 
         response.status = 500
         response.content_type = 'application/fhir+json'
-        response.body = outcome.to_json
+        response.body = FHIR::OperationOutcome.new(issue: [issue]).to_json
       end
 
       # @private
@@ -374,7 +392,14 @@ module Inferno
 
         make_response
       rescue StandardError => e
-        halt 500, e.full_message
+        logger.error(e.full_message)
+        render_error_and_halt do
+          error_response(
+            'An error occurred while processing this request.',
+            code: 'exception',
+            diagnostics: e.full_message
+          )
+        end
       end
 
       # @private

--- a/lib/inferno/dsl/suite_endpoint.rb
+++ b/lib/inferno/dsl/suite_endpoint.rb
@@ -279,7 +279,9 @@ module Inferno
 
       # @private
       def find_test_run_identifier
-        @test_run_identifier ||= test_run_identifier
+        return @test_run_identifier if defined?(@test_run_identifier) # handle memoization in the nil case
+
+        @test_run_identifier = test_run_identifier
       rescue StandardError => e
         logger.error(e.full_message)
         render_error_and_halt do
@@ -293,10 +295,10 @@ module Inferno
 
       # @private
       def no_session_message
-        if test_run_identifier.blank?
+        if find_test_run_identifier.blank?
           'No test identifier found.'
         else
-          "Unable to find test run with identifier '#{test_run_identifier}'."
+          "Unable to find test run with identifier '#{find_test_run_identifier}'."
         end
       end
 

--- a/lib/inferno/dsl/suite_endpoint.rb
+++ b/lib/inferno/dsl/suite_endpoint.rb
@@ -128,10 +128,10 @@ module Inferno
       # @return [String]
       #
       # @example
-      #   def test_run_identifier_description
+      #   def test_run_identifier_location_description
       #     "the 'code' query parameter"
       #   end
-      def test_run_identifier_description
+      def test_run_identifier_location_description
         ''
       end
 
@@ -317,16 +317,17 @@ module Inferno
 
       # @private
       def no_session_message
-        message =
-          if find_test_run_identifier.blank?
-            "No test identifier found on request to '#{request.url}'."
-          else
-            "Unable to find test run with identifier '#{find_test_run_identifier}' " \
-              "on request to '#{request.url}'."
-          end
+        base_message = "Unable to find test run for request to '#{request.url}'"
+        location = test_run_identifier_location_description
+        identifier = find_test_run_identifier
 
-        description = test_run_identifier_description
-        description.present? ? "#{message} Expected in #{description}." : message
+        if identifier.blank?
+          detail = location.present? ? " in #{location}" : ''
+          "#{base_message}: no identifier found#{detail}."
+        else
+          detail = location.present? ? ", found in #{location}," : ''
+          "#{base_message}: identifier '#{identifier}'#{detail} is not associated with a waiting session."
+        end
       end
 
       # @private

--- a/spec/inferno/dsl/suite_endpoint_spec.rb
+++ b/spec/inferno/dsl/suite_endpoint_spec.rb
@@ -28,4 +28,44 @@ RSpec.describe Inferno::DSL::SuiteEndpoint, :request do
 
     expect(last_response.body).to eq('EXPECTED_RESPONSE_BODY')
   end
+
+  describe 'when no matching test session is found' do
+    it 'defaults to a plain text 500 response' do
+      post '/custom/infra_test/no_session_test'
+
+      expect(last_response.status).to eq(500)
+      expect(last_response.body).to eq(
+        "Unable to find test run with identifier 'NONEXISTENT_IDENTIFIER'."
+      )
+    end
+
+    it 'uses a different message when the test run identifier is blank' do
+      post '/custom/infra_test/blank_identifier_test'
+
+      expect(last_response.status).to eq(500)
+      expect(last_response.body).to eq('No test identifier found.')
+    end
+
+    it 'returns a FHIR OperationOutcome as application/fhir+json when configured to do so' do
+      post '/custom/infra_test/operation_outcome_test'
+
+      expect(last_response.status).to eq(500)
+      expect(last_response.headers['Content-Type']).to eq('application/fhir+json')
+
+      outcome = FHIR::OperationOutcome.new(JSON.parse(last_response.body))
+      expect(outcome.issue.first.severity).to eq('fatal')
+      expect(outcome.issue.first.code).to eq('not-found')
+      expect(outcome.issue.first.details.text).to eq(
+        "Unable to find test run with identifier 'NONEXISTENT_IDENTIFIER'."
+      )
+    end
+
+    it 'uses a fully custom no_session_response override and still halts the request' do
+      post '/custom/infra_test/custom_no_session_response_test'
+
+      expect(last_response.status).to eq(404)
+      expect(last_response.headers['Content-Type']).to eq('application/json; charset=utf-8')
+      expect(JSON.parse(last_response.body)).to eq('error' => 'no matching session')
+    end
+  end
 end

--- a/spec/inferno/dsl/suite_endpoint_spec.rb
+++ b/spec/inferno/dsl/suite_endpoint_spec.rb
@@ -46,7 +46,8 @@ RSpec.describe Inferno::DSL::SuiteEndpoint, :request do
 
       expect(last_response.status).to eq(500)
       expect(last_response.body).to eq(
-        "Unable to find test run with identifier 'NONEXISTENT_IDENTIFIER'."
+        "Unable to find test run with identifier 'NONEXISTENT_IDENTIFIER' " \
+        "on request to 'http://example.org/custom/infra_test/no_session_test'."
       )
     end
 
@@ -54,7 +55,20 @@ RSpec.describe Inferno::DSL::SuiteEndpoint, :request do
       post '/custom/infra_test/blank_identifier_test'
 
       expect(last_response.status).to eq(500)
-      expect(last_response.body).to eq('No test identifier found.')
+      expect(last_response.body).to eq(
+        "No test identifier found on request to 'http://example.org/custom/infra_test/blank_identifier_test'."
+      )
+    end
+
+    it 'appends the test_run_identifier_description when the endpoint provides one' do
+      post '/custom/infra_test/identifier_description_test'
+
+      expect(last_response.status).to eq(500)
+      expect(last_response.body).to eq(
+        "Unable to find test run with identifier 'NONEXISTENT_IDENTIFIER' " \
+        "on request to 'http://example.org/custom/infra_test/identifier_description_test'. " \
+        "Expected in the 'code' query parameter."
+      )
     end
 
     it 'returns a FHIR OperationOutcome as application/fhir+json when configured to do so' do
@@ -67,7 +81,8 @@ RSpec.describe Inferno::DSL::SuiteEndpoint, :request do
       expect(outcome.issue.first.severity).to eq('fatal')
       expect(outcome.issue.first.code).to eq('not-found')
       expect(outcome.issue.first.details.text).to eq(
-        "Unable to find test run with identifier 'NONEXISTENT_IDENTIFIER'."
+        "Unable to find test run with identifier 'NONEXISTENT_IDENTIFIER' " \
+        "on request to 'http://example.org/custom/infra_test/operation_outcome_test'."
       )
     end
 
@@ -86,7 +101,9 @@ RSpec.describe Inferno::DSL::SuiteEndpoint, :request do
 
       post '/custom/infra_test/identifier_error_test'
 
-      expect(Inferno::Application[:logger]).to have_received(:error).with(/BOOM_IDENTIFIER/)
+      # No test run/session has been resolved yet at this point, so no session is logged.
+      expect(Inferno::Application[:logger]).to have_received(:error)
+        .with(%r{\A\[http://example.org/custom/infra_test/identifier_error_test\] (?!session=).*BOOM_IDENTIFIER}m)
       expect(last_response.status).to eq(500)
       expect(last_response.body).to include('An error occurred while determining the test run identifier')
       expect(last_response.body).to include('BOOM_IDENTIFIER')
@@ -114,7 +131,11 @@ RSpec.describe Inferno::DSL::SuiteEndpoint, :request do
 
       post '/custom/infra_test/exception_test'
 
-      expect(Inferno::Application[:logger]).to have_received(:error).with(/BOOM_MAKE_RESPONSE/)
+      # test_run has already been resolved by this point, so the session is included in the log.
+      log_url = Regexp.escape('http://example.org/custom/infra_test/exception_test')
+      expect(Inferno::Application[:logger]).to have_received(:error).with(
+        /\A\[#{log_url}\] session=#{test_run.test_session_id}.*BOOM_MAKE_RESPONSE/m
+      )
       expect(last_response.status).to eq(500)
       expect(last_response.body).to include('An error occurred while processing this request')
       expect(last_response.body).to include('BOOM_MAKE_RESPONSE')

--- a/spec/inferno/dsl/suite_endpoint_spec.rb
+++ b/spec/inferno/dsl/suite_endpoint_spec.rb
@@ -156,4 +156,35 @@ RSpec.describe Inferno::DSL::SuiteEndpoint, :request do
       expect(outcome.issue.first.diagnostics).to include('BOOM_MAKE_RESPONSE')
     end
   end
+
+  describe 'when update_result causes the test run to resume' do
+    it 'resumes the test run and exposes the repo accessor methods' do
+      allow(Inferno::Jobs).to receive(:perform)
+
+      post '/custom/infra_test/resume_test'
+
+      expect(last_response.status).to eq(200)
+      body = JSON.parse(last_response.body)
+      expect(body['test_id']).to eq(InfrastructureTest::Suite.groups.first.groups.first.tests.first.id)
+      expect(body['requests_repo_class']).to eq('Inferno::Repositories::Requests')
+
+      expect(Inferno::Jobs).to have_received(:perform).with(Inferno::Jobs::ResumeTestRun, test_run.id)
+      expect(Inferno::Repositories::TestRuns.new.find(test_run.id).status).to eq('queued')
+    end
+  end
+
+  describe 'when persisting the incoming request fails' do
+    it 'logs the error instead of raising' do
+      allow(Inferno::Application[:logger]).to receive(:error)
+      allow_any_instance_of(Inferno::Repositories::Requests)
+        .to receive(:create).and_raise(StandardError, 'BOOM_PERSIST')
+
+      post '/custom/infra_test/json_test',
+           { json_param: 'EXPECTED_RESPONSE_BODY' }.to_json,
+           'CONTENT_TYPE' => 'application/json'
+
+      expect(last_response.body).to eq('EXPECTED_RESPONSE_BODY')
+      expect(Inferno::Application[:logger]).to have_received(:error).with(/BOOM_PERSIST/)
+    end
+  end
 end

--- a/spec/inferno/dsl/suite_endpoint_spec.rb
+++ b/spec/inferno/dsl/suite_endpoint_spec.rb
@@ -68,4 +68,58 @@ RSpec.describe Inferno::DSL::SuiteEndpoint, :request do
       expect(JSON.parse(last_response.body)).to eq('error' => 'no matching session')
     end
   end
+
+  describe 'when an error is raised while determining the test run identifier' do
+    it 'logs the error and defaults to a plain text 500 response' do
+      allow(Inferno::Application[:logger]).to receive(:error)
+
+      post '/custom/infra_test/identifier_error_test'
+
+      expect(Inferno::Application[:logger]).to have_received(:error).with(/BOOM_IDENTIFIER/)
+      expect(last_response.status).to eq(500)
+      expect(last_response.body).to include('An error occurred while determining the test run identifier')
+      expect(last_response.body).to include('BOOM_IDENTIFIER')
+    end
+
+    it 'returns a FHIR OperationOutcome as application/fhir+json when configured to do so' do
+      post '/custom/infra_test/identifier_error_operation_outcome_test'
+
+      expect(last_response.status).to eq(500)
+      expect(last_response.headers['Content-Type']).to eq('application/fhir+json')
+
+      outcome = FHIR::OperationOutcome.new(JSON.parse(last_response.body))
+      expect(outcome.issue.first.severity).to eq('fatal')
+      expect(outcome.issue.first.code).to eq('exception')
+      expect(outcome.issue.first.details.text).to eq(
+        'An error occurred while determining the test run identifier for this request.'
+      )
+      expect(outcome.issue.first.diagnostics).to include('BOOM_IDENTIFIER')
+    end
+  end
+
+  describe 'when an unhandled exception is raised while processing the request' do
+    it 'logs the error and defaults to a plain text 500 response' do
+      allow(Inferno::Application[:logger]).to receive(:error)
+
+      post '/custom/infra_test/exception_test'
+
+      expect(Inferno::Application[:logger]).to have_received(:error).with(/BOOM_MAKE_RESPONSE/)
+      expect(last_response.status).to eq(500)
+      expect(last_response.body).to include('An error occurred while processing this request')
+      expect(last_response.body).to include('BOOM_MAKE_RESPONSE')
+    end
+
+    it 'returns a FHIR OperationOutcome as application/fhir+json when configured to do so' do
+      post '/custom/infra_test/exception_operation_outcome_test'
+
+      expect(last_response.status).to eq(500)
+      expect(last_response.headers['Content-Type']).to eq('application/fhir+json')
+
+      outcome = FHIR::OperationOutcome.new(JSON.parse(last_response.body))
+      expect(outcome.issue.first.severity).to eq('fatal')
+      expect(outcome.issue.first.code).to eq('exception')
+      expect(outcome.issue.first.details.text).to eq('An error occurred while processing this request.')
+      expect(outcome.issue.first.diagnostics).to include('BOOM_MAKE_RESPONSE')
+    end
+  end
 end

--- a/spec/inferno/dsl/suite_endpoint_spec.rb
+++ b/spec/inferno/dsl/suite_endpoint_spec.rb
@@ -168,7 +168,12 @@ RSpec.describe Inferno::DSL::SuiteEndpoint, :request do
       expect(body['test_id']).to eq(InfrastructureTest::Suite.groups.first.groups.first.tests.first.id)
       expect(body['requests_repo_class']).to eq('Inferno::Repositories::Requests')
 
-      expect(Inferno::Jobs).to have_received(:perform).with(Inferno::Jobs::ResumeTestRun, test_run.id)
+      expect(Inferno::Jobs).to have_received(:perform)
+        .with(Inferno::Jobs::ResumeTestRun, test_run.id,
+              { tags: ['source:suite_endpoint',
+                       "session:#{test_run.test_session_id}",
+                       'run:basic',
+                       'test:infra_test-outer_inline_group-inner_inline_group-inline_test_1'] })
       expect(Inferno::Repositories::TestRuns.new.find(test_run.id).status).to eq('queued')
     end
   end

--- a/spec/inferno/dsl/suite_endpoint_spec.rb
+++ b/spec/inferno/dsl/suite_endpoint_spec.rb
@@ -29,6 +29,17 @@ RSpec.describe Inferno::DSL::SuiteEndpoint, :request do
     expect(last_response.body).to eq('EXPECTED_RESPONSE_BODY')
   end
 
+  describe '.error_response_format' do
+    it 'raises an ArgumentError when given an unrecognized format' do
+      expect do
+        Class.new(described_class) { error_response_format :bogus_format }
+      end.to raise_error(
+        ArgumentError,
+        'Unknown error_response_format `:bogus_format`. Must be one of text, operation_outcome.'
+      )
+    end
+  end
+
   describe 'when no matching test session is found' do
     it 'defaults to a plain text 500 response' do
       post '/custom/infra_test/no_session_test'

--- a/spec/inferno/dsl/suite_endpoint_spec.rb
+++ b/spec/inferno/dsl/suite_endpoint_spec.rb
@@ -46,8 +46,8 @@ RSpec.describe Inferno::DSL::SuiteEndpoint, :request do
 
       expect(last_response.status).to eq(500)
       expect(last_response.body).to eq(
-        "Unable to find test run with identifier 'NONEXISTENT_IDENTIFIER' " \
-        "on request to 'http://example.org/custom/infra_test/no_session_test'."
+        "Unable to find test run for request to 'http://example.org/custom/infra_test/no_session_test': " \
+        "identifier 'NONEXISTENT_IDENTIFIER' is not associated with a waiting session."
       )
     end
 
@@ -56,18 +56,20 @@ RSpec.describe Inferno::DSL::SuiteEndpoint, :request do
 
       expect(last_response.status).to eq(500)
       expect(last_response.body).to eq(
-        "No test identifier found on request to 'http://example.org/custom/infra_test/blank_identifier_test'."
+        "Unable to find test run for request to 'http://example.org/custom/infra_test/blank_identifier_test': " \
+        'no identifier found.'
       )
     end
 
-    it 'appends the test_run_identifier_description when the endpoint provides one' do
+    it 'appends the test_run_identifier_location_description when the endpoint provides one' do
       post '/custom/infra_test/identifier_description_test'
 
       expect(last_response.status).to eq(500)
       expect(last_response.body).to eq(
-        "Unable to find test run with identifier 'NONEXISTENT_IDENTIFIER' " \
-        "on request to 'http://example.org/custom/infra_test/identifier_description_test'. " \
-        "Expected in the 'code' query parameter."
+        'Unable to find test run for request to ' \
+        "'http://example.org/custom/infra_test/identifier_description_test': " \
+        "identifier 'NONEXISTENT_IDENTIFIER', found in the 'code' query parameter, " \
+        'is not associated with a waiting session.'
       )
     end
 
@@ -81,8 +83,8 @@ RSpec.describe Inferno::DSL::SuiteEndpoint, :request do
       expect(outcome.issue.first.severity).to eq('fatal')
       expect(outcome.issue.first.code).to eq('not-found')
       expect(outcome.issue.first.details.text).to eq(
-        "Unable to find test run with identifier 'NONEXISTENT_IDENTIFIER' " \
-        "on request to 'http://example.org/custom/infra_test/operation_outcome_test'."
+        "Unable to find test run for request to 'http://example.org/custom/infra_test/operation_outcome_test': " \
+        "identifier 'NONEXISTENT_IDENTIFIER' is not associated with a waiting session."
       )
     end
 


### PR DESCRIPTION
# Summary

Previously, when an error occurred during processing of a request by a suite endpoint, Inferno always returned a 500 response with plain text and did not always log the problem in the application logs. Now, errors are always logged to the application log and test writers can
- Tell Inferno to use FHIR OperationOutcome responses for all errors
- Further customize the response generated when no session is found

See details in this [documentation update PR](https://github.com/inferno-framework/inferno-framework.github.io/pull/115).

# Testing Guidance

Verify using the PAS test kit 

## Setup

Setup the verification using these instructions
1. Check out this branch of inferno_core locally.
2. Check out PAS branch id-167-suite-endpoints-custom-no-session-response (associated with [draft PR 89](https://github.com/inferno-framework/davinci-pas-test-kit/pull/89))
3. Make sure that PAS's GemFile points to your `inferno-core` directory (default is a sibling with the PAS test kit directory).
4. Start the PAS test kit background services in docker and the test kit in ruby.

## Verify OperationOutcome Feature

1. Start a "[Da Vinci PAS Client Suite v2.2.1](http://localhost:4567/davinci_pas_client_suite_v221)" session using the SMART backend services option.
2. Using Postman or another tool, POST a non-FHIR payload with no Authorization header to `http://localhost:4567/custom/davinci_pas_client_suite_v221/fhir/Claim/$submit`. A OperationOutcome should come back indicating that no identifier was found, the endpoint url that was hit, and where the identifier was expected (one of two places).
3. Using Postman or another tool, POST a non-FHIR payload with no Authorization header to `http://localhost:4567/custom/davinci_pas_client_suite_v221/demo/fhir/Claim/$submit`. A OperationOutcome should come back indicating that `demo` was found as the identifier but no sessions existed, the endpoint url that was hit, and where the identifier was found (one of two places).
4. Start group "1 Client Registration" with client id `demo` and jwks url `https://inferno.healthit.gov` (invalid, which is fine). When waiting, make the same POST of a non-FHIR payload with no Authorization header to `http://localhost:4567/custom/davinci_pas_client_suite_v221/demo/fhir/Claim/$submit`. An OperationOutcome should be returned indicating an exception occurred during processing (session did match).

## Verify custom no session error response

1. If group "1 Client Registration" is no longer running or the wait has expired, restart that test
2. Using Postman or another tool, POST the x-www-form-urlencoded content below to `http://localhost:4567/custom/davinci_pas_client_suite_v221/auth/token`. A 401 with a custom json object should be returned, but with the same message as 3 above indicating the identifier was not found.
3. Restart the same group, but change the Client Id to `smart_client_test_demo`. When waiting, send the same content and note that a different error is returned around jwks keys (indicates the session matched but other details were wrong).

Content for auth token request.
```
client_assertion=eyJhbGciOiJFUzM4NCIsImtpZCI6IjRiNDlhNzM5ZDFlYjExNWIzMjI1ZjRjZjliZWI2ZDFiIiwidHlwIjoiSldUIn0.eyJpc3MiOiJzbWFydF9jbGllbnRfdGVzdF9kZW1vIiwic3ViIjoic21hcnRfY2xpZW50X3Rlc3RfZGVtbyIsImF1ZCI6Imh0dHBzOi8vaW5mZXJuby5oZWFsdGhpdC5nb3Yvc3VpdGVzL2N1c3RvbS9zbWFydF9jbGllbnRfc3R1Ml8yL2F1dGgvdG9rZW4iLCJleHAiOjE3Nzk0NjY4MzksImp0aSI6IjJlYmJkMjYyY2ZlNzQ0N2M2Y2FmNGZkMTUxOGUxNDNmZDM4N2U1Mzg0NTJhZWRkODc5YjBmMjcxOGQ2OTY1MjEifQ.yCIdc90FEtNrPh61XH-lgUw596LKKUX_xP9yRPCfvZt4M_c-NYEERvWoS13hXYM0bgSsZrnZPcFka_2LwP7H5xjyJ_yuE_dyPXY4VdtWfie9RGehssKKXK2Nc4UGrYwD&client_assertion_type=urn%253Aietf%253Aparams%253Aoauth%253Aclient-assertion-type%253Ajwt-bearer&code=eyJjbGllbnRfaWQiOiJzbWFydF9jbGllbnRfdGVzdF9kZW1vIiwiZXhwaXJhdGlvbiI6MTc3OTQ2NzEzOSwibm9uY2UiOiJjYzg2NGI3ZjMxODAwNWIwIn0&code_verifier=7220d455-142d-4478-b060-535df3d169f4-1e4987fe-d2ea-4756-bfb5-2a4d147bf2dd&grant_type=authorization_code&redirect_uri=https%253A%252F%252Finferno.healthit.gov%252Fsuites%252Fcustom%252Fsmart_stu2_2%252Fredirect
```



