### PR TITLE
Compute children_available_inputs once per available_inputs call

### DIFF
--- a/lib/inferno/dsl/input_output_handling.rb
+++ b/lib/inferno/dsl/input_output_handling.rb
@@ -193,14 +193,16 @@ module Inferno
               inputs[input.name.to_sym] = Entities::Input.new(**input.to_hash)
             end
 
+        # children_available_inputs walks the entire subtree, so it is computed once here
+        # rather than once per input. merge_with_child only mutates its receiver, so the
+        # child definitions are safe to reuse for the merge below.
+        child_inputs = children_available_inputs(selected_suite_options)
+
         available_inputs.each do |input, current_definition|
-          child_definition = children_available_inputs(selected_suite_options)[input]
-          current_definition.merge_with_child(child_definition)
+          current_definition.merge_with_child(child_inputs[input])
         end
 
-        available_inputs = children_available_inputs(selected_suite_options).merge(available_inputs)
-
-        order_available_inputs(available_inputs)
+        order_available_inputs(child_inputs.merge(available_inputs))
       end
     end
   end

--- a/spec/inferno/dsl/input_output_handling_spec.rb
+++ b/spec/inferno/dsl/input_output_handling_spec.rb
@@ -52,6 +52,34 @@ RSpec.describe Inferno::DSL::InputOutputHandling do
       expect(v1_inputs).to include(:v1_input, :all_versions_input)
       expect(v2_inputs).to include(:v2_input, :all_versions_input)
     end
+
+    it 'walks each child subtree only once' do
+      suite = Class.new(Inferno::Entities::TestSuite) do
+        id SecureRandom.uuid
+        input :a, :b, :c
+
+        group do
+          input :a, :b, :c
+          test do
+            input :a, :b, :c
+            run { nil }
+          end
+        end
+      end
+
+      call_count = 0
+      counter = Module.new do
+        define_method(:children_available_inputs) do |*args|
+          call_count += 1
+          super(*args)
+        end
+      end
+      suite.singleton_class.prepend(counter)
+
+      suite.available_inputs
+
+      expect(call_count).to eq(1)
+    end
   end
 
   describe '.missing_inputs' do


### PR DESCRIPTION
`available_inputs` obtains its child inputs from `children_available_inputs`, which
recurses over the runnable's entire subtree. It calls it once per input inside the merge
loop, and once more to build the result:

```ruby
available_inputs.each do |input, current_definition|
  child_definition = children_available_inputs(selected_suite_options)[input]
  current_definition.merge_with_child(child_definition)
end

available_inputs = children_available_inputs(selected_suite_options).merge(available_inputs)
```

Nothing memoises it, so a runnable with N inputs walks its subtree N+1 times, and the
recursion repeats that at every level, so the cost compounds with depth.

This is on the hot path for `POST /test_sessions`, which serialises the full suite tree.

### The change

Hoist the call into a local. `merge_with_child` only mutates its receiver and reads the
child, so the two walks could never observe each other and the resulting definitions are
unchanged.

### Measurements

Synthetic suites, inferno-core only, no external test kits (script below). Depth `d`,
breadth `b`, inputs declared on every runnable:

| shape | runnables | before | after | speedup | output identical |
|---|---|---|---|---|---|
| d=2 b=2 inputs=3 | 11 | 0.005s | 0.000s | 27x | yes |
| d=3 b=2 inputs=3 | 23 | 0.044s | 0.000s | 126x | yes |
| d=4 b=2 inputs=3 | 47 | 0.282s | 0.001s | 368x | yes |
| d=5 b=2 inputs=3 | 95 | 2.125s | 0.002s | 1205x | yes |
| d=4 b=3 inputs=5 | 202 | 14.676s | 0.006s | 2570x | yes |

Each added level multiplies the previous cost by roughly 8x. A 95-runnable suite spends
2.1s in `available_inputs`.

On our real suites (AU Core, via `TestSuite.render_as_hash(view: :full)` in a deployed
pod), where session creation was timing out at the reverse proxy:

| suite | tests | before | after |
|---|---|---|---|
| au_ps_v100 | 87 | 0.016s | 0.013s |
| au_core_v100 | 394 | 4.50s | 0.218s |
| au_core_v200 | 425 | 5.12s | 0.349s |
| au_core_v210_draft | 498 | 6.09s | 0.244s |

SHA256 of the serialised output is identical before and after for every suite registered in
that deployment: the four above, plus the six that come from the test kits in our Gemfile
(`smart`, `smart_stu2`, `smart_stu2_2`, `smart_access_brands`, `tls`, `validations`).

For a suite you can check directly: on inferno.healthit.gov, creating a
`g10_certification` session with US Core 7 / SMART App Launch 2.2.0 / Bulk Data 2.0.0
returns 808 runnables and takes a couple of seconds, and the wall time varies with client
location because the response is ~1.5MB. I have not profiled that instance, so I am not
claiming how much of that is `available_inputs`, only that a suite of that size is well
into the range where this showed up for us.

### Two live deployments, with and without the change

Our dev and prod environments differ in whether they have this change, because prod pins an
older image, so the difference is observable without building anything:

```
# WITHOUT the change
curl -s -o /dev/null -w '%{time_total}\n' -X POST \
  'https://inferno.sparked-fhir.com/suites/api/test_sessions?test_suite_id=au_core_v210_draft'

# WITH the change
curl -s -o /dev/null -w '%{time_total}\n' -X POST \
  'https://development.inferno.sparked-fhir.com/suites/api/test_sessions?test_suite_id=au_core_v210_draft'
```

| suite | tests | without | with |
|---|---|---|---|
| au_ps_v100 | 87 | 0.36s | 0.32s |
| au_core_v100 | 394 | 4.44s | 0.80s |
| au_core_v200 | 425 | 4.85s | 0.82s |
| au_core_v210_draft | 498 | 5.55s | 0.81s |

`au_ps_v100` is the control: it is small enough not to be affected, and it measures the same
on both, so the difference on the larger suites is not one environment simply being faster.
Two runs of each were within noise.

These are end-to-end times over the public internet including a response of roughly 1MB, so
they understate the in-process difference measured above (6.09s to 0.244s). The constant
network and transfer cost is what turns 25x into about 6x here.

### Known limitation

This removes the N+1 *within* a single `available_inputs` call. It does not remove the
redundancy *across* calls: the serialiser calls `available_inputs` on every node, and each
of those still walks its own subtree, so a full render remains superlinear in depth.
Fixing that properly needs a render-scoped cache, which is a much larger change and
plausibly the reason `@children_available_inputs` is listed in `VARIABLES_NOT_TO_COPY` as
"Needs to be recalculated". I have kept this PR to the part that is unambiguously safe and
verifiable. Happy to look at the broader caching question separately if that is of
interest.

### Verification

The added spec counts calls to `children_available_inputs` and fails with `4` instead of
`1` without the change, so it gates the regression deterministically rather than by
timing.

`bundle exec rspec` passes in full (1333 examples, 0 failures), and RuboCop is clean on
both changed files.

<details>
<summary>Reproduction script (drop in the repo root, <code>bundle exec ruby bench_available_inputs.rb</code>)</summary>

```ruby
ENV['APP_ENV'] ||= 'test' # in-memory sqlite, same as the spec suite

require_relative 'lib/inferno/config/application'
require_relative 'lib/inferno/utils/migration'
Inferno::Utils::Migration.new.run
Inferno::Application.finalize!

require 'benchmark'
require 'securerandom'

# Restores the pre-fix body so both can be measured in one process.
module PreviousImplementation
  def available_inputs(selected_suite_options = nil)
    available_inputs =
      config.inputs
        .slice(*inputs)
        .each_with_object({}) do |(_, input), inputs|
          inputs[input.name.to_sym] = Inferno::Entities::Input.new(**input.to_hash)
        end

    available_inputs.each do |input, current_definition|
      child_definition = children_available_inputs(selected_suite_options)[input]
      current_definition.merge_with_child(child_definition)
    end

    available_inputs = children_available_inputs(selected_suite_options).merge(available_inputs)

    order_available_inputs(available_inputs)
  end
end

def build_suite(depth:, breadth:, n_inputs:)
  input_names = (1..n_inputs).map { |i| :"input_#{i}" }

  # procs, not lambdas: class_eval yields the class into the block.
  builder = lambda do |level|
    proc do
      input(*input_names)
      if level < depth
        breadth.times { group(&builder.call(level + 1)) }
      else
        test do
          input(*input_names)
          run { nil }
        end
      end
    end
  end

  Class.new(Inferno::Entities::TestSuite) do
    id SecureRandom.uuid
    input(*input_names)
    breadth.times { group(&builder.call(1)) }
  end
end

def count_runnables(runnable)
  1 + runnable.children.sum { |c| count_runnables(c) }
end

puts format('%-28s %8s %10s %10s %9s %s', 'shape', 'runnables', 'previous', 'current', 'speedup', 'identical')
puts '-' * 80

[
  { depth: 2, breadth: 2, n_inputs: 3 },
  { depth: 3, breadth: 2, n_inputs: 3 },
  { depth: 4, breadth: 2, n_inputs: 3 },
  { depth: 5, breadth: 2, n_inputs: 3 },
  { depth: 4, breadth: 3, n_inputs: 5 }
].each do |shape|
  suite = build_suite(**shape)
  n = count_runnables(suite)

  current = Benchmark.realtime { @after = suite.available_inputs }

  walk = lambda do |r|
    r.singleton_class.prepend(PreviousImplementation)
    r.children.each { |c| walk.call(c) }
  end
  walk.call(suite)

  previous = Benchmark.realtime { @before = suite.available_inputs }

  label = "d=#{shape[:depth]} b=#{shape[:breadth]} inputs=#{shape[:n_inputs]}"
  puts format('%-28s %8d %9.3fs %9.3fs %8.1fx %s',
              label, n, previous, current, previous / current,
              @before.keys == @after.keys && @before.values.map(&:to_hash) == @after.values.map(&:to_hash))
end
```

</details>
