### PR TITLE
ID-219: support expansion-parameters on validator calls

### DIFF
--- a/lib/inferno/apps/cli/execute_script.rb
+++ b/lib/inferno/apps/cli/execute_script.rb
@@ -138,7 +138,7 @@ module Inferno
 
       ExecutionStatus = Struct.new(
         :done, :failed, :timed_out, :cancel_pending, :current_session, :current_timeout, :last_log_time,
-        :cross_session_status, :last_step_signatures
+        :poll_start_time, :cross_session_status, :last_step_signatures
       )
 
       attr_accessor :yaml_file, :options, :execution_status
@@ -155,6 +155,7 @@ module Inferno
           cancel_pending: false,
           current_session: sessions.first,
           current_timeout: options[:default_poll_timeout],
+          poll_start_time: nil,
           cross_session_status: {},
           last_step_signatures: {}
         )
@@ -416,6 +417,7 @@ module Inferno
         warn ''
         warn "Polling session: #{session.key} (#{session.session_id}) timeout=#{timeout}s"
         deadline = Time.now + timeout
+        execution_status.poll_start_time = Time.now
         execution_status.last_log_time = Time.now - LOG_INTERVAL_SECONDS
 
         loop do
@@ -518,12 +520,14 @@ module Inferno
         last_completed = last_completed_from_status(status)
         poll_status_last_test =
           last_completed.present? ? " - last test: #{format_last_completed(last_completed, session_key)}" : ''
-        warn "  [#{session_key}] #{status['status']} (#{test_progress(status)})#{poll_status_last_test}"
+        elapsed = (Time.now - execution_status.poll_start_time).round
+        warn "  [#{session_key}] #{status['status']} (#{test_progress(status, elapsed)})" \
+             "#{poll_status_last_test}"
         execution_status.last_log_time = Time.now
       end
 
-      def test_progress(status)
-        "#{status['completed_test_count']}/#{status['test_count']} tests"
+      def test_progress(status, elapsed)
+        "completed #{status['completed_test_count']}/#{status['test_count']} tests in #{elapsed}s"
       end
 
       def fetch_session_status(session_id)

--- a/lib/inferno/dsl/fhir_resource_validation.rb
+++ b/lib/inferno/dsl/fhir_resource_validation.rb
@@ -26,6 +26,7 @@ module Inferno
     #       allowExampleUrls true
     #       txServer nil
     #     end
+    #     expansion_parameters 'path/to/expansion_parameters.json'
     #   end
     module FHIRResourceValidation
       def self.included(klass)
@@ -117,6 +118,99 @@ module Inferno
         end
 
         alias cli_context validation_context
+
+        # Environment variable containing the default expansion parameters.
+        # Used by {#expansion_parameters} when no value has been set
+        # explicitly. May contain either the raw JSON content of a FHIR
+        # Parameters resource (if it starts with `{`) or a path to a file
+        # containing one.
+        EXPANSION_PARAMETERS_ENV_VAR = 'FHIR_RESOURCE_VALIDATOR_EXPANSION_PARAMETERS'.freeze
+
+        # Set the expansion parameters to be sent with each validation
+        # request. This configures how the validator's terminology engine
+        # expands value sets during validation (e.g. designation
+        # preferences, forcing the use of the latest terminology versions,
+        # etc.). The content is sent inline with every validation request
+        # made by this validator, since the validator does not have access
+        # to Inferno's filesystem.
+        #
+        # Accepts either a Hash containing the contents of a FHIR Parameters
+        # resource, or a String path to a file (JSON or XML) containing one.
+        # The file is read once, the first time it's needed.
+        #
+        # If never set explicitly, this falls back to the
+        # `FHIR_RESOURCE_VALIDATOR_EXPANSION_PARAMETERS` environment
+        # variable, if present. This allows a shared set of expansion
+        # parameters to be configured once for every test kit that uses a
+        # given validator instance, while still letting individual test
+        # kits opt out or override it by calling this method themselves.
+        # The environment variable's content is treated as raw JSON if it
+        # starts with `{`, and otherwise as a file path.
+        #
+        # @example
+        #   # Passing a Hash
+        #   fhir_resource_validator do
+        #     url 'http://example.com/validator'
+        #     expansion_parameters({
+        #       resourceType: 'Parameters',
+        #       parameter: [{ name: 'excludeNested', valueBoolean: true }]
+        #     })
+        #   end
+        #
+        # @example
+        #   # Passing a file path
+        #   fhir_resource_validator do
+        #     url 'http://example.com/validator'
+        #     expansion_parameters 'path/to/expansion_parameters.json'
+        #   end
+        #
+        # @param value [Hash, String, nil] contents of a Parameters resource
+        #   as a Hash, or a path to a file (JSON or XML) containing one
+        def expansion_parameters(value = nil)
+          if value
+            @expansion_parameters = build_expansion_parameters(value)
+          elsif !@expansion_parameters_resolved
+            env_value = ENV.fetch(EXPANSION_PARAMETERS_ENV_VAR, nil)
+            @expansion_parameters = build_expansion_parameters_from_env(env_value) if env_value
+          end
+          @expansion_parameters_resolved = true
+
+          @expansion_parameters
+        end
+
+        # @private
+        # Determines whether the environment variable's content is raw JSON
+        # or a file path based on its first non-whitespace character.
+        def build_expansion_parameters_from_env(env_value)
+          if env_value.lstrip.start_with?('{')
+            build_expansion_parameters_from_json_content(env_value)
+          else
+            build_expansion_parameters(env_value)
+          end
+        end
+
+        # @private
+        def build_expansion_parameters(value)
+          case value
+          when Hash
+            build_expansion_parameters_from_json_content(value.to_json)
+          else
+            {
+              fileName: File.basename(value),
+              fileContent: File.read(value),
+              fileType: nil
+            }
+          end
+        end
+
+        # @private
+        def build_expansion_parameters_from_json_content(json_content)
+          {
+            fileName: 'expansion_parameters.json',
+            fileContent: json_content,
+            fileType: nil
+          }
+        end
 
         # @private
         # Used internally by perform_additional_validation
@@ -622,6 +716,8 @@ module Inferno
             ],
             sessionId: @session_id
           }
+          wrapped_resource[:expansionParameters] = expansion_parameters if expansion_parameters
+
           wrapped_resource.to_json
         end
       end

--- a/spec/fixtures/expansion_parameters.json
+++ b/spec/fixtures/expansion_parameters.json
@@ -1,0 +1,9 @@
+{
+  "resourceType": "Parameters",
+  "parameter": [
+    {
+      "name": "excludeNested",
+      "valueBoolean": true
+    }
+  ]
+}

--- a/spec/inferno/dsl/fhir_resource_validation_spec.rb
+++ b/spec/inferno/dsl/fhir_resource_validation_spec.rb
@@ -701,6 +701,204 @@ RSpec.describe Inferno::DSL::FHIRResourceValidation do
     end
   end
 
+  describe '#expansion_parameters' do
+    let(:expansion_parameters_path) { File.join(__dir__, '..', '..', 'fixtures', 'expansion_parameters.json') }
+    let(:expansion_parameters_content) { File.read(expansion_parameters_path) }
+    let(:expansion_parameters_hash) { JSON.parse(expansion_parameters_content) }
+
+    def expected_request_body(expansion_parameters: nil)
+      body = {
+        cliContext: {
+          sv: '4.0.1',
+          doNative: false,
+          extensions: ['any'],
+          disableDefaultResourceFetcher: true,
+          profiles: [profile_url]
+        },
+        filesToValidate: [
+          {
+            fileName: "#{profile_url}.json",
+            fileContent: resource.source_contents,
+            fileType: 'json'
+          }
+        ],
+        sessionId: nil
+      }
+      body[:expansionParameters] = expansion_parameters if expansion_parameters
+      body.to_json
+    end
+
+    before do
+      allow(Inferno::Feature).to receive(:use_validation_context_key?).and_return(false)
+    end
+
+    it 'is nil when not configured and the environment variable is unset' do
+      v = Inferno::DSL::FHIRResourceValidation::Validator.new do
+        url 'http://example.com'
+      end
+
+      expect(v.expansion_parameters).to be_nil
+    end
+
+    context 'when given a file path' do
+      it 'reads and stores the file contents as a FileInfo hash' do
+        v = Inferno::DSL::FHIRResourceValidation::Validator.new do
+          url 'http://example.com'
+        end
+
+        v.expansion_parameters(expansion_parameters_path)
+
+        expect(v.expansion_parameters).to eq(
+          {
+            fileName: 'expansion_parameters.json',
+            fileContent: expansion_parameters_content,
+            fileType: nil
+          }
+        )
+      end
+
+      it 'includes expansionParameters in the request body' do
+        v = Inferno::DSL::FHIRResourceValidation::Validator.new do
+          url 'http://example.com'
+          expansion_parameters File.join(__dir__, '..', '..', 'fixtures', 'expansion_parameters.json')
+        end
+
+        stub_request(:post, 'http://example.com/validate')
+          .with(body: expected_request_body(expansion_parameters: {
+                                              fileName: 'expansion_parameters.json',
+                                              fileContent: expansion_parameters_content,
+                                              fileType: nil
+                                            }))
+          .to_return(status: 200, body: '{}')
+
+        expect(v.validate(resource, profile_url)).to eq('{}')
+      end
+    end
+
+    context 'when given a Hash' do
+      it 'serializes it to JSON and stores it as a FileInfo hash' do
+        v = Inferno::DSL::FHIRResourceValidation::Validator.new do
+          url 'http://example.com'
+        end
+
+        v.expansion_parameters(expansion_parameters_hash)
+
+        expect(v.expansion_parameters).to eq(
+          {
+            fileName: 'expansion_parameters.json',
+            fileContent: expansion_parameters_hash.to_json,
+            fileType: nil
+          }
+        )
+      end
+
+      it 'includes expansionParameters in the request body' do
+        v = Inferno::DSL::FHIRResourceValidation::Validator.new do
+          url 'http://example.com'
+        end
+        v.expansion_parameters(expansion_parameters_hash)
+
+        stub_request(:post, 'http://example.com/validate')
+          .with(body: expected_request_body(expansion_parameters: {
+                                              fileName: 'expansion_parameters.json',
+                                              fileContent: expansion_parameters_hash.to_json,
+                                              fileType: nil
+                                            }))
+          .to_return(status: 200, body: '{}')
+
+        expect(v.validate(resource, profile_url)).to eq('{}')
+      end
+    end
+
+    context 'when the FHIR_RESOURCE_VALIDATOR_EXPANSION_PARAMETERS environment variable is set' do
+      def stub_env_var(value)
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch)
+          .with('FHIR_RESOURCE_VALIDATOR_EXPANSION_PARAMETERS', nil)
+          .and_return(value)
+      end
+
+      context 'with a value that starts with `{`' do
+        before { stub_env_var(expansion_parameters_content) }
+
+        it 'is treated as raw JSON content and used as the default' do
+          v = Inferno::DSL::FHIRResourceValidation::Validator.new do
+            url 'http://example.com'
+          end
+
+          expect(v.expansion_parameters).to eq(
+            {
+              fileName: 'expansion_parameters.json',
+              fileContent: expansion_parameters_content,
+              fileType: nil
+            }
+          )
+        end
+
+        it 'is overridden when configured explicitly' do
+          override_hash = { resourceType: 'Parameters', parameter: [] }
+
+          v = Inferno::DSL::FHIRResourceValidation::Validator.new do
+            url 'http://example.com'
+            expansion_parameters({ resourceType: 'Parameters', parameter: [] })
+          end
+
+          expect(v.expansion_parameters).to eq(
+            {
+              fileName: 'expansion_parameters.json',
+              fileContent: override_hash.to_json,
+              fileType: nil
+            }
+          )
+        end
+      end
+
+      context 'with a value that does not start with `{`' do
+        before { stub_env_var(expansion_parameters_path) }
+
+        it 'is treated as a file path and used as the default' do
+          v = Inferno::DSL::FHIRResourceValidation::Validator.new do
+            url 'http://example.com'
+          end
+
+          expect(v.expansion_parameters).to eq(
+            {
+              fileName: 'expansion_parameters.json',
+              fileContent: expansion_parameters_content,
+              fileType: nil
+            }
+          )
+        end
+      end
+
+      context 'with leading whitespace before the `{`' do
+        before { stub_env_var("  \n#{expansion_parameters_content}") }
+
+        it 'is still treated as raw JSON content' do
+          v = Inferno::DSL::FHIRResourceValidation::Validator.new do
+            url 'http://example.com'
+          end
+
+          expect(v.expansion_parameters).to eq(
+            {
+              fileName: 'expansion_parameters.json',
+              fileContent: "  \n#{expansion_parameters_content}",
+              fileType: nil
+            }
+          )
+        end
+      end
+    end
+
+    it 'does not include expansionParameters in the request body when not configured' do
+      stub_request(:post, 'http://example.com/validate')
+        .with(body: expected_request_body)
+        .to_return(status: 200, body: '{}')
+
+      expect(validator.validate(resource, profile_url)).to eq('{}')
+    end
+  end
+
   describe '.find_validator' do
     it 'finds the correct validator based on suite options' do
       suite = OptionsSuite::Suite


### PR DESCRIPTION
# Summary

In order to track the latest terminology versions (e.g., RXNorm, SNOMED CT) Inferno is adding support for specifying terminology expansion parameters with "force-system-version" repetitions to the validator asking it to always use particular a versions of a code system when validating against the terminology server. This feature is newly supported within the fhir validator-wrapper project.

Design:
- In order to track terminology versions at a deployment level, by default expansion parameters are indicated by a environment variable `FHIR_RESOURCE_VALIDATOR_EXPANSION_PARAMETERS`. The value of this variable is either a JSON string containing a Parameters resource, or a file path pointing to a file with the Parameters resource.
- Test suites that want to override the default behavior and always use a particular expansion can specify that Parameters resource within a `fhir_resource_validator` definition, again as either a hash representation of a Parameters resource directly or a path to a file with the content.

Additional changes:
- pushed image inferno_community/fhir_resource_validator version 1.0.83 to DockerHub.
- made a slight tweak to logging messages during script execution.

# Testing Guidance

Review the updated documentation: https://github.com/inferno-framework/inferno-framework.github.io/pull/118.

1. import the (g)(10) tests (uncomment line in GemFile, run bundle, uncomment line in the demo_suite.rb file
2. Establish prior non-ideal behavior
   1. Start inferno
   2. Start a US core v5.0.1 server test session
   3. Choose the reference server preset
   4. Run group 2.3, providing SAMPLE_TOKEN as the access token
   5. There will be several warnings indicating that the version of SNOMED CT was not found
   6. Start a US core v7.0.0 server test session
   7. Choose the reference server preset
   8. Run group 4.17, providing SAMPLE_TOKEN as the access token
   9. There will be several warnings indicating that the version of RxNorm was not found
3. Demonstrate corrected behavior
   1. shutdown Inferno (background services can stay running) 
   2. add the following line to the `.env.development` file, forcing available versions of RXNorm and SNOMED CT: `FHIR_RESOURCE_VALIDATOR_EXPANSION_PARAMETERS: '{"resourceType":"Parameters","parameter":[{"name":"force-system-version","valueCanonical":"http://www.nlm.nih.gov/research/umls/rxnorm|03022026"},{"name":"force-system-version","valueCanonical":"http://snomed.info/sct|http://snomed.info/sct/731000124108/version/20250901"}]}'`
   3. Perform steps 2.ii-2.ix and the warnings around the code system versions will be gone. NOTE: at this time only the RxNorm warnings are gone and the SNOMED warnings remain because of a known validator bug that will be fixed in the next release. Because we don't want to wait for them to add this functionality and release it, this failure is ok. 
