### PR TITLE
FQM-470: Add support for patternString slice discriminator

### DIFF
--- a/lib/inferno/dsl/must_support_metadata_extractor.rb
+++ b/lib/inferno/dsl/must_support_metadata_extractor.rb
@@ -364,6 +364,11 @@ module Inferno
                   path: navigation_compatible_discriminator_path(discriminator_path),
                   value: pattern_element.fixed
                 }
+              elsif pattern_element.patternString
+                fixed_values << {
+                  path: navigation_compatible_discriminator_path(discriminator_path),
+                  value: pattern_element.patternString
+                }
               elsif pattern_value.present?
                 raise StandardError, "Found more than one pattern slices for the same element #{pattern_element}."
               else

--- a/spec/inferno/dsl/must_support_metadata_extractor_spec.rb
+++ b/spec/inferno/dsl/must_support_metadata_extractor_spec.rb
@@ -340,6 +340,55 @@ RSpec.describe Inferno::DSL::MustSupportMetadataExtractor do
       )
     end
 
+    it 'extracts patternString slice discriminators as value metadata' do
+      slicing = FHIR::ElementDefinition::Slicing.new(
+        discriminator: [
+          FHIR::ElementDefinition::Slicing::Discriminator.new(type: 'value', path: 'linkId'),
+          FHIR::ElementDefinition::Slicing::Discriminator.new(type: 'value', path: 'type')
+        ]
+      )
+      profile_elements = [
+        FHIR::ElementDefinition.new(
+          id: 'Questionnaire.item',
+          path: 'Questionnaire.item',
+          slicing:
+        ),
+        FHIR::ElementDefinition.new(
+          id: 'Questionnaire.item:demographics',
+          path: 'Questionnaire.item',
+          sliceName: 'demographics',
+          mustSupport: true
+        ),
+        FHIR::ElementDefinition.new(
+          id: 'Questionnaire.item:demographics.linkId',
+          path: 'Questionnaire.item.linkId',
+          patternString: 'demographics'
+        ),
+        FHIR::ElementDefinition.new(
+          id: 'Questionnaire.item:demographics.type',
+          path: 'Questionnaire.item.type',
+          fixedCode: 'group'
+        )
+      ]
+
+      slices = described_class.new(profile_elements, profile, 'Questionnaire', ig_resources).value_slices
+
+      expect(slices).to contain_exactly(
+        {
+          slice_id: 'Questionnaire.item:demographics',
+          slice_name: 'demographics',
+          path: 'item',
+          discriminator: {
+            type: 'value',
+            values: [
+              { path: 'linkId', value: 'demographics' },
+              { path: 'type', value: 'group' }
+            ]
+          }
+        }
+      )
+    end
+
     it 'preserves fixed false discriminator values and normalizes discriminator paths' do
       extension_url = 'http://example.org/StructureDefinition/careTeamClaimScope'
       discriminator = FHIR::ElementDefinition::Slicing::Discriminator.new(


### PR DESCRIPTION
# Summary

This adds support for `patternString` slice discriminators in metadata extraction. Because FHIR requires a primitive `patternString` to match the instance value exactly, I'm treating it as an exact-value discriminator rather than using the specialized partial-matching logic required for complex pattern types (in `save_pattern_slice`).

The need for this was identified in https://github.com/inferno-framework/davinci-dtr-test-kit/pull/119.

# Testing Guidance

Checkout DTR test kit branch [`fqm-470-remove-obsolete-workaround`](https://github.com/inferno-framework/davinci-dtr-test-kit/tree/fqm-470-remove-obsolete-workaround) (which removes a workaround), and point the Gemfile at a local copy of Inferno Core with this branch checked out. Then `bundle exec rake dtr:generate`. There should be no change to any generated metadata.yml.